### PR TITLE
feat: basic layout with mock reservations

### DIFF
--- a/web/src/app/(lab)/dashboard/page.tsx
+++ b/web/src/app/(lab)/dashboard/page.tsx
@@ -1,15 +1,15 @@
 import DeviceCard from "@/components/DeviceCard";
-async function fetchDevices() {
-  const r = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL ?? ''}/api/devices`, { cache: 'no-store' });
-  return (await r.json()).devices as any[];
-}
+import { getDevices } from "@/lib/api";
+
 export default async function DashboardPage() {
-  const devices = await fetchDevices();
+  const { devices } = await getDevices();
   return (
-    <main className="p-6 max-w-6xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">機器ダッシュボード</h1>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {devices.map((d: any) => <DeviceCard key={d.id} d={d} />)}
+    <main className="app-container py-6">
+      <h1 className="mb-4 text-2xl font-bold">機器ダッシュボード</h1>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {devices.map((d: any) => (
+          <DeviceCard key={d.id} d={d} />
+        ))}
       </div>
     </main>
   );

--- a/web/src/app/api/mock/reservations/route.ts
+++ b/web/src/app/api/mock/reservations/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+type R = { uid: string; start: string; end: string; purpose?: string };
+let RES: R[] = [];
+export async function GET(req: NextRequest) {
+  const uid = req.nextUrl.searchParams.get('uid');
+  return NextResponse.json({ reservations: uid ? RES.filter((r) => r.uid === uid) : RES });
+}
+export async function POST(req: NextRequest) {
+  const r = (await req.json()) as R;
+  const s = new Date(r.start).getTime(),
+    e = new Date(r.end).getTime();
+  if (!(s < e))
+    return NextResponse.json({ error: '開始は終了より前にしてください' }, { status: 400 });
+  const overlap = RES.some(
+    (x) => x.uid === r.uid && !(new Date(x.end).getTime() <= s || e <= new Date(x.start).getTime()),
+  );
+  if (overlap) return NextResponse.json({ error: 'その時間帯は予約済みです' }, { status: 409 });
+  RES.unshift(r);
+  return NextResponse.json({ ok: true });
+}

--- a/web/src/app/devices/[uid]/page.tsx
+++ b/web/src/app/devices/[uid]/page.tsx
@@ -1,23 +1,39 @@
-import { notFound } from 'next/navigation';
-import { MOCK_DEVICES } from '@/lib/mock';
-import BadgeStatus from '@/components/BadgeStatus';
+import { notFound } from "next/navigation";
+import BadgeStatus from "@/components/BadgeStatus";
+import { getDevice, getReservations } from "@/lib/api";
 
-export default function DeviceDetail({ params }: { params: { uid: string } }) {
-  const d = MOCK_DEVICES.find((x) => x.device_uid === decodeURIComponent(params.uid));
+export default async function DeviceDetail({ params }: { params: { uid: string } }) {
+  const uid = decodeURIComponent(params.uid);
+  const d = await getDevice(uid);
   if (!d) return notFound();
+  const { reservations } = await getReservations(uid);
   return (
-    <main className="p-6 max-w-3xl mx-auto space-y-4">
-      <div className="flex items-center justify-between">
+    <main className="app-container py-6">
+      <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-bold">{d.name}</h1>
         <BadgeStatus state={d.status} />
       </div>
-      <div className="text-neutral-700">
-        UID: {d.device_uid}／カテゴリ: {d.category}／位置: {d.location}／SOP v{d.sop_version}
-      </div>
-      <div className="flex gap-3">
-        <button className="rounded-2xl border px-4 py-2">予約</button>
-        <button className="rounded-2xl border px-4 py-2">使用開始</button>
-        <button className="rounded-2xl border px-4 py-2">QRポスター</button>
+      <div className="grid gap-6 md:grid-cols-[1fr_260px]">
+        <section className="space-y-4">
+          <div className="text-neutral-700">
+            UID: {d.device_uid}／カテゴリ: {d.category}／位置: {d.location}／SOP v{d.sop_version}
+          </div>
+          <div>
+            <h2 className="mb-2 font-semibold">最近の予約</h2>
+            <ul className="space-y-1 text-sm text-neutral-700">
+              {reservations.slice(0, 3).map((r: any, i: number) => (
+                <li key={i}>
+                  {r.start} - {r.end}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+        <aside className="h-fit space-y-3 rounded-2xl border p-4">
+          <button className="w-full rounded-2xl border px-4 py-2">予約</button>
+          <button className="w-full rounded-2xl border px-4 py-2">使用開始</button>
+          <button className="w-full rounded-2xl border px-4 py-2">QRポスター</button>
+        </aside>
       </div>
     </main>
   );

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -3,3 +3,7 @@
 @tailwind utilities;
 
 html, body { height: 100%; }
+
+.app-container {
+  @apply max-w-[1040px] mx-auto px-4 sm:px-6;
+}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -7,7 +7,22 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="ja">
       <body className="min-h-screen bg-white text-neutral-900 antialiased">
-        {children}
+        <header className="fixed top-0 z-10 w-full border-b bg-white/80 backdrop-blur">
+          <div className="app-container flex h-14 items-center justify-between">
+            <a href="/" className="font-bold">
+              Lab Yoyaku
+            </a>
+            <nav className="flex gap-4 text-sm">
+              <a href="/dashboard" className="hover:underline">
+                ダッシュボード
+              </a>
+              <a href="/dashboard" className="hover:underline">
+                機器一覧
+              </a>
+            </nav>
+          </div>
+        </header>
+        <div className="pt-14">{children}</div>
       </body>
     </html>
   );

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,14 +1,31 @@
-import Link from 'next/link';
+import Link from "next/link";
+import { getDevices } from "@/lib/api";
 
-export default function Home() {
+export default async function Home() {
+  const { devices } = await getDevices();
   return (
-    <main className="p-6">
+    <main className="app-container py-6">
       <h1>こんにちは Lab Yoyaku</h1>
       <p className="mt-4">
         <Link href="/dashboard" className="text-blue-600 underline">
           ダッシュボードへ
         </Link>
       </p>
+      <div className="mt-6 space-y-2">
+        <h2 className="font-semibold">最近の機器</h2>
+        <ul className="list-disc pl-5 text-blue-600 underline">
+          {devices.slice(0, 3).map((d: any) => (
+            <li key={d.id}>
+              <Link href={`/devices/${d.device_uid}`}>{d.name}</Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="mt-6">
+        <button className="rounded-2xl border px-4 py-2" disabled>
+          新規機器を登録（後で実装）
+        </button>
+      </div>
     </main>
   );
 }

--- a/web/src/components/DeviceCard.tsx
+++ b/web/src/components/DeviceCard.tsx
@@ -4,10 +4,12 @@ import BadgeStatus from "./BadgeStatus";
 import type { Device } from "@/lib/mock";
 
 export default function DeviceCard({ d }: { d: Device }) {
+  const nextAction =
+    d.status === "in_use" ? "終了予定 17:00" : "次予約 15:00";
   return (
     <Link
       href={`/devices/${d.device_uid}`}
-      className="block rounded-2xl border p-4 hover:shadow-md transition"
+      className="group block rounded-2xl border p-4 transition hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-500"
     >
       <div className="flex items-center justify-between">
         <h3 className="text-lg font-semibold">{d.name}</h3>
@@ -16,8 +18,14 @@ export default function DeviceCard({ d }: { d: Device }) {
       <div className="mt-2 text-sm text-neutral-600">
         {d.category} ・ {d.location}
       </div>
-      <div className="text-xs text-neutral-500">
+      <div className="mt-1 text-xs text-neutral-500">
         UID: {d.device_uid} ・ SOP v{d.sop_version}
+      </div>
+      <div className="mt-4 flex items-center justify-between text-sm text-neutral-600">
+        <span>{nextAction}</span>
+        <span className="text-neutral-400 transition group-hover:translate-x-1 group-hover:text-neutral-600" aria-hidden>
+          →
+        </span>
       </div>
     </Link>
   );

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,0 +1,20 @@
+export const getDevices = async () =>
+  await (await fetch('/api/devices', { cache: 'no-store' })).json();
+
+export const getDevice = async (uid: string) => {
+  const { devices } = await getDevices();
+  return devices.find((d: any) => d.device_uid === uid);
+};
+
+export const getReservations = async (uid: string) =>
+  await (await fetch(`/api/mock/reservations?uid=${uid}`, { cache: 'no-store' })).json();
+
+export const createReservation = async (p: any) => {
+  const r = await fetch('/api/mock/reservations', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(p),
+  });
+  if (!r.ok) throw await r.json();
+  return r.json();
+};


### PR DESCRIPTION
## Summary
- add global container utility and fixed header navigation
- enrich device cards and dashboard using shared API helpers
- implement mock reservations API endpoint

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a142051de48323841d1784d9fa67fc