### PR TITLE
feat: add group password support

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "clsx": "^2.1.0",
-    "qrcode.react": "^3.1.0"
+    "qrcode.react": "^3.1.0",
+    "bcryptjs": "^2.4.3"
   },
   "devDependencies": {
     "@types/react": "18.2.21",

--- a/web/src/app/api/mock/groups/[slug]/route.ts
+++ b/web/src/app/api/mock/groups/[slug]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { groups, devices } from "@/lib/mock-db";
+import { groups, devices, publicizeGroup } from "@/lib/mock-db";
 export async function GET(_: NextRequest, { params:{slug} }: any) {
   const g = groups.find(x=>x.slug===slug);
   if(!g) return NextResponse.json({error:"not found"}, {status:404});
-  return NextResponse.json({ group: g, devices: devices.filter(d=>d.groupId===g.id) });
+  return NextResponse.json({ group: publicizeGroup(g), devices: devices.filter(d=>d.groupId===g.id) });
 }

--- a/web/src/app/api/mock/groups/join/route.ts
+++ b/web/src/app/api/mock/groups/join/route.ts
@@ -1,9 +1,22 @@
-import { NextRequest, NextResponse } from "next/server";
-import { groups } from "@/lib/mock-db";
+import { NextResponse } from "next/server";
+import { joinGroup, publicizeGroup } from "@/lib/mock-db";
 
-export async function POST(req: NextRequest) {
-  const { code } = await req.json();
-  const g = groups.find((x) => x.slug === code);
-  if (!g) return NextResponse.json({ error: 'not found' }, { status: 404 });
-  return NextResponse.json({ ok: true, group: g });
+export async function POST(req: Request) {
+  const { group, password } = await req.json(); // group = name or slug
+  if (!group || !password) {
+    return NextResponse.json(
+      { error: "group, password は必須" },
+      { status: 400 },
+    );
+  }
+  try {
+    const g = await joinGroup(group, password);
+    return NextResponse.json(
+      { group: publicizeGroup(g) },
+      { status: 200 },
+    );
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 401 });
+  }
 }
+

--- a/web/src/app/api/mock/groups/route.ts
+++ b/web/src/app/api/mock/groups/route.ts
@@ -1,12 +1,26 @@
-import { NextRequest, NextResponse } from "next/server";
-import { groups } from "@/lib/mock-db";
-export async function GET() { return NextResponse.json({ groups }); }
+import { NextResponse } from "next/server";
+import { groups, createGroup, publicizeGroup } from "@/lib/mock-db";
 
-export async function POST(req: NextRequest) {
-  const { name, slug } = await req.json();
-  if (!name || !slug)
-    return NextResponse.json({ error: "invalid" }, { status: 400 });
-  const g = { id: crypto.randomUUID(), name, slug };
-  groups.push(g);
-  return NextResponse.json({ group: g }, { status: 201 });
+export async function GET() {
+  return NextResponse.json({ groups: groups.map(publicizeGroup) });
 }
+
+export async function POST(req: Request) {
+  const { name, slug, password } = await req.json();
+  if (!name || !slug || !password) {
+    return NextResponse.json(
+      { error: "name, slug, password は必須" },
+      { status: 400 },
+    );
+  }
+  try {
+    const g = await createGroup({ name, slug, password });
+    return NextResponse.json(
+      { group: publicizeGroup(g) },
+      { status: 201 },
+    );
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 400 });
+  }
+}
+

--- a/web/src/app/groups/join/page.tsx
+++ b/web/src/app/groups/join/page.tsx
@@ -1,35 +1,55 @@
-'use client';
-import { useState } from 'react';
-import Button from '@/components/ui/Button';
+"use client";
 
-export default function GroupJoin() {
-  const [code, setCode] = useState('');
+import { useState } from "react";
+import { useRouter } from "next/navigation";
 
-  const submit = async (e: React.FormEvent) => {
+export default function GroupJoinPage() {
+  const [group, setGroup] = useState(""); // name or slug
+  const [password, setPassword] = useState("");
+  const [err, setErr] = useState<string | null>(null);
+  const router = useRouter();
+
+  async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
-    const r = await fetch('/api/mock/groups/join', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ code }),
+    setErr(null);
+    const res = await fetch("/api/mock/groups/join", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ group, password }),
     });
-    if (r.ok) {
-      alert('参加できました');
-      setCode('');
-    } else {
-      alert('コードが無効です');
+    const data = await res.json();
+    if (!res.ok) {
+      setErr(data.error || "参加に失敗しました");
+      return;
     }
-  };
+    router.push(`/groups/${data.group.slug}/calendar`);
+  }
 
   return (
-    <main className="max-w-md space-y-4">
-      <h1 className="text-2xl font-bold">グループに参加</h1>
-      <form onSubmit={submit} className="space-y-4">
-        <div>
-          <label className="block text-sm font-medium mb-1">招待コード</label>
-          <input value={code} onChange={e=>setCode(e.target.value)} className="w-full rounded border p-2" required />
-        </div>
-        <Button type="submit" variant="primary">参加する</Button>
+    <main className="max-w-2xl p-6 space-y-6">
+      <h1 className="text-3xl font-bold">グループに参加</h1>
+      <form onSubmit={onSubmit} className="space-y-5">
+        <label className="block">
+          <div className="mb-1">グループ名 または slug</div>
+          <input
+            className="w-full rounded-xl border p-3"
+            value={group}
+            onChange={(e) => setGroup(e.target.value)}
+          />
+        </label>
+        <label className="block">
+          <div className="mb-1">パスワード</div>
+          <input
+            type="password"
+            className="w-full rounded-xl border p-3"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </label>
+        {err && <p className="text-red-600 text-sm">{err}</p>}
+        <button className="rounded-xl bg-black text-white px-5 py-2">参加する</button>
       </form>
     </main>
   );
 }
+

--- a/web/src/app/groups/new/page.tsx
+++ b/web/src/app/groups/new/page.tsx
@@ -1,42 +1,64 @@
-'use client';
-import { useState } from 'react';
-import Button from '@/components/ui/Button';
+"use client";
 
-export default function GroupNew() {
-  const [name, setName] = useState('');
-  const [slug, setSlug] = useState('');
+import { useState } from "react";
+import { useRouter } from "next/navigation";
 
-  const submit = async (e: React.FormEvent) => {
+export default function GroupNewPage() {
+  const [name, setName] = useState("");
+  const [slug, setSlug] = useState("");
+  const [password, setPassword] = useState("");
+  const [err, setErr] = useState<string | null>(null);
+  const router = useRouter();
+
+  async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
-    const r = await fetch('/api/mock/groups', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, slug }),
+    setErr(null);
+    const res = await fetch("/api/mock/groups", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, slug, password }),
     });
-    if (r.ok) {
-      alert('グループを作成しました');
-      setName('');
-      setSlug('');
-    } else {
-      const err = await r.json();
-      alert(err.error ?? 'エラー');
+    const data = await res.json();
+    if (!res.ok) {
+      setErr(data.error || "作成に失敗しました");
+      return;
     }
-  };
+    router.push(`/groups/${data.group.slug}/calendar`);
+  }
 
   return (
-    <main className="max-w-md space-y-4">
-      <h1 className="text-2xl font-bold">グループ作成</h1>
-      <form onSubmit={submit} className="space-y-4">
-        <div>
-          <label className="block text-sm font-medium mb-1">名称</label>
-          <input value={name} onChange={e=>setName(e.target.value)} className="w-full rounded border p-2" required />
-        </div>
-        <div>
-          <label className="block text-sm font-medium mb-1">slug</label>
-          <input value={slug} onChange={e=>setSlug(e.target.value)} className="w-full rounded border p-2" required />
-        </div>
-        <Button type="submit" variant="primary">作成</Button>
+    <main className="max-w-2xl p-6 space-y-6">
+      <h1 className="text-3xl font-bold">グループ作成</h1>
+      <form onSubmit={onSubmit} className="space-y-5">
+        <label className="block">
+          <div className="mb-1">名称</div>
+          <input
+            className="w-full rounded-xl border p-3"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </label>
+        <label className="block">
+          <div className="mb-1">slug</div>
+          <input
+            className="w-full rounded-xl border p-3"
+            value={slug}
+            onChange={(e) => setSlug(e.target.value)}
+          />
+        </label>
+        <label className="block">
+          <div className="mb-1">パスワード</div>
+          <input
+            type="password"
+            className="w-full rounded-xl border p-3"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </label>
+        {err && <p className="text-red-600 text-sm">{err}</p>}
+        <button className="rounded-xl bg-black text-white px-5 py-2">作成</button>
       </form>
     </main>
   );
 }
+

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -24,7 +24,11 @@ export const getDevice = async (uid: string) => {
   return devices.find((d: any) => d.device_uid === uid);
 };
 
-export const createGroup = async (payload: any) => {
+export const createGroup = async (payload: {
+  name: string;
+  slug: string;
+  password: string;
+}) => {
   const r = await fetch(abs('/api/mock/groups'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -34,11 +38,11 @@ export const createGroup = async (payload: any) => {
   return r.json();
 };
 
-export const joinGroup = async (code: string) => {
+export const joinGroup = async (payload: { group: string; password: string }) => {
   const r = await fetch(abs('/api/mock/groups/join'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ code }),
+    body: JSON.stringify(payload),
   });
   if (!r.ok) throw await r.json();
   return r.json();

--- a/web/src/lib/mock-db.ts
+++ b/web/src/lib/mock-db.ts
@@ -1,19 +1,125 @@
+import bcrypt from "bcryptjs";
 import type { Group, Device, Reservation, Negotiation } from "./types";
 
-export const groups: Group[] = [
-  { id:"g1", name:"植物生理学研究室", slug:"plant-phys" },
-  { id:"g2", name:"分析化学研究室",   slug:"analytical" }
-];
+// in-memory mock database
+export const mockDB = {
+  groups: [
+    { id: "g1", name: "植物生理学研究室", slug: "plant-phys" },
+    { id: "g2", name: "分析化学研究室", slug: "analytical" },
+  ] as Group[],
+  devices: [
+    {
+      id: "d1",
+      device_uid: "JR-PAM-01",
+      name: "ジュニアPAM",
+      category: "fluorometer",
+      location: "Room 302",
+      status: "available",
+      sop_version: 3,
+      groupId: "g1",
+    },
+    {
+      id: "d2",
+      device_uid: "PCR-02",
+      name: "PCR (Thermal Cycler)",
+      category: "pcr",
+      location: "Room 305",
+      status: "reserved",
+      sop_version: 5,
+      groupId: "g1",
+    },
+    {
+      id: "d3",
+      device_uid: "GC-01",
+      name: "GC-MS",
+      category: "gcms",
+      location: "Room 210",
+      status: "maintenance",
+      sop_version: 7,
+      groupId: "g2",
+    },
+  ] as Device[],
+  reservations: [
+    {
+      id: "r1",
+      deviceId: "d2",
+      groupId: "g1",
+      start: new Date().toISOString(),
+      end: new Date(Date.now() + 60 * 60e3).toISOString(),
+      note: "PCR 予備実験",
+      status: "in_use",
+      bookedByType: "user",
+      bookedById: "u-suzuki",
+    },
+    {
+      id: "r2",
+      deviceId: "d1",
+      groupId: "g1",
+      start: new Date(Date.now() + 2 * 60 * 60e3).toISOString(),
+      end: new Date(Date.now() + 3 * 60 * 60e3).toISOString(),
+      note: "光合成測定",
+      status: "confirmed",
+      bookedByType: "group",
+      bookedById: "g1",
+    },
+  ] as Reservation[],
+  negotiations: [] as Negotiation[],
+};
 
-export const devices: Device[] = [
-  { id:"d1", device_uid:"JR-PAM-01", name:"ジュニアPAM", category:"fluorometer", location:"Room 302", status:"available", sop_version:3, groupId:"g1" },
-  { id:"d2", device_uid:"PCR-02",    name:"PCR (Thermal Cycler)", category:"pcr", location:"Room 305", status:"reserved", sop_version:5, groupId:"g1" },
-  { id:"d3", device_uid:"GC-01",     name:"GC-MS", category:"gcms", location:"Room 210", status:"maintenance", sop_version:7, groupId:"g2" },
-];
+// legacy named exports for convenience
+export const groups = mockDB.groups;
+export const devices = mockDB.devices;
+export const reservations = mockDB.reservations;
+export const negotiations = mockDB.negotiations;
 
-export const reservations: Reservation[] = [
-  { id:"r1", deviceId:"d2", groupId:"g1", start:new Date().toISOString(), end:new Date(Date.now()+60*60e3).toISOString(), note:"PCR 予備実験", status:"in_use", bookedByType:"user", bookedById:"u-suzuki" },
-  { id:"r2", deviceId:"d1", groupId:"g1", start:new Date(Date.now()+2*60*60e3).toISOString(), end:new Date(Date.now()+3*60*60e3).toISOString(), note:"光合成測定", status:"confirmed", bookedByType:"group", bookedById:"g1" },
-];
+// remove passwordHash when sending to client
+export const publicizeGroup = (g: Group) => {
+  const { passwordHash, ...rest } = g;
+  return rest;
+};
 
-export const negotiations: Negotiation[] = [];
+export async function hashPassword(plain: string) {
+  const salt = await bcrypt.genSalt(10);
+  return bcrypt.hash(plain, salt);
+}
+
+export async function verifyPassword(hash: string, plain: string) {
+  return bcrypt.compare(plain, hash);
+}
+
+export function getGroupByNameOrSlug(identifier: string) {
+  const key = identifier.trim().toLowerCase();
+  return mockDB.groups.find(
+    (g) => g.name.toLowerCase() === key || g.slug.toLowerCase() === key,
+  );
+}
+
+export async function createGroup(input: {
+  name: string;
+  slug: string;
+  password: string;
+}) {
+  if (getGroupByNameOrSlug(input.name) || getGroupByNameOrSlug(input.slug)) {
+    throw new Error("同名/同slugのグループが既に存在します");
+  }
+  const passwordHash = await hashPassword(input.password);
+  const group: Group = {
+    id: crypto.randomUUID(),
+    name: input.name,
+    slug: input.slug,
+    passwordHash,
+  };
+  mockDB.groups.push(group);
+  return group;
+}
+
+export async function joinGroup(identifier: string, password: string) {
+  const g = getGroupByNameOrSlug(identifier);
+  if (!g) throw new Error("グループが見つかりません");
+  if (!g.passwordHash)
+    throw new Error("このグループはまだパスワード設定がありません");
+  const ok = await verifyPassword(g.passwordHash, password);
+  if (!ok) throw new Error("パスワードが違います");
+  return g;
+}
+

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,4 +1,10 @@
-export type Group = { id: string; name: string; slug: string };
+export type Group = {
+  id: string;
+  name: string;
+  slug: string;
+  // クライアントには返さない想定
+  passwordHash?: string;
+};
 export type Member = { userId: string; groupId: string; role: 'admin'|'member' };
 export type Device = {
   id: string; device_uid: string; name: string; category?: string; location?: string;

--- a/web/src/types/bcryptjs.d.ts
+++ b/web/src/types/bcryptjs.d.ts
@@ -1,0 +1,12 @@
+declare module "bcryptjs" {
+  export function genSalt(rounds?: number): Promise<string>;
+  export function hash(plain: string, salt: string): Promise<string>;
+  export function compare(plain: string, hash: string): Promise<boolean>;
+  const _default: {
+    genSalt: typeof genSalt;
+    hash: typeof hash;
+    compare: typeof compare;
+  };
+  export default _default;
+}
+


### PR DESCRIPTION
## Summary
- add bcryptjs and extend Group type with password hash
- secure mock DB with password hashing and verify utilities
- require password on group creation and joining via API and forms

## Testing
- `pnpm lint` *(fails: request to fetch pnpm due to network restriction)*
- `pnpm typecheck` *(fails: request to fetch pnpm due to network restriction)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c315980883238cdbd1e74f4b2490