### PR TITLE
Add mock API persistence and improve form accessibility

### DIFF
--- a/web/src/app/api/mock/devices/route.ts
+++ b/web/src/app/api/mock/devices/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { devices, groups } from "@/lib/mock-db";
+import { devices, groups, save } from "@/lib/mock-db";
+import type { Device } from "@/lib/types";
 
 export async function POST(req: NextRequest) {
   const p = await req.json();
   const g = groups.find((x) => x.slug === p.groupSlug || x.id === p.groupId);
   if (!g) return NextResponse.json({ error: 'group not found' }, { status: 404 });
-  const device = {
+  const device: Device = {
     id: crypto.randomUUID(),
     device_uid: p.device_uid ?? `DEV-${Math.random().toString(36).slice(2,8)}`,
     name: p.name,
@@ -16,5 +17,13 @@ export async function POST(req: NextRequest) {
     groupId: g.id,
   };
   devices.push(device);
+  save();
   return NextResponse.json({ device }, { status: 201 });
+}
+
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const groupId = url.searchParams.get("groupId");
+  const list = groupId ? devices.filter((d) => d.groupId === groupId) : devices;
+  return NextResponse.json({ devices: list });
 }

--- a/web/src/app/api/mock/negotiations/[id]/route.ts
+++ b/web/src/app/api/mock/negotiations/[id]/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { negotiations } from "@/lib/mock-db";
+import { negotiations, save } from "@/lib/mock-db";
 
 export async function PATCH(req: NextRequest, { params:{id} }:{ params:{ id:string } }) {
   const p = await req.json();
   const rec = negotiations.find(n=>n.id===id);
   if(!rec) return NextResponse.json({ error:'not found' }, { status:404 });
   if(p.status) rec.status = p.status;
+  save();
   return NextResponse.json({ negotiation: rec });
 }

--- a/web/src/app/api/mock/negotiations/route.ts
+++ b/web/src/app/api/mock/negotiations/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { negotiations } from "@/lib/mock-db";
+import { negotiations, save } from "@/lib/mock-db";
+import type { Negotiation } from "@/lib/types";
 
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);
@@ -11,7 +12,7 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   const p = await req.json();
-  const rec = {
+  const rec: Negotiation = {
     id: crypto.randomUUID(),
     deviceId: p.deviceId,
     requesterName: p.requesterName,
@@ -21,5 +22,6 @@ export async function POST(req: NextRequest) {
     createdAt: new Date().toISOString(),
   };
   negotiations.unshift(rec);
+  save();
   return NextResponse.json({ negotiation: rec }, { status: 201 });
 }

--- a/web/src/app/api/mock/reservations/route.ts
+++ b/web/src/app/api/mock/reservations/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { reservations } from "@/lib/mock-db";
+import { reservations, save } from "@/lib/mock-db";
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);
   const deviceId = url.searchParams.get("deviceId");
@@ -21,5 +21,6 @@ export async function POST(req: NextRequest) {
   if(overlap) return NextResponse.json({error:"その時間帯は予約済みです"}, {status:409});
   const rec = { id: crypto.randomUUID(), status: "confirmed", ...p };
   reservations.unshift(rec);
+  save();
   return NextResponse.json({ ok:true, reservation: rec }, {status:201});
 }

--- a/web/src/app/error.tsx
+++ b/web/src/app/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { useEffect } from "react";
+
+export default function ErrorPage({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+  return (
+    <main className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">エラーが発生しました</h1>
+      <p className="text-neutral-600">{error.message}</p>
+      <button
+        onClick={reset}
+        className="rounded border px-4 py-2"
+      >
+        再試行
+      </button>
+    </main>
+  );
+}

--- a/web/src/app/groups/[slug]/calendar/page.tsx
+++ b/web/src/app/groups/[slug]/calendar/page.tsx
@@ -46,7 +46,7 @@ export default async function GroupCalendar({
           }}
         >
           {/* ヘッダ行 */}
-          <div className="bg-neutral-50 border-b p-2 font-medium">時間</div>
+          <div className="bg-neutral-50 border-b border-r p-2 font-medium">時間</div>
           {devs.map((d) => (
             <div key={d.id} className="bg-neutral-50 border-b p-2 font-medium">
               {d.name}

--- a/web/src/app/groups/[slug]/devices/new/page.tsx
+++ b/web/src/app/groups/[slug]/devices/new/page.tsx
@@ -5,7 +5,7 @@ import Button from '@/components/ui/Button';
 export default function DeviceNew({ params:{slug} }:{ params:{ slug:string } }) {
   const [name,setName] = useState('');
   const [category,setCategory] = useState('');
-  const [location,setLocation] = useState('');
+  const [place,setPlace] = useState('');
   const [sop,setSop] = useState('1');
 
   const submit = async (e:React.FormEvent)=>{
@@ -13,11 +13,11 @@ export default function DeviceNew({ params:{slug} }:{ params:{ slug:string } }) 
     const r = await fetch('/api/mock/devices',{
       method:'POST',
       headers:{'Content-Type':'application/json'},
-      body: JSON.stringify({ name, category, location, sop_version:sop, groupSlug: slug })
+      body: JSON.stringify({ name, category, location:place, sop_version:sop, groupSlug: slug })
     });
     if(r.ok){
       const { device } = await r.json();
-      location.href = `/devices/${device.device_uid}/poster`;
+      window.location.href = `/devices/${device.device_uid}/poster`;
     } else {
       alert('エラー');
     }
@@ -37,7 +37,7 @@ export default function DeviceNew({ params:{slug} }:{ params:{ slug:string } }) 
         </div>
         <div>
           <label className="block text-sm font-medium mb-1">場所</label>
-          <input value={location} onChange={e=>setLocation(e.target.value)} className="w-full rounded border p-2" />
+          <input value={place} onChange={e=>setPlace(e.target.value)} className="w-full rounded border p-2" />
         </div>
         <div>
           <label className="block text-sm font-medium mb-1">SOPバージョン</label>

--- a/web/src/app/groups/join/page.tsx
+++ b/web/src/app/groups/join/page.tsx
@@ -7,11 +7,13 @@ export default function GroupJoinPage() {
   const [group, setGroup] = useState(""); // name or slug
   const [password, setPassword] = useState("");
   const [err, setErr] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
   const router = useRouter();
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
     setErr(null);
+    setLoading(true);
     const res = await fetch("/api/mock/groups/join", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -20,6 +22,7 @@ export default function GroupJoinPage() {
     const data = await res.json();
     if (!res.ok) {
       setErr(data.error || "参加に失敗しました");
+      setLoading(false);
       return;
     }
     router.push(`/groups/${data.group.slug}/calendar`);
@@ -35,6 +38,8 @@ export default function GroupJoinPage() {
             className="w-full rounded-xl border p-3"
             value={group}
             onChange={(e) => setGroup(e.target.value)}
+            required
+            aria-required="true"
           />
         </label>
         <label className="block">
@@ -44,10 +49,22 @@ export default function GroupJoinPage() {
             className="w-full rounded-xl border p-3"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
+            required
+            aria-required="true"
           />
         </label>
-        {err && <p className="text-red-600 text-sm">{err}</p>}
-        <button className="rounded-xl bg-black text-white px-5 py-2">参加する</button>
+        {err && (
+          <p className="text-red-600 text-sm" role="alert" aria-live="polite">
+            {err}
+          </p>
+        )}
+        <button
+          className="rounded-xl bg-black text-white px-5 py-2 disabled:opacity-50 disabled:cursor-not-allowed"
+          disabled={loading || !group || !password}
+          aria-disabled={loading || !group || !password}
+        >
+          {loading ? "参加中..." : "参加する"}
+        </button>
       </form>
     </main>
   );

--- a/web/src/app/groups/new/page.tsx
+++ b/web/src/app/groups/new/page.tsx
@@ -16,6 +16,7 @@ export default function GroupNewPage() {
   const [slug, setSlug] = useState("");
   const [password, setPassword] = useState("");
   const [err, setErr] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
   const router = useRouter();
 
   useEffect(() => {
@@ -25,9 +26,11 @@ export default function GroupNewPage() {
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
     setErr(null);
+    setLoading(true);
     const safeSlug = toSlug(slug || name);
     if (!safeSlug) {
       setErr("slug を半角英数字で入力してください（名称から自動生成されます）");
+      setLoading(false);
       return;
     }
     const res = await fetch("/api/mock/groups", {
@@ -38,6 +41,7 @@ export default function GroupNewPage() {
     const data = await res.json();
     if (!res.ok) {
       setErr(data.error || "作成に失敗しました");
+      setLoading(false);
       return;
     }
     router.push(`/groups/${data.group.slug}/calendar`);
@@ -53,6 +57,8 @@ export default function GroupNewPage() {
             className="w-full rounded-xl border p-3"
             value={name}
             onChange={(e) => setName(e.target.value)}
+            required
+            aria-required="true"
           />
         </label>
         <label className="block">
@@ -61,6 +67,8 @@ export default function GroupNewPage() {
             className="w-full rounded-xl border p-3"
             value={slug}
             onChange={(e) => setSlug(e.target.value)}
+            required
+            aria-required="true"
           />
         </label>
         <label className="block">
@@ -70,10 +78,22 @@ export default function GroupNewPage() {
             className="w-full rounded-xl border p-3"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
+            required
+            aria-required="true"
           />
         </label>
-        {err && <p className="text-red-600 text-sm">{err}</p>}
-        <button className="rounded-xl bg-black text-white px-5 py-2">作成</button>
+        {err && (
+          <p className="text-red-600 text-sm" role="alert" aria-live="polite">
+            {err}
+          </p>
+        )}
+        <button
+          className="rounded-xl bg-black text-white px-5 py-2 disabled:opacity-50 disabled:cursor-not-allowed"
+          disabled={loading || !name || !slug || !password}
+          aria-disabled={loading || !name || !slug || !password}
+        >
+          {loading ? "作成中..." : "作成"}
+        </button>
       </form>
     </main>
   );

--- a/web/src/app/not-found.tsx
+++ b/web/src/app/not-found.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">ページが見つかりません</h1>
+      <p className="text-neutral-600">お探しのページは存在しないか、移動した可能性があります。</p>
+      <Link href="/" className="text-blue-600 hover:underline">
+        トップへ戻る
+      </Link>
+    </main>
+  );
+}

--- a/web/src/components/DevicePoster.tsx
+++ b/web/src/components/DevicePoster.tsx
@@ -1,4 +1,4 @@
-// eslint-disable-next-line import/no-unresolved, @typescript-eslint/no-var-requires
+// eslint-disable-next-line import/no-unresolved
 const { QRCodeCanvas } = require('qrcode.react');
 
 export default function DevicePoster({ device }: { device: any }) {

--- a/web/src/components/NegotiationList.tsx
+++ b/web/src/components/NegotiationList.tsx
@@ -23,8 +23,24 @@ export default function NegotiationList({ deviceId, initialNegotiations }:{ devi
   return (
     <div className="space-y-4">
       <form onSubmit={submit} className="space-y-2">
-        <input value={name} onChange={e=>setName(e.target.value)} placeholder="名前" className="w-full rounded border p-2" required />
-        <textarea value={msg} onChange={e=>setMsg(e.target.value)} placeholder="メッセージ" className="w-full rounded border p-2" required />
+        <input
+          value={name}
+          onChange={e=>setName(e.target.value)}
+          placeholder="名前"
+          aria-label="名前"
+          className="w-full rounded border p-2"
+          required
+          aria-required="true"
+        />
+        <textarea
+          value={msg}
+          onChange={e=>setMsg(e.target.value)}
+          placeholder="メッセージ"
+          aria-label="メッセージ"
+          className="w-full rounded border p-2"
+          required
+          aria-required="true"
+        />
         <Button type="submit" variant="primary">送信</Button>
       </form>
       <ul className="space-y-2">

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -4,7 +4,7 @@ export default function Button(
   {children, className, variant='outline', ...props}:
   React.ButtonHTMLAttributes<HTMLButtonElement> & {variant?:'primary'|'outline'|'danger'}
 ){
-  const base="inline-flex items-center justify-center rounded-2xl px-4 py-2 text-sm transition";
+  const base="inline-flex items-center justify-center rounded-2xl px-4 py-2 text-sm transition disabled:opacity-50 disabled:cursor-not-allowed";
   const styles={
     primary:"bg-neutral-900 text-white hover:bg-neutral-800",
     outline:"border hover:-translate-y-0.5 shadow-sm",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -4,30 +4,54 @@ const BASE =
   "http://localhost:3000";
 const abs = (p: string) => new URL(p, BASE).toString();
 
-export const getDevices = async () => (await fetch(abs("/api/devices"), { cache:"no-store" })).json();
-export const getGroups  = async () => (await fetch(abs("/api/mock/groups"), { cache:"no-store" })).json();
+export const listDevices = async (groupId?: string) => {
+  const params = groupId ? `?groupId=${encodeURIComponent(groupId)}` : "";
+  const res = await fetch(abs(`/api/mock/devices${params}`), { cache: "no-store" });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+};
+export const getDevices = listDevices;
+
+export const getGroups = async () => {
+  const res = await fetch(abs("/api/mock/groups"), { cache: "no-store" });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+};
 export const getGroup = async (slug: string) => {
   const res = await fetch(
     abs(`/api/mock/groups/${encodeURIComponent(slug)}`),
     { cache: "no-store" }
   );
-  if (!res.ok) throw new Error("group not found");
+  if (!res.ok) throw new Error(await res.text());
   return res.json();
 };
-export const getReservations = async (q:{groupId?:string, deviceId?:string, from?:string, to?:string}) => {
+export const listReservations = async (q: {
+  groupId?: string;
+  deviceId?: string;
+  from?: string;
+  to?: string;
+}) => {
   const params = new URLSearchParams(q as any).toString();
-  return (await fetch(abs(`/api/mock/reservations?${params}`), { cache:"no-store" })).json();
-};
-export const createReservation = async (payload:any) => {
-  const r = await fetch(abs("/api/mock/reservations"), {
-    method:"POST", headers:{ "Content-Type":"application/json" }, body: JSON.stringify(payload)
+  const res = await fetch(abs(`/api/mock/reservations?${params}`), {
+    cache: "no-store",
   });
-  if(!r.ok) throw await r.json();
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+};
+export const getReservations = listReservations;
+
+export const createReservation = async (payload: any) => {
+  const r = await fetch(abs("/api/mock/reservations"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!r.ok) throw new Error(await r.text());
   return r.json();
 };
 
 export const getDevice = async (uid: string) => {
-  const { devices } = await getDevices();
+  const { devices } = await listDevices();
   return devices.find((d: any) => d.device_uid === uid);
 };
 
@@ -41,7 +65,7 @@ export const createGroup = async (payload: {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
   });
-  if (!r.ok) throw await r.json();
+  if (!r.ok) throw new Error(await r.text());
   return r.json();
 };
 
@@ -51,7 +75,7 @@ export const joinGroup = async (payload: { group: string; password: string }) =>
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
   });
-  if (!r.ok) throw await r.json();
+  if (!r.ok) throw new Error(await r.text());
   return r.json();
 };
 
@@ -61,13 +85,17 @@ export const createDevice = async (payload: any) => {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
   });
-  if (!r.ok) throw await r.json();
+  if (!r.ok) throw new Error(await r.text());
   return r.json();
 };
 
 export const getNegotiations = async (deviceId: string) => {
   const params = new URLSearchParams({ deviceId }).toString();
-  return (await fetch(abs(`/api/mock/negotiations?${params}`), { cache: 'no-store' })).json();
+  const res = await fetch(abs(`/api/mock/negotiations?${params}`), {
+    cache: 'no-store',
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
 };
 
 export const createNegotiation = async (payload: any) => {
@@ -76,7 +104,7 @@ export const createNegotiation = async (payload: any) => {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
   });
-  if (!r.ok) throw await r.json();
+  if (!r.ok) throw new Error(await r.text());
   return r.json();
 };
 
@@ -86,6 +114,6 @@ export const updateNegotiation = async (id: string, status: string) => {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ status }),
   });
-  if (!r.ok) throw await r.json();
+  if (!r.ok) throw new Error(await r.text());
   return r.json();
 };

--- a/web/src/lib/mock-db.ts
+++ b/web/src/lib/mock-db.ts
@@ -110,6 +110,7 @@ export async function createGroup(input: {
     passwordHash,
   };
   mockDB.groups.push(group);
+  save();
   return group;
 }
 
@@ -121,5 +122,34 @@ export async function joinGroup(identifier: string, password: string) {
   const ok = await verifyPassword(g.passwordHash, password);
   if (!ok) throw new Error("パスワードが違います");
   return g;
+}
+
+const isBrowser = typeof window !== "undefined";
+const KEY = "lab-yoyaku-mock-db";
+
+export function save() {
+  if (!isBrowser || process.env.NODE_ENV !== "development") return;
+  try {
+    localStorage.setItem(KEY, JSON.stringify(mockDB));
+  } catch {
+    // ignore
+  }
+}
+
+export function load() {
+  if (!isBrowser || process.env.NODE_ENV !== "development") return;
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (raw) {
+      const data = JSON.parse(raw);
+      Object.assign(mockDB, data);
+    }
+  } catch {
+    // ignore
+  }
+}
+
+if (isBrowser && process.env.NODE_ENV === "development") {
+  load();
 }
 


### PR DESCRIPTION
## Summary
- persist mock database to localStorage and expose device listing API
- enhance API helpers with better error handling
- add accessible group forms and global error pages

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a2ccc93cf483239c63a60ca2dcdde0