### PR TITLE
Use explicit mock endpoint for group join

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -48,8 +48,9 @@ export const getGroup = (slug: string) =>
 export const createGroup = (p: { name: string; slug: string; password: string }) =>
   api<Group>('/groups', { method: 'POST', body: JSON.stringify(p) });
 export const joinGroup = (p: { identifier: string; password: string }) =>
-  api<{ group: Group; member: Member }>('/groups/join', {
+  api<{ group: Group; member: Member }>('/api/mock/groups/join', {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(p),
   });
 


### PR DESCRIPTION
## Summary
- point joinGroup requests to `/api/mock/groups/join`
- include JSON content-type header for joinGroup API call

## Testing
- `npx next lint --max-warnings=0`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a5419524b48323bd6c391814c1f2d6