### PR TITLE
Replace Button navigation with Link in home page

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
-import Button from "@/components/ui/Button";
 
 export default function Home() {
+  const btn = "inline-flex items-center rounded-2xl px-4 py-2 text-sm border hover:-translate-y-0.5 shadow-sm transition";
+
   return (
     <section className="space-y-12">
       <div className="space-y-3">
@@ -15,26 +16,38 @@ export default function Home() {
         <div className="rounded-2xl border p-6">
           <h2 className="font-semibold mb-2">① グループを作成</h2>
           <p className="text-sm text-neutral-600 mb-4">研究室/班をグループとして立ち上げ、メンバーを招待します。</p>
-          <Button variant="primary" onClick={() => (location.href = "/groups/new")}>グループを作る</Button>
+          <Link href="/groups/new" className={`${btn} bg-neutral-900 text-white hover:bg-neutral-800`}>
+            グループを作る
+          </Link>
         </div>
         <div className="rounded-2xl border p-6">
           <h2 className="font-semibold mb-2">② グループに参加</h2>
           <p className="text-sm text-neutral-600 mb-4">招待リンク or コードから参加。機器一覧とカレンダーが使えます。</p>
-          <Button onClick={() => (location.href = "/groups/join")}>参加する</Button>
+          <Link href="/groups/join" className={btn}>
+            参加する
+          </Link>
         </div>
         <div className="rounded-2xl border p-6">
           <h2 className="font-semibold mb-2">③ 機器登録 & カレンダー</h2>
           <p className="text-sm text-neutral-600 mb-4">機器ごとのQRを発行し、予約・使用中がひと目で分かります。</p>
-          <Link className="text-blue-600 hover:underline" href="/dashboard">ダッシュボードを見る</Link>
+          <Link className="text-blue-600 hover:underline" href="/dashboard">
+            ダッシュボードを見る
+          </Link>
         </div>
       </div>
 
       <div className="space-y-3">
         <h3 className="text-xl font-semibold">ショートカット</h3>
         <div className="flex gap-3">
-          <Button onClick={() => (location.href = "/groups")}>グループ一覧</Button>
-          <Button onClick={() => (location.href = "/devices")}>機器一覧</Button>
-          <Button onClick={() => (location.href = "/dashboard")}>ダッシュボード</Button>
+          <Link href="/groups" className={btn}>
+            グループ一覧
+          </Link>
+          <Link href="/devices" className={btn}>
+            機器一覧
+          </Link>
+          <Link href="/dashboard" className={btn}>
+            ダッシュボード
+          </Link>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Avoid passing `onClick` from the server by replacing client `Button` with `Link` elements on the home page

## Testing
- `npm run lint` (fails: Definition for rule '@typescript-eslint/no-var-requires' was not found)
- `npm run typecheck` (fails: Property 'href' does not exist on type 'string')

------
https://chatgpt.com/codex/tasks/task_e_68a2afd054bc83239dfd471ac69b7753