### PR TITLE
refactor: use getGroup in group detail

### DIFF
--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -1,23 +1,17 @@
-import { api } from '@/lib/api';
+import { getGroup } from '@/lib/api';
 import ErrorView from '@/components/ErrorView';
-import type { Group, Member, Device } from '@/lib/types';
+import type { Device } from '@/lib/types';
 
 export default async function GroupDetail({ params: { slug } }: { params: { slug: string } }) {
   try {
-    const g = await api<
-      Group & {
-        members: Member[];
-        devices: Device[];
-        counts: { members: number; devices: number };
-      }
-    >(`/api/mock/groups/${slug}`);
+    const g = await getGroup(slug);
     return (
       <main className="space-y-4">
         <h1 className="text-2xl font-bold">{g.name}</h1>
         <div>
           <h2 className="text-lg font-semibold mt-4">機器</h2>
           <ul className="list-disc pl-5 space-y-1">
-            {g.devices.map((d: any) => (
+            {g.devices.map((d: Device) => (
               <li key={d.id}>{d.name}</li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- use typed `getGroup` helper instead of direct `api` call
- ensure device mapping uses `Device` type

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `pnpm typecheck` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a54196c15c8323b217c69455183362