### PR TITLE
feat(web): add mock device dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules/
 .pnpm-store/
 .npm/
+.next/
 
 # Python
 __pycache__/
@@ -11,6 +12,7 @@ __pycache__/
 # Env
 .env
 .env.*
+!web/.env.local
 
 # Misc
 .DS_Store

--- a/web/.env.local
+++ b/web/.env.local
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_BASE_URL=http://localhost:3000

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/web/src/app/(lab)/dashboard/page.tsx
+++ b/web/src/app/(lab)/dashboard/page.tsx
@@ -1,0 +1,26 @@
+import DeviceCard from '@/components/DeviceCard';
+
+async function fetchDevices() {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_BASE_URL ?? ''}/api/devices`,
+    { cache: 'no-store' }
+  );
+  return (await res.json()).devices as any[];
+}
+
+export default async function DashboardPage() {
+  const devices = await fetchDevices();
+  return (
+    <main className="p-6 max-w-6xl mx-auto">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold">機器ダッシュボード</h1>
+        <p className="text-sm text-neutral-600">QRからのディープリンク先: /devices/[uid]</p>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {devices.map((d) => (
+          <DeviceCard key={d.id} d={d} />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/web/src/app/api/devices/route.ts
+++ b/web/src/app/api/devices/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { MOCK_DEVICES } from '@/lib/mock';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json({ devices: MOCK_DEVICES });
+}

--- a/web/src/app/devices/[uid]/page.tsx
+++ b/web/src/app/devices/[uid]/page.tsx
@@ -1,0 +1,28 @@
+import { notFound } from 'next/navigation';
+import { MOCK_DEVICES } from '@/lib/mock';
+import BadgeStatus from '@/components/BadgeStatus';
+
+export default function DeviceDetail({ params }: { params: { uid: string } }) {
+  const d = MOCK_DEVICES.find((x) => x.device_uid === decodeURIComponent(params.uid));
+  if (!d) return notFound();
+  return (
+    <main className="p-6 max-w-3xl mx-auto">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">{d.name}</h1>
+        <BadgeStatus state={d.status} />
+      </div>
+      <div className="mt-4 space-y-1 text-neutral-700">
+        <div>UID: {d.device_uid}</div>
+        <div>
+          カテゴリ: {d.category} ／ 位置: {d.location}
+        </div>
+        <div>SOP バージョン: v{d.sop_version}</div>
+      </div>
+      <div className="mt-6 flex gap-3">
+        <button className="rounded-2xl border px-4 py-2">予約</button>
+        <button className="rounded-2xl border px-4 py-2">使用開始</button>
+        <button className="rounded-2xl border px-4 py-2">QRポスター</button>
+      </div>
+    </main>
+  );
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,3 +1,14 @@
+import Link from 'next/link';
+
 export default function Home() {
-  return <h1>こんにちは Lab Yoyaku</h1>;
+  return (
+    <main className="p-6">
+      <h1>こんにちは Lab Yoyaku</h1>
+      <p className="mt-4">
+        <Link href="/(lab)/dashboard" className="text-blue-600 underline">
+          ダッシュボードへ
+        </Link>
+      </p>
+    </main>
+  );
 }

--- a/web/src/components/BadgeStatus.tsx
+++ b/web/src/components/BadgeStatus.tsx
@@ -1,0 +1,25 @@
+'use client';
+import React from 'react';
+
+type Props = { state: 'available' | 'reserved' | 'in_use' | 'maintenance' | 'out_of_service' };
+export default function BadgeStatus({ state }: Props) {
+  const label: Record<Props['state'], string> = {
+    available: '空き',
+    reserved: '予約済み',
+    in_use: '使用中',
+    maintenance: 'メンテ中',
+    out_of_service: '停止中',
+  };
+  const color: Record<Props['state'], string> = {
+    available: 'bg-green-100 text-green-700',
+    reserved: 'bg-amber-100 text-amber-700',
+    in_use: 'bg-blue-100 text-blue-700',
+    maintenance: 'bg-red-100 text-red-700',
+    out_of_service: 'bg-neutral-200 text-neutral-600',
+  };
+  return (
+    <span className={`inline-flex items-center rounded-2xl px-3 py-1 text-sm ${color[state]}`}>
+      {label[state]}
+    </span>
+  );
+}

--- a/web/src/components/DeviceCard.tsx
+++ b/web/src/components/DeviceCard.tsx
@@ -1,0 +1,25 @@
+'use client';
+import Link from 'next/link';
+import BadgeStatus from './BadgeStatus';
+import type { Device } from '@/lib/mock';
+
+export default function DeviceCard({ d }: { d: Device }) {
+  return (
+    <Link
+      href={`/devices/${d.device_uid}`}
+      className="block rounded-2xl border p-4 hover:shadow-md transition"
+    >
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">{d.name}</h3>
+        <BadgeStatus state={d.status} />
+      </div>
+      <div className="mt-2 text-sm text-neutral-600">
+        <div>UID: {d.device_uid}</div>
+        <div>
+          {d.category} ・ {d.location}
+        </div>
+        <div>SOP v{d.sop_version}</div>
+      </div>
+    </Link>
+  );
+}

--- a/web/src/lib/mock.ts
+++ b/web/src/lib/mock.ts
@@ -1,0 +1,16 @@
+export type DeviceState = 'available' | 'reserved' | 'in_use' | 'maintenance' | 'out_of_service';
+export type Device = {
+  id: string;
+  device_uid: string;
+  name: string;
+  category?: string;
+  location?: string;
+  status: DeviceState;
+  sop_version: number;
+};
+
+export const MOCK_DEVICES: Device[] = [
+  { id: 'd1', device_uid: 'JR-PAM-01', name: 'ジュニアPAM', category: 'fluorometer', location: 'Room 302', status: 'available', sop_version: 3 },
+  { id: 'd2', device_uid: 'PCR-02', name: 'PCR (Thermal Cycler)', category: 'pcr', location: 'Room 305', status: 'reserved', sop_version: 5 },
+  { id: 'd3', device_uid: 'GC-01', name: 'GC-MS', category: 'gcms', location: 'Room 210', status: 'maintenance', sop_version: 7 },
+];

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -13,8 +17,26 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "src/*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- add mock device data and API route for frontend-only mode
- build dashboard and device detail pages using mock data
- link homepage to dashboard and configure TS path alias

## Testing
- `npm --prefix web run lint`
- `npm --prefix web run build`

------
https://chatgpt.com/codex/tasks/task_e_68a0b5d228548323a750ac3c614a036c