### PR TITLE
Resolve server-side fetch URLs with headers-derived base

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,5 +1,16 @@
+import { headers } from "next/headers";
+
+const baseFromHeaders = () => {
+  const h = headers();
+  const proto = h.get("x-forwarded-proto") ?? "http";
+  const host = h.get("x-forwarded-host") ?? h.get("host");
+  return `${proto}://${host}`;
+};
+
+const abs = (p: string) => new URL(p, baseFromHeaders()).toString();
+
 export const getDevices = async () =>
-  await (await fetch('/api/devices', { cache: 'no-store' })).json();
+  (await fetch(abs("/api/devices"), { cache: "no-store" })).json();
 
 export const getDevice = async (uid: string) => {
   const { devices } = await getDevices();
@@ -7,12 +18,14 @@ export const getDevice = async (uid: string) => {
 };
 
 export const getReservations = async (uid: string) =>
-  await (await fetch(`/api/mock/reservations?uid=${uid}`, { cache: 'no-store' })).json();
+  (await fetch(abs(`/api/mock/reservations?uid=${uid}`), {
+    cache: "no-store",
+  })).json();
 
 export const createReservation = async (p: any) => {
-  const r = await fetch('/api/mock/reservations', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+  const r = await fetch(abs("/api/mock/reservations"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(p),
   });
   if (!r.ok) throw await r.json();


### PR DESCRIPTION
## Summary
- derive absolute API URLs from incoming request headers to fix server-side relative fetch errors

## Testing
- `pnpm -F web lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a14517f9ec8323aa63a445a9f33001