### PR TITLE
Set up Tailwind CSS and fix dashboard routing

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "14.1.0",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "clsx": "^2.1.0"
   },
   "devDependencies": {
     "@types/react": "18.2.21",
@@ -19,6 +20,9 @@
     "typescript": "5.3.3",
     "eslint": "8.56.0",
     "eslint-config-next": "14.1.0",
-    "prettier": "3.1.0"
+    "prettier": "3.1.0",
+    "tailwindcss": "^3.4.1",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.16"
   }
 }

--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -1,18 +1,6 @@
-const plugins = {
-  autoprefixer: {},
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 };
-
-try {
-  // Load Tailwind CSS only if it's installed; otherwise fall back to plain styles
-  // so "pnpm dev" does not crash when tailwindcss is missing.
-  // Projects should run `pnpm install` to enable Tailwind processing.
-  // eslint-disable-next-line global-require, import/no-extraneous-dependencies
-  plugins.tailwindcss = require('tailwindcss');
-} catch {
-  // Tailwind CSS is optional in environments where dependencies cannot be installed.
-  // A warning is printed to help developers debug missing styling.
-  // eslint-disable-next-line no-console
-  console.warn('tailwindcss module not found; skipping Tailwind processing');
-}
-
-module.exports = { plugins };

--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -1,0 +1,18 @@
+const plugins = {
+  autoprefixer: {},
+};
+
+try {
+  // Load Tailwind CSS only if it's installed; otherwise fall back to plain styles
+  // so "pnpm dev" does not crash when tailwindcss is missing.
+  // Projects should run `pnpm install` to enable Tailwind processing.
+  // eslint-disable-next-line global-require, import/no-extraneous-dependencies
+  plugins.tailwindcss = require('tailwindcss');
+} catch {
+  // Tailwind CSS is optional in environments where dependencies cannot be installed.
+  // A warning is printed to help developers debug missing styling.
+  // eslint-disable-next-line no-console
+  console.warn('tailwindcss module not found; skipping Tailwind processing');
+}
+
+module.exports = { plugins };

--- a/web/src/app/(lab)/dashboard/page.tsx
+++ b/web/src/app/(lab)/dashboard/page.tsx
@@ -1,25 +1,15 @@
-import DeviceCard from '@/components/DeviceCard';
-
+import DeviceCard from "@/components/DeviceCard";
 async function fetchDevices() {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_URL ?? ''}/api/devices`,
-    { cache: 'no-store' }
-  );
-  return (await res.json()).devices as any[];
+  const r = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL ?? ''}/api/devices`, { cache: 'no-store' });
+  return (await r.json()).devices as any[];
 }
-
 export default async function DashboardPage() {
   const devices = await fetchDevices();
   return (
     <main className="p-6 max-w-6xl mx-auto">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold">機器ダッシュボード</h1>
-        <p className="text-sm text-neutral-600">QRからのディープリンク先: /devices/[uid]</p>
-      </div>
+      <h1 className="text-2xl font-bold mb-4">機器ダッシュボード</h1>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {devices.map((d) => (
-          <DeviceCard key={d.id} d={d} />
-        ))}
+        {devices.map((d: any) => <DeviceCard key={d.id} d={d} />)}
       </div>
     </main>
   );

--- a/web/src/app/devices/[uid]/page.tsx
+++ b/web/src/app/devices/[uid]/page.tsx
@@ -6,19 +6,15 @@ export default function DeviceDetail({ params }: { params: { uid: string } }) {
   const d = MOCK_DEVICES.find((x) => x.device_uid === decodeURIComponent(params.uid));
   if (!d) return notFound();
   return (
-    <main className="p-6 max-w-3xl mx-auto">
+    <main className="p-6 max-w-3xl mx-auto space-y-4">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">{d.name}</h1>
         <BadgeStatus state={d.status} />
       </div>
-      <div className="mt-4 space-y-1 text-neutral-700">
-        <div>UID: {d.device_uid}</div>
-        <div>
-          カテゴリ: {d.category} ／ 位置: {d.location}
-        </div>
-        <div>SOP バージョン: v{d.sop_version}</div>
+      <div className="text-neutral-700">
+        UID: {d.device_uid}／カテゴリ: {d.category}／位置: {d.location}／SOP v{d.sop_version}
       </div>
-      <div className="mt-6 flex gap-3">
+      <div className="flex gap-3">
         <button className="rounded-2xl border px-4 py-2">予約</button>
         <button className="rounded-2xl border px-4 py-2">使用開始</button>
         <button className="rounded-2xl border px-4 py-2">QRポスター</button>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1,5 +1,5 @@
-html, body {
-  padding: 0;
-  margin: 0;
-  font-family: sans-serif;
-}
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body { height: 100%; }

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,15 +1,14 @@
-import type { Metadata } from 'next';
-import './globals.css';
+import "./globals.css";
+import type { Metadata } from "next";
 
-export const metadata: Metadata = {
-  title: 'Lab Yoyaku',
-  description: 'Lab equipment reservation system',
-};
+export const metadata: Metadata = { title: "Lab Yoyaku" };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja">
-      <body>{children}</body>
+      <body className="min-h-screen bg-white text-neutral-900 antialiased">
+        {children}
+      </body>
     </html>
   );
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -5,7 +5,7 @@ export default function Home() {
     <main className="p-6">
       <h1>こんにちは Lab Yoyaku</h1>
       <p className="mt-4">
-        <Link href="/(lab)/dashboard" className="text-blue-600 underline">
+        <Link href="/dashboard" className="text-blue-600 underline">
           ダッシュボードへ
         </Link>
       </p>

--- a/web/src/components/BadgeStatus.tsx
+++ b/web/src/components/BadgeStatus.tsx
@@ -1,25 +1,14 @@
 'use client';
-import React from 'react';
+import clsx from 'clsx';
 
-type Props = { state: 'available' | 'reserved' | 'in_use' | 'maintenance' | 'out_of_service' };
-export default function BadgeStatus({ state }: Props) {
-  const label: Record<Props['state'], string> = {
-    available: '空き',
-    reserved: '予約済み',
-    in_use: '使用中',
-    maintenance: 'メンテ中',
-    out_of_service: '停止中',
-  };
-  const color: Record<Props['state'], string> = {
+export default function BadgeStatus({ state }: { state: 'available' | 'reserved' | 'in_use' | 'maintenance' | 'out_of_service' }) {
+  const label = { available: '空き', reserved: '予約済み', in_use: '使用中', maintenance: 'メンテ中', out_of_service: '停止中' };
+  const color = {
     available: 'bg-green-100 text-green-700',
     reserved: 'bg-amber-100 text-amber-700',
     in_use: 'bg-blue-100 text-blue-700',
     maintenance: 'bg-red-100 text-red-700',
     out_of_service: 'bg-neutral-200 text-neutral-600',
-  };
-  return (
-    <span className={`inline-flex items-center rounded-2xl px-3 py-1 text-sm ${color[state]}`}>
-      {label[state]}
-    </span>
-  );
+  } as const;
+  return <span className={clsx('inline-flex items-center rounded-2xl px-3 py-1 text-sm', color[state])}>{label[state]}</span>;
 }

--- a/web/src/components/DeviceCard.tsx
+++ b/web/src/components/DeviceCard.tsx
@@ -1,7 +1,7 @@
-'use client';
-import Link from 'next/link';
-import BadgeStatus from './BadgeStatus';
-import type { Device } from '@/lib/mock';
+"use client";
+import Link from "next/link";
+import BadgeStatus from "./BadgeStatus";
+import type { Device } from "@/lib/mock";
 
 export default function DeviceCard({ d }: { d: Device }) {
   return (
@@ -14,11 +14,10 @@ export default function DeviceCard({ d }: { d: Device }) {
         <BadgeStatus state={d.status} />
       </div>
       <div className="mt-2 text-sm text-neutral-600">
-        <div>UID: {d.device_uid}</div>
-        <div>
-          {d.category} ・ {d.location}
-        </div>
-        <div>SOP v{d.sop_version}</div>
+        {d.category} ・ {d.location}
+      </div>
+      <div className="text-xs text-neutral-500">
+        UID: {d.device_uid} ・ SOP v{d.sop_version}
       </div>
     </Link>
   );

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,0 +1,9 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./src/app/**/*.{ts,tsx}",
+    "./src/components/**/*.{ts,tsx}",
+  ],
+  theme: { extend: {} },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- configure Tailwind CSS with PostCSS and utilities
- add device dashboard UI and link from home page
- update components and pages to use Tailwind styles
- guard PostCSS config against missing tailwindcss module so dev server doesn't crash

## Testing
- `pnpm lint` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm build` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bc8567f88323a00a43d90b4b5ec0