### PR TITLE
Fix group detail API usage and add error handling

### DIFF
--- a/web/src/app/api/mock/groups/[slug]/route.ts
+++ b/web/src/app/api/mock/groups/[slug]/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from 'next/server';
-import { findGroupBySlug, findMembers, findDevices } from '@/lib/mock-db';
+import {
+  findGroupBySlug,
+  findMembers,
+  findDevices,
+  insertMember,
+} from '@/lib/mock-db';
 
 const publicGroup = (g: any) => {
   const { passwordHash, ...rest } = g;
@@ -13,6 +18,34 @@ export async function GET(
   const group = findGroupBySlug(slug);
   if (!group)
     return NextResponse.json({ ok: false, error: 'not found' }, { status: 404 });
+  const members = findMembers(group.id);
+  const devices = findDevices(group.id);
+  return NextResponse.json({
+    ok: true,
+    data: {
+      ...publicGroup(group),
+      members,
+      devices,
+      counts: { members: members.length, devices: devices.length },
+    },
+  });
+}
+
+export async function POST(
+  req: Request,
+  { params: { slug } }: { params: { slug: string } }
+) {
+  const group = findGroupBySlug(slug);
+  if (!group)
+    return NextResponse.json({ ok: false, error: 'not found' }, { status: 404 });
+
+  const body = await req.json().catch(() => ({}));
+  if (body?.action === 'join' && body?.member) {
+    const members = findMembers(group.id);
+    if (!members.some(m => m.id === body.member || m.displayName === body.member)) {
+      insertMember({ groupId: group.id, displayName: body.member, role: 'member' });
+    }
+  }
   const members = findMembers(group.id);
   const devices = findDevices(group.id);
   return NextResponse.json({

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -1,18 +1,42 @@
-import { getGroup } from '@/lib/api';
+import { api } from '@/lib/api';
+import ErrorView from '@/components/ErrorView';
+import type { Group, Member, Device } from '@/lib/types';
 
 export default async function GroupDetail({ params: { slug } }: { params: { slug: string } }) {
-  const g = await getGroup(slug);
-  return (
-    <main className="space-y-4">
-      <h1 className="text-2xl font-bold">{g.name}</h1>
-      <div>
-        <h2 className="text-lg font-semibold mt-4">機器</h2>
-        <ul className="list-disc pl-5 space-y-1">
-          {g.devices.map((d: any) => (
-            <li key={d.id}>{d.name}</li>
-          ))}
-        </ul>
-      </div>
-    </main>
-  );
+  try {
+    const g = await api<
+      Group & {
+        members: Member[];
+        devices: Device[];
+        counts: { members: number; devices: number };
+      }
+    >(`/api/mock/groups/${slug}`);
+    return (
+      <main className="space-y-4">
+        <h1 className="text-2xl font-bold">{g.name}</h1>
+        <div>
+          <h2 className="text-lg font-semibold mt-4">機器</h2>
+          <ul className="list-disc pl-5 space-y-1">
+            {g.devices.map((d: any) => (
+              <li key={d.id}>{d.name}</li>
+            ))}
+          </ul>
+        </div>
+      </main>
+    );
+  } catch (e: any) {
+    const msg = (e?.message ?? '') as string;
+    const isNotFound = /API 404/.test(msg) || /not found/.test(msg);
+    return (
+      <ErrorView
+        title="エラーが発生しました"
+        detail={
+          isNotFound
+            ? `グループ ${slug} が見つかりません。作成/参加が成功しているか、LocalStorageの初期化をご確認ください。`
+            : msg
+        }
+        retryHref="/groups"
+      />
+    );
+  }
 }

--- a/web/src/components/ErrorView.tsx
+++ b/web/src/components/ErrorView.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+export default function ErrorView({
+  title,
+  detail,
+  retryHref,
+}: {
+  title: string;
+  detail?: string;
+  retryHref?: string;
+}) {
+  return (
+    <main className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">{title}</h1>
+      {detail && <p className="text-neutral-600">{detail}</p>}
+      {retryHref && (
+        <Link
+          href={retryHref}
+          className="inline-block rounded border px-4 py-2 hover:bg-neutral-50"
+        >
+          戻る
+        </Link>
+      )}
+    </main>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -20,7 +20,8 @@ const API_BASE =
     : (process.env.NEXT_PUBLIC_API_URL ?? '').replace(/\/$/, '');
 
 export async function api<T>(path: string, init?: RequestInit): Promise<T> {
-  const url = buildUrl(`${API_BASE}${path}`);
+  const fullPath = path.startsWith('/api/') ? path : `${API_BASE}${path}`;
+  const url = buildUrl(fullPath);
   const res = await fetch(url, {
     cache: 'no-store',
     ...init,


### PR DESCRIPTION
## Summary
- Allow api helper to accept absolute paths
- Fetch group details via mock API and show friendly errors
- Support group joins through slug-based POST endpoint

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a53b270f548323ab962bb471c7a37b