### PR TITLE
Handle missing group and slug validation

### DIFF
--- a/web/src/app/api/mock/groups/[slug]/route.ts
+++ b/web/src/app/api/mock/groups/[slug]/route.ts
@@ -1,7 +1,20 @@
-import { NextRequest, NextResponse } from "next/server";
-import { groups, devices, publicizeGroup } from "@/lib/mock-db";
-export async function GET(_: NextRequest, { params:{slug} }: any) {
-  const g = groups.find(x=>x.slug===slug);
-  if(!g) return NextResponse.json({error:"not found"}, {status:404});
-  return NextResponse.json({ group: publicizeGroup(g), devices: devices.filter(d=>d.groupId===g.id) });
+import { NextResponse } from "next/server";
+import {
+  getGroupByNameOrSlug,
+  publicizeGroup,
+  devices,
+} from "@/lib/mock-db";
+
+export async function GET(
+  _req: Request,
+  { params: { slug } }: { params: { slug: string } }
+) {
+  const g = getGroupByNameOrSlug(slug);
+  if (!g) {
+    return NextResponse.json({ error: "Group not found" }, { status: 404 });
+  }
+  return NextResponse.json({
+    group: publicizeGroup(g),
+    devices: devices.filter((d) => d.groupId === g.id),
+  });
 }

--- a/web/src/app/groups/[slug]/calendar/page.tsx
+++ b/web/src/app/groups/[slug]/calendar/page.tsx
@@ -1,3 +1,4 @@
+import { notFound } from "next/navigation";
 import { getGroup, getReservations } from "@/lib/api";
 import { devices } from "@/lib/mock-db"; // 本番はAPI化
 import BadgeUsage from "@/components/BadgeUsage";
@@ -7,7 +8,10 @@ export default async function GroupCalendar({
 }: {
   params: { slug: string };
 }) {
-  const { group } = await getGroup(slug);
+  const data = await getGroup(slug).catch(() => null);
+  const group = data?.group;
+  if (!group) return notFound();
+
   const devs = devices.filter((d) => d.groupId === group.id);
   const from = new Date();
   from.setHours(0, 0, 0, 0);

--- a/web/src/app/groups/new/page.tsx
+++ b/web/src/app/groups/new/page.tsx
@@ -1,7 +1,15 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+
+function toSlug(input: string) {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^\p{Letter}\p{Number}]+/gu, "-")
+    .replace(/^-+|-+$/g, "");
+}
 
 export default function GroupNewPage() {
   const [name, setName] = useState("");
@@ -10,13 +18,22 @@ export default function GroupNewPage() {
   const [err, setErr] = useState<string | null>(null);
   const router = useRouter();
 
+  useEffect(() => {
+    if (!slug) setSlug(toSlug(name));
+  }, [name]); // eslint-disable-line react-hooks/exhaustive-deps
+
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
     setErr(null);
+    const safeSlug = toSlug(slug || name);
+    if (!safeSlug) {
+      setErr("slug を半角英数字で入力してください（名称から自動生成されます）");
+      return;
+    }
     const res = await fetch("/api/mock/groups", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name, slug, password }),
+      body: JSON.stringify({ name, slug: safeSlug, password }),
     });
     const data = await res.json();
     if (!res.ok) {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -6,7 +6,14 @@ const abs = (p: string) => new URL(p, BASE).toString();
 
 export const getDevices = async () => (await fetch(abs("/api/devices"), { cache:"no-store" })).json();
 export const getGroups  = async () => (await fetch(abs("/api/mock/groups"), { cache:"no-store" })).json();
-export const getGroup   = async (slug:string) => (await fetch(abs(`/api/mock/groups/${slug}`),{cache:"no-store"})).json();
+export const getGroup = async (slug: string) => {
+  const res = await fetch(
+    abs(`/api/mock/groups/${encodeURIComponent(slug)}`),
+    { cache: "no-store" }
+  );
+  if (!res.ok) throw new Error("group not found");
+  return res.json();
+};
 export const getReservations = async (q:{groupId?:string, deviceId?:string, from?:string, to?:string}) => {
   const params = new URLSearchParams(q as any).toString();
   return (await fetch(abs(`/api/mock/reservations?${params}`), { cache:"no-store" })).json();


### PR DESCRIPTION
## Summary
- avoid crashing calendar view by returning 404 when group is missing
- return proper 404 from group lookup API
- auto-generate and validate slugs in group creation form
- harden `getGroup` API helper with encoding and error handling

## Testing
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/no-var-requires' was not found)*
- `npm run typecheck` *(fails: TS2345/TS2339 in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c72072b4832387a53b86fda0502f