### PR TITLE
feat: overhaul calendar and add onboarding pages

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,8 @@
     "next": "14.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "clsx": "^2.1.0"
+    "clsx": "^2.1.0",
+    "qrcode.react": "^3.1.0"
   },
   "devDependencies": {
     "@types/react": "18.2.21",

--- a/web/src/app/api/mock/devices/route.ts
+++ b/web/src/app/api/mock/devices/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { devices, groups } from "@/lib/mock-db";
+
+export async function POST(req: NextRequest) {
+  const p = await req.json();
+  const g = groups.find((x) => x.slug === p.groupSlug || x.id === p.groupId);
+  if (!g) return NextResponse.json({ error: 'group not found' }, { status: 404 });
+  const device = {
+    id: crypto.randomUUID(),
+    device_uid: p.device_uid ?? `DEV-${Math.random().toString(36).slice(2,8)}`,
+    name: p.name,
+    category: p.category,
+    location: p.location,
+    status: 'available',
+    sop_version: Number(p.sop_version) || 1,
+    groupId: g.id,
+  };
+  devices.push(device);
+  return NextResponse.json({ device }, { status: 201 });
+}

--- a/web/src/app/api/mock/groups/join/route.ts
+++ b/web/src/app/api/mock/groups/join/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from "next/server";
+import { groups } from "@/lib/mock-db";
+
+export async function POST(req: NextRequest) {
+  const { code } = await req.json();
+  const g = groups.find((x) => x.slug === code);
+  if (!g) return NextResponse.json({ error: 'not found' }, { status: 404 });
+  return NextResponse.json({ ok: true, group: g });
+}

--- a/web/src/app/api/mock/groups/route.ts
+++ b/web/src/app/api/mock/groups/route.ts
@@ -1,3 +1,12 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { groups } from "@/lib/mock-db";
 export async function GET() { return NextResponse.json({ groups }); }
+
+export async function POST(req: NextRequest) {
+  const { name, slug } = await req.json();
+  if (!name || !slug)
+    return NextResponse.json({ error: "invalid" }, { status: 400 });
+  const g = { id: crypto.randomUUID(), name, slug };
+  groups.push(g);
+  return NextResponse.json({ group: g }, { status: 201 });
+}

--- a/web/src/app/api/mock/negotiations/[id]/route.ts
+++ b/web/src/app/api/mock/negotiations/[id]/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest, NextResponse } from "next/server";
+import { negotiations } from "@/lib/mock-db";
+
+export async function PATCH(req: NextRequest, { params:{id} }:{ params:{ id:string } }) {
+  const p = await req.json();
+  const rec = negotiations.find(n=>n.id===id);
+  if(!rec) return NextResponse.json({ error:'not found' }, { status:404 });
+  if(p.status) rec.status = p.status;
+  return NextResponse.json({ negotiation: rec });
+}

--- a/web/src/app/api/mock/negotiations/route.ts
+++ b/web/src/app/api/mock/negotiations/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { negotiations } from "@/lib/mock-db";
+
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const deviceId = url.searchParams.get('deviceId');
+  let list = negotiations;
+  if (deviceId) list = list.filter(n=>n.deviceId===deviceId);
+  return NextResponse.json({ negotiations: list });
+}
+
+export async function POST(req: NextRequest) {
+  const p = await req.json();
+  const rec = {
+    id: crypto.randomUUID(),
+    deviceId: p.deviceId,
+    requesterName: p.requesterName,
+    message: p.message,
+    targetReservationId: p.targetReservationId,
+    status: 'open',
+    createdAt: new Date().toISOString(),
+  };
+  negotiations.unshift(rec);
+  return NextResponse.json({ negotiation: rec }, { status: 201 });
+}

--- a/web/src/app/devices/[uid]/negotiations/page.tsx
+++ b/web/src/app/devices/[uid]/negotiations/page.tsx
@@ -1,0 +1,15 @@
+import { notFound } from 'next/navigation';
+import { getDevice, getNegotiations } from '@/lib/api';
+import NegotiationList from '@/components/NegotiationList';
+
+export default async function NegotiationsPage({ params:{uid} }:{ params:{ uid:string } }){
+  const d = await getDevice(decodeURIComponent(uid));
+  if(!d) return notFound();
+  const { negotiations } = await getNegotiations(d.id);
+  return (
+    <main className="space-y-4">
+      <h1 className="text-2xl font-bold">交渉: {d.name}</h1>
+      <NegotiationList deviceId={d.id} initialNegotiations={negotiations} />
+    </main>
+  );
+}

--- a/web/src/app/devices/[uid]/page.tsx
+++ b/web/src/app/devices/[uid]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import Link from "next/link";
 import BadgeStatus from "@/components/BadgeStatus";
 import ReservationModal from "@/components/ReservationModal";
 import { getDevice, getReservations } from "@/lib/api";
@@ -32,9 +33,20 @@ export default async function DeviceDetail({ params }: { params: { uid: string }
           </section>
         </section>
         <aside className="h-fit space-y-3 rounded-2xl border p-4">
-          <ReservationModal deviceId={d.id} groupId={d.groupId}/>
+          <ReservationModal deviceId={d.id} groupId={d.groupId} />
           <button className="w-full rounded-2xl border px-4 py-2">使用開始</button>
-          <button className="w-full rounded-2xl border px-4 py-2">QRポスター</button>
+          <Link
+            href={`/devices/${encodeURIComponent(d.device_uid)}/poster`}
+            className="block w-full rounded-2xl border px-4 py-2 text-center"
+          >
+            QRポスター
+          </Link>
+          <Link
+            href={`/devices/${encodeURIComponent(d.device_uid)}/negotiations`}
+            className="block w-full rounded-2xl border px-4 py-2 text-center"
+          >
+            交渉スレッド
+          </Link>
         </aside>
       </div>
     </main>

--- a/web/src/app/devices/[uid]/poster/page.tsx
+++ b/web/src/app/devices/[uid]/poster/page.tsx
@@ -1,0 +1,9 @@
+import { notFound } from 'next/navigation';
+import { getDevice } from '@/lib/api';
+import DevicePoster from '@/components/DevicePoster';
+
+export default async function PosterPage({ params:{uid} }:{ params:{ uid:string } }){
+  const d = await getDevice(decodeURIComponent(uid));
+  if(!d) return notFound();
+  return <DevicePoster device={d} />;
+}

--- a/web/src/app/groups/[slug]/calendar/page.tsx
+++ b/web/src/app/groups/[slug]/calendar/page.tsx
@@ -2,57 +2,114 @@ import { getGroup, getReservations } from "@/lib/api";
 import { devices } from "@/lib/mock-db"; // 本番はAPI化
 import BadgeUsage from "@/components/BadgeUsage";
 
-function hoursRange(start=8,end=22){return Array.from({length:(end-start+1)},(_,i)=>start+i);}
-
-export default async function GroupCalendar({ params:{slug} }:{params:{slug:string}}){
+export default async function GroupCalendar({
+  params: { slug },
+}: {
+  params: { slug: string };
+}) {
   const { group } = await getGroup(slug);
-  const devs = devices.filter(d=>d.groupId===group.id);
-  const from = new Date(); from.setHours(0,0,0,0);
-  const to = new Date(from); to.setDate(from.getDate()+7);
-  const { reservations } = await getReservations({ groupId: group.id, from: from.toISOString(), to: to.toISOString() });
+  const devs = devices.filter((d) => d.groupId === group.id);
+  const from = new Date();
+  from.setHours(0, 0, 0, 0);
+  const to = new Date(from);
+  to.setDate(from.getDate() + 7);
+  const { reservations } = await getReservations({
+    groupId: group.id,
+    from: from.toISOString(),
+    to: to.toISOString(),
+  });
 
-  // CSS Grid: 列=デバイス、行=時間スロット
+  const dayStart = new Date();
+  dayStart.setHours(8, 0, 0, 0);
+  const slots = 28;
+  const hours = Array.from({ length: slots }, (_, i) =>
+    new Date(dayStart.getTime() + i * 30 * 60 * 1000)
+  );
+
   return (
     <main className="space-y-4">
       <h1 className="text-2xl font-bold">{group.name} のカレンダー（週）</h1>
-      <div className="text-sm text-neutral-600">凡例：<BadgeUsage type="group" /> <BadgeUsage type="user" name="A.Suzuki" /></div>
+      <div className="text-sm text-neutral-600">
+        凡例：<BadgeUsage type="group" /> <BadgeUsage type="user" name="A.Suzuki" />
+      </div>
+
       <div className="overflow-x-auto border rounded-2xl">
-        <div className="min-w-[960px] grid" style={{gridTemplateColumns:`160px repeat(${devs.length}, 1fr)`}}>
-          {/* ヘッダー行 */}
+        <div
+          className="min-w-[960px] grid relative"
+          style={{
+            gridTemplateColumns: `140px repeat(${devs.length}, minmax(200px, 1fr))`,
+            gridTemplateRows: `40px repeat(${slots}, 40px)`,
+          }}
+        >
+          {/* ヘッダ行 */}
           <div className="bg-neutral-50 border-b p-2 font-medium">時間</div>
-          {devs.map(d=><div key={d.id} className="bg-neutral-50 border-b p-2 font-medium">{d.name}</div>)}
+          {devs.map((d) => (
+            <div key={d.id} className="bg-neutral-50 border-b p-2 font-medium">
+              {d.name}
+            </div>
+          ))}
 
-          {/* 本体：30分刻み */}
-          {Array.from({length: (14*2)},(_,i)=>i).map(i=>{
-            const t = new Date(from.getTime()+i*30*60*1000);
-            const label = t.toTimeString().slice(0,5);
-            return (
-              <>
-                <div key={`t-${i}`} className="border-r p-2 text-sm text-neutral-500">{label}</div>
-                {devs.map((d,idx)=>{
-                  const slotKey=`c-${i}-${idx}`;
-                  return <div key={slotKey} className="border-b h-12 relative" />;
-                })}
-              </>
+          {/* 時刻ラベル列 */}
+          {hours.map((t, i) => (
+            <div
+              key={`time-${i}`}
+              className="border-r p-2 text-sm text-neutral-500"
+              style={{ gridColumn: 1, gridRow: i + 2 }}
+            >
+              {t.toTimeString().slice(0, 5)}
+            </div>
+          ))}
+
+          {/* 各デバイスの空グリッド */}
+          {devs.map((d, col) =>
+            hours.map((_, i) => (
+              <div
+                key={`cell-${col}-${i}`}
+                className="border-b"
+                style={{ gridColumn: col + 2, gridRow: i + 2 }}
+              />
+            ))
+          )}
+
+          {/* 予約イベント */}
+          {reservations.map((r: any) => {
+            const col = devs.findIndex((d) => d.id === r.deviceId);
+            if (col < 0) return null;
+            const startIdx = Math.max(
+              0,
+              Math.floor(
+                (new Date(r.start).getTime() - dayStart.getTime()) /
+                  (30 * 60 * 1000)
+              )
             );
-          })}
-
-          {/* 予約を重ね描き（重なり簡易） */}
-          {reservations.map((r:any)=>{
-            const col = devs.findIndex(d=>d.id===r.deviceId);
-            if(col<0) return null;
-            const startIdx = Math.max(0, Math.floor((new Date(r.start).getTime()-from.getTime())/(30*60*1000)));
-            const endIdx   = Math.min(28, Math.ceil((new Date(r.end).getTime()-from.getTime())/(30*60*1000)));
-            const top = startIdx*48; const height = Math.max(24,(endIdx-startIdx)*48-4);
+            const endIdx = Math.max(
+              startIdx + 1,
+              Math.ceil(
+                (new Date(r.end).getTime() - dayStart.getTime()) /
+                  (30 * 60 * 1000)
+              )
+            );
+            const isGroup = r.bookedByType === "group";
             return (
               <div
                 key={r.id}
-                className={`absolute bg-amber-100 border-amber-300 border rounded-md px-2 py-1 text-sm`}
-                style={{ left: 160 + col*( (960-160)/devs.length ), top, width: (960-160)/devs.length - 8, height }}
-                title={`${r.start} - ${r.end}`}
+                className={`rounded-md px-2 py-1 text-sm bg-amber-100 ${
+                  isGroup
+                    ? "border-2 border-emerald-400"
+                    : "border border-sky-300"
+                }`}
+                style={{
+                  gridColumn: col + 2,
+                  gridRow: `${startIdx + 2} / ${endIdx + 2}`,
+                }}
+                title={`${new Date(r.start).toLocaleString()} - ${new Date(
+                  r.end
+                ).toLocaleTimeString()}`}
               >
-                <span className="block truncate text-neutral-800">{r.note ?? "予約"}</span>
-                <span className="text-xs text-neutral-500">{r.bookedByType==='group'?'グループ予約':'個人予約'}</span>
+                <div className="truncate text-neutral-800">{r.note ?? "予約"}</div>
+                <div className="text-xs text-neutral-500">
+                  {isGroup ? "グループ予約" : `個人予約`}
+                </div>
               </div>
             );
           })}

--- a/web/src/app/groups/[slug]/devices/new/page.tsx
+++ b/web/src/app/groups/[slug]/devices/new/page.tsx
@@ -1,0 +1,50 @@
+'use client';
+import { useState } from 'react';
+import Button from '@/components/ui/Button';
+
+export default function DeviceNew({ params:{slug} }:{ params:{ slug:string } }) {
+  const [name,setName] = useState('');
+  const [category,setCategory] = useState('');
+  const [location,setLocation] = useState('');
+  const [sop,setSop] = useState('1');
+
+  const submit = async (e:React.FormEvent)=>{
+    e.preventDefault();
+    const r = await fetch('/api/mock/devices',{
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({ name, category, location, sop_version:sop, groupSlug: slug })
+    });
+    if(r.ok){
+      const { device } = await r.json();
+      location.href = `/devices/${device.device_uid}/poster`;
+    } else {
+      alert('エラー');
+    }
+  };
+
+  return (
+    <main className="max-w-md space-y-4">
+      <h1 className="text-2xl font-bold">機器登録</h1>
+      <form onSubmit={submit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium mb-1">名称</label>
+          <input value={name} onChange={e=>setName(e.target.value)} className="w-full rounded border p-2" required />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">カテゴリ</label>
+          <input value={category} onChange={e=>setCategory(e.target.value)} className="w-full rounded border p-2" />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">場所</label>
+          <input value={location} onChange={e=>setLocation(e.target.value)} className="w-full rounded border p-2" />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">SOPバージョン</label>
+          <input value={sop} onChange={e=>setSop(e.target.value)} className="w-full rounded border p-2" />
+        </div>
+        <Button type="submit" variant="primary">登録</Button>
+      </form>
+    </main>
+  );
+}

--- a/web/src/app/groups/join/page.tsx
+++ b/web/src/app/groups/join/page.tsx
@@ -1,0 +1,35 @@
+'use client';
+import { useState } from 'react';
+import Button from '@/components/ui/Button';
+
+export default function GroupJoin() {
+  const [code, setCode] = useState('');
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const r = await fetch('/api/mock/groups/join', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code }),
+    });
+    if (r.ok) {
+      alert('参加できました');
+      setCode('');
+    } else {
+      alert('コードが無効です');
+    }
+  };
+
+  return (
+    <main className="max-w-md space-y-4">
+      <h1 className="text-2xl font-bold">グループに参加</h1>
+      <form onSubmit={submit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium mb-1">招待コード</label>
+          <input value={code} onChange={e=>setCode(e.target.value)} className="w-full rounded border p-2" required />
+        </div>
+        <Button type="submit" variant="primary">参加する</Button>
+      </form>
+    </main>
+  );
+}

--- a/web/src/app/groups/new/page.tsx
+++ b/web/src/app/groups/new/page.tsx
@@ -1,0 +1,42 @@
+'use client';
+import { useState } from 'react';
+import Button from '@/components/ui/Button';
+
+export default function GroupNew() {
+  const [name, setName] = useState('');
+  const [slug, setSlug] = useState('');
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const r = await fetch('/api/mock/groups', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, slug }),
+    });
+    if (r.ok) {
+      alert('グループを作成しました');
+      setName('');
+      setSlug('');
+    } else {
+      const err = await r.json();
+      alert(err.error ?? 'エラー');
+    }
+  };
+
+  return (
+    <main className="max-w-md space-y-4">
+      <h1 className="text-2xl font-bold">グループ作成</h1>
+      <form onSubmit={submit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium mb-1">名称</label>
+          <input value={name} onChange={e=>setName(e.target.value)} className="w-full rounded border p-2" required />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">slug</label>
+          <input value={slug} onChange={e=>setSlug(e.target.value)} className="w-full rounded border p-2" required />
+        </div>
+        <Button type="submit" variant="primary">作成</Button>
+      </form>
+    </main>
+  );
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,47 +1,42 @@
 import Link from "next/link";
+import Button from "@/components/ui/Button";
 
 export default function Home() {
   return (
-    <section className="space-y-8">
-      <div className="space-y-2">
-        <h1 className="text-2xl font-bold">こんにちは Lab Yoyaku</h1>
-        <Link href="/dashboard" className="text-blue-600 hover:underline">
-          ダッシュボードへ
-        </Link>
+    <section className="space-y-12">
+      <div className="space-y-3">
+        <h1 className="text-3xl font-bold">Lab Yoyaku へようこそ</h1>
+        <p className="text-neutral-600">
+          研究室の機器をグループ単位で管理し、QRコードから利用状況やカレンダーを確認・予約できます。
+        </p>
+      </div>
+
+      <div className="grid gap-6 sm:grid-cols-3">
+        <div className="rounded-2xl border p-6">
+          <h2 className="font-semibold mb-2">① グループを作成</h2>
+          <p className="text-sm text-neutral-600 mb-4">研究室/班をグループとして立ち上げ、メンバーを招待します。</p>
+          <Button variant="primary" onClick={() => (location.href = "/groups/new")}>グループを作る</Button>
+        </div>
+        <div className="rounded-2xl border p-6">
+          <h2 className="font-semibold mb-2">② グループに参加</h2>
+          <p className="text-sm text-neutral-600 mb-4">招待リンク or コードから参加。機器一覧とカレンダーが使えます。</p>
+          <Button onClick={() => (location.href = "/groups/join")}>参加する</Button>
+        </div>
+        <div className="rounded-2xl border p-6">
+          <h2 className="font-semibold mb-2">③ 機器登録 & カレンダー</h2>
+          <p className="text-sm text-neutral-600 mb-4">機器ごとのQRを発行し、予約・使用中がひと目で分かります。</p>
+          <Link className="text-blue-600 hover:underline" href="/dashboard">ダッシュボードを見る</Link>
+        </div>
       </div>
 
       <div className="space-y-3">
-        <h2 className="text-xl font-semibold">最近の機器</h2>
-        <ul className="list-disc pl-5 space-y-2 text-blue-700">
-          <li>
-            <Link href="/devices/JR-PAM-01" className="hover:underline">
-              ジュニアPAM
-            </Link>
-          </li>
-          <li>
-            <Link href="/devices/PCR-02" className="hover:underline">
-              PCR (Thermal Cycler)
-            </Link>
-          </li>
-          <li>
-            <Link href="/devices/GC-01" className="hover:underline">
-              GC-MS
-            </Link>
-          </li>
-        </ul>
-      </div>
-
-      <div>
-        <button
-          type="button"
-          className="inline-flex items-center rounded-2xl border px-5 py-3 text-sm font-medium shadow-sm hover:-translate-y-0.5 hover:shadow transition"
-          disabled
-          title="後で実装"
-        >
-          新規機器を登録（後で実装）
-        </button>
+        <h3 className="text-xl font-semibold">ショートカット</h3>
+        <div className="flex gap-3">
+          <Button onClick={() => (location.href = "/groups")}>グループ一覧</Button>
+          <Button onClick={() => (location.href = "/devices")}>機器一覧</Button>
+          <Button onClick={() => (location.href = "/dashboard")}>ダッシュボード</Button>
+        </div>
       </div>
     </section>
   );
 }
-

--- a/web/src/components/DevicePoster.tsx
+++ b/web/src/components/DevicePoster.tsx
@@ -1,0 +1,22 @@
+// eslint-disable-next-line import/no-unresolved, @typescript-eslint/no-var-requires
+const { QRCodeCanvas } = require('qrcode.react');
+
+export default function DevicePoster({ device }: { device: any }) {
+  const url = `${process.env.NEXT_PUBLIC_BASE_URL}/devices/${device.device_uid}?from=qr`;
+  return (
+    <div className="mx-auto w-[794px] h-[1123px] p-10 border rounded bg-white">
+      <h1 className="text-3xl font-bold mb-6">Lab Yoyaku</h1>
+      <h2 className="text-2xl font-semibold mb-2">{device.name}</h2>
+      <p className="text-neutral-600 mb-6">UID: {device.device_uid}</p>
+      <div className="flex items-center gap-10">
+        <QRCodeCanvas value={url} size={280} includeMargin />
+        <div className="text-sm text-neutral-700 leading-7">
+          <p>このQRから予約状況とカレンダーが確認できます。</p>
+          <p className="font-medium">URL: {url}</p>
+          <p className="mt-4">※利用前にSOP/注意を必ず確認してください。</p>
+        </div>
+      </div>
+      <footer className="mt-16 text-neutral-500">© Lab Yoyaku</footer>
+    </div>
+  );
+}

--- a/web/src/components/NegotiationList.tsx
+++ b/web/src/components/NegotiationList.tsx
@@ -1,0 +1,47 @@
+'use client';
+import { useState } from 'react';
+import Button from '@/components/ui/Button';
+import { createNegotiation, updateNegotiation } from '@/lib/api';
+
+export default function NegotiationList({ deviceId, initialNegotiations }:{ deviceId:string; initialNegotiations:any[] }){
+  const [list,setList] = useState(initialNegotiations);
+  const [name,setName] = useState('');
+  const [msg,setMsg] = useState('');
+
+  const submit = async (e:React.FormEvent)=>{
+    e.preventDefault();
+    const { negotiation } = await createNegotiation({ deviceId, requesterName:name, message:msg });
+    setList([negotiation, ...list]);
+    setName(''); setMsg('');
+  };
+
+  const change = async (id:string, status:string)=>{
+    const { negotiation } = await updateNegotiation(id, status);
+    setList(list.map(n=>n.id===id?negotiation:n));
+  };
+
+  return (
+    <div className="space-y-4">
+      <form onSubmit={submit} className="space-y-2">
+        <input value={name} onChange={e=>setName(e.target.value)} placeholder="名前" className="w-full rounded border p-2" required />
+        <textarea value={msg} onChange={e=>setMsg(e.target.value)} placeholder="メッセージ" className="w-full rounded border p-2" required />
+        <Button type="submit" variant="primary">送信</Button>
+      </form>
+      <ul className="space-y-2">
+        {list.map(n=>(
+          <li key={n.id} className="rounded border p-2">
+            <div className="font-medium">{n.requesterName} <span className="text-xs text-neutral-500">{new Date(n.createdAt).toLocaleString()}</span></div>
+            <div className="text-sm text-neutral-700 whitespace-pre-line">{n.message}</div>
+            <div className="text-xs mt-2">状態: {n.status}</div>
+            {n.status==='open' && (
+              <div className="space-x-2 mt-2">
+                <Button type="button" onClick={()=>change(n.id,'accepted')}>承諾</Button>
+                <Button type="button" onClick={()=>change(n.id,'rejected')}>拒否</Button>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -23,3 +23,58 @@ export const getDevice = async (uid: string) => {
   const { devices } = await getDevices();
   return devices.find((d: any) => d.device_uid === uid);
 };
+
+export const createGroup = async (payload: any) => {
+  const r = await fetch(abs('/api/mock/groups'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!r.ok) throw await r.json();
+  return r.json();
+};
+
+export const joinGroup = async (code: string) => {
+  const r = await fetch(abs('/api/mock/groups/join'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ code }),
+  });
+  if (!r.ok) throw await r.json();
+  return r.json();
+};
+
+export const createDevice = async (payload: any) => {
+  const r = await fetch(abs('/api/mock/devices'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!r.ok) throw await r.json();
+  return r.json();
+};
+
+export const getNegotiations = async (deviceId: string) => {
+  const params = new URLSearchParams({ deviceId }).toString();
+  return (await fetch(abs(`/api/mock/negotiations?${params}`), { cache: 'no-store' })).json();
+};
+
+export const createNegotiation = async (payload: any) => {
+  const r = await fetch(abs('/api/mock/negotiations'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!r.ok) throw await r.json();
+  return r.json();
+};
+
+export const updateNegotiation = async (id: string, status: string) => {
+  const r = await fetch(abs(`/api/mock/negotiations/${id}`), {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status }),
+  });
+  if (!r.ok) throw await r.json();
+  return r.json();
+};

--- a/web/src/lib/mock-db.ts
+++ b/web/src/lib/mock-db.ts
@@ -1,4 +1,4 @@
-import type { Group, Device, Reservation } from "./types";
+import type { Group, Device, Reservation, Negotiation } from "./types";
 
 export const groups: Group[] = [
   { id:"g1", name:"植物生理学研究室", slug:"plant-phys" },
@@ -15,3 +15,5 @@ export const reservations: Reservation[] = [
   { id:"r1", deviceId:"d2", groupId:"g1", start:new Date().toISOString(), end:new Date(Date.now()+60*60e3).toISOString(), note:"PCR 予備実験", status:"in_use", bookedByType:"user", bookedById:"u-suzuki" },
   { id:"r2", deviceId:"d1", groupId:"g1", start:new Date(Date.now()+2*60*60e3).toISOString(), end:new Date(Date.now()+3*60*60e3).toISOString(), note:"光合成測定", status:"confirmed", bookedByType:"group", bookedById:"g1" },
 ];
+
+export const negotiations: Negotiation[] = [];

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -14,3 +14,14 @@ export type Reservation = {
   bookedByType: BookedByType; bookedById: string; // groupId or userId
   createdByUserId?: string;
 };
+
+export type NegotiationStatus = 'open'|'accepted'|'rejected';
+export type Negotiation = {
+  id: string;
+  targetReservationId?: string;
+  deviceId: string;
+  requesterName: string;
+  message: string;
+  status: NegotiationStatus;
+  createdAt: string;
+};

--- a/web/src/types/qrcode.react.d.ts
+++ b/web/src/types/qrcode.react.d.ts
@@ -1,0 +1,1 @@
+declare module 'qrcode.react';


### PR DESCRIPTION
## Summary
- snap calendar events to CSS grid
- add onboarding home plus group/device creation forms
- prototype device posters with QR and negotiation threads

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `pnpm typecheck` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a29e70b11c832394c8aa2a133d0f4b