### PR TITLE
refactor: improve group not found message

### DIFF
--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -32,7 +32,7 @@ export default async function GroupDetail({ params: { slug } }: { params: { slug
         title="エラーが発生しました"
         detail={
           isNotFound
-            ? `グループ ${slug} が見つかりません。作成/参加が成功しているか、LocalStorageの初期化をご確認ください。`
+            ? `グループ ${slug} が見つかりません。作成/参加が成功しているか確認してください。`
             : msg
         }
         retryHref="/groups"


### PR DESCRIPTION
## Summary
- replace LocalStorage-related hint with clearer suggestion when group not found

## Testing
- `pnpm --filter web lint` (fails: Proxy response 403 when HTTP Tunneling)
- `pnpm --filter web typecheck` (fails: Proxy response 403 when HTTP Tunneling)


------
https://chatgpt.com/codex/tasks/task_e_68a54197b4488323b776cab286229ccd