### PR TITLE
Add mock device and reservation APIs and UI

### DIFF
--- a/web/src/app/api/mock/groups/[slug]/devices/route.ts
+++ b/web/src/app/api/mock/groups/[slug]/devices/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import { loadDB, saveDB, uid } from '@/lib/mockdb';
+
+export async function GET(_req: Request, { params }: { params: { slug: string } }) {
+  const db = loadDB();
+  const g = db.groups.find(x => x.slug === params.slug);
+  if (!g) return NextResponse.json({ ok: false, error: 'not found' }, { status: 404 });
+  return NextResponse.json({ ok: true, data: g.devices });
+}
+
+export async function POST(req: Request, { params }: { params: { slug: string } }) {
+  const body = await req.json().catch(() => ({}));
+  const { name, note } = body ?? {};
+  if (!name) return NextResponse.json({ ok: false, error: 'name required' }, { status: 400 });
+
+  const db = loadDB();
+  const g = db.groups.find(x => x.slug === params.slug);
+  if (!g) return NextResponse.json({ ok: false, error: 'not found' }, { status: 404 });
+
+  const d = { id: uid(), name: String(name).trim(), note: note?.trim?.() } ;
+  g.devices.push(d);
+  saveDB(db);
+  return NextResponse.json({ ok: true, data: d });
+}

--- a/web/src/app/api/mock/groups/[slug]/reservations/route.ts
+++ b/web/src/app/api/mock/groups/[slug]/reservations/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { loadDB, saveDB, uid, overlap } from '@/lib/mockdb';
+
+export async function GET(_req: Request, { params }: { params: { slug: string } }) {
+  const db = loadDB();
+  const g = db.groups.find(x => x.slug === params.slug);
+  if (!g) return NextResponse.json({ ok: false, error: 'not found' }, { status: 404 });
+  return NextResponse.json({ ok: true, data: g.reservations });
+}
+
+export async function POST(req: Request, { params }: { params: { slug: string } }) {
+  const { deviceId, user, start, end, purpose } = await req.json().catch(() => ({}));
+  if (!deviceId || !user || !start || !end) {
+    return NextResponse.json({ ok: false, error: 'missing fields' }, { status: 400 });
+  }
+  const s = new Date(start), e = new Date(end);
+  if (!(s < e)) return NextResponse.json({ ok: false, error: 'invalid range' }, { status: 400 });
+
+  const db = loadDB();
+  const g = db.groups.find(x => x.slug === params.slug);
+  if (!g) return NextResponse.json({ ok: false, error: 'group not found' }, { status: 404 });
+
+  if (!g.members.includes(user)) {
+    return NextResponse.json({ ok: false, error: 'user not in group' }, { status: 403 });
+  }
+  if (!g.devices.find(d => d.id === deviceId)) {
+    return NextResponse.json({ ok: false, error: 'device not found' }, { status: 404 });
+  }
+
+  // 同一デバイスの重複チェック
+  const hasConflict = g.reservations.some(r =>
+    r.deviceId === deviceId && overlap(start, end, r.start, r.end)
+  );
+  if (hasConflict) {
+    return NextResponse.json({ ok: false, error: 'conflict' }, { status: 409 });
+  }
+
+  const r = { id: uid(), deviceId, user, start, end, purpose };
+  g.reservations.push(r);
+  saveDB(db);
+  return NextResponse.json({ ok: true, data: r });
+}

--- a/web/src/app/api/mock/groups/[slug]/route.ts
+++ b/web/src/app/api/mock/groups/[slug]/route.ts
@@ -1,61 +1,26 @@
 import { NextResponse } from 'next/server';
-import {
-  findGroupBySlug,
-  findMembers,
-  findDevices,
-  insertMember,
-} from '@/lib/mock-db';
+import { loadDB, saveDB } from '@/lib/mockdb';
 
-const publicGroup = (g: any) => {
-  const { passwordHash, ...rest } = g;
-  return rest;
-};
-
-export async function GET(
-  _req: Request,
-  { params: { slug } }: { params: { slug: string } }
-) {
-  const group = findGroupBySlug(slug);
-  if (!group)
-    return NextResponse.json({ ok: false, error: 'not found' }, { status: 404 });
-  const members = findMembers(group.id);
-  const devices = findDevices(group.id);
-  return NextResponse.json({
-    ok: true,
-    data: {
-      ...publicGroup(group),
-      members,
-      devices,
-      counts: { members: members.length, devices: devices.length },
-    },
-  });
+export async function GET(_req: Request, { params: { slug } }: { params: { slug: string } }) {
+  const db = loadDB();
+  const g = db.groups.find(x => x.slug === slug);
+  if (!g) return NextResponse.json({ ok: false, error: 'not found' }, { status: 404 });
+  return NextResponse.json({ ok: true, data: g });
 }
 
 export async function POST(
   req: Request,
   { params: { slug } }: { params: { slug: string } }
 ) {
-  const group = findGroupBySlug(slug);
-  if (!group)
-    return NextResponse.json({ ok: false, error: 'not found' }, { status: 404 });
+  const db = loadDB();
+  const g = db.groups.find(x => x.slug === slug);
+  if (!g) return NextResponse.json({ ok: false, error: 'not found' }, { status: 404 });
 
   const body = await req.json().catch(() => ({}));
   if (body?.action === 'join' && body?.member) {
-    const members = findMembers(group.id);
-    if (!members.some(m => m.id === body.member || m.displayName === body.member)) {
-      insertMember({ groupId: group.id, displayName: body.member, role: 'member' });
-    }
+    const m = String(body.member);
+    if (!g.members.includes(m)) g.members.push(m);
   }
-  const members = findMembers(group.id);
-  const devices = findDevices(group.id);
-  return NextResponse.json({
-    ok: true,
-    data: {
-      ...publicGroup(group),
-      members,
-      devices,
-      counts: { members: members.length, devices: devices.length },
-    },
-  });
+  saveDB(db);
+  return NextResponse.json({ ok: true, data: g });
 }
-

--- a/web/src/app/api/mock/groups/route.ts
+++ b/web/src/app/api/mock/groups/route.ts
@@ -1,27 +1,37 @@
 import { NextResponse } from 'next/server';
-import { mockDB, insertGroup } from '@/lib/mock-db';
+import { loadDB, saveDB } from '@/lib/mockdb';
 
 const publicGroup = (g: any) => {
-  const { passwordHash, ...rest } = g;
+  const { password, ...rest } = g;
   return rest;
 };
 
 export async function GET() {
-  return NextResponse.json({ ok: true, data: mockDB.groups.map(publicGroup) });
+  const db = loadDB();
+  return NextResponse.json({ ok: true, data: db.groups.map(publicGroup) });
 }
 
 export async function POST(req: Request) {
-  const { name, slug, password } = await req.json();
-  if (!name || !slug || !password)
+  const { name, slug, password } = await req.json().catch(() => ({}));
+  if (!name || !slug) {
     return NextResponse.json(
-      { ok: false, error: 'name, slug, password are required' },
+      { ok: false, error: 'name and slug are required' },
       { status: 400 }
     );
-  try {
-    const group = await insertGroup({ name, slug, password });
-    return NextResponse.json({ ok: true, data: publicGroup(group) }, { status: 201 });
-  } catch (e: any) {
-    return NextResponse.json({ ok: false, error: e.message }, { status: 400 });
   }
+  const db = loadDB();
+  if (db.groups.some(g => g.slug === slug)) {
+    return NextResponse.json({ ok: false, error: 'slug exists' }, { status: 400 });
+  }
+  const group = {
+    slug: String(slug).trim(),
+    name: String(name).trim(),
+    password: password ? String(password) : undefined,
+    members: [],
+    devices: [],
+    reservations: [],
+  };
+  db.groups.push(group);
+  saveDB(db);
+  return NextResponse.json({ ok: true, data: publicGroup(group) }, { status: 201 });
 }
-

--- a/web/src/app/groups/[slug]/components.tsx
+++ b/web/src/app/groups/[slug]/components.tsx
@@ -1,0 +1,135 @@
+'use client';
+import { useEffect, useMemo, useState } from 'react';
+import { api } from '@/lib/api';
+
+export function DevicesSection({ slug }: { slug: string }) {
+  const [list, setList] = useState<any[]>([]);
+  const [name, setName] = useState('');
+  const [note, setNote] = useState('');
+  const [err, setErr] = useState('');
+
+  async function load() {
+    const d = await api(`/api/mock/groups/${slug}/devices`);
+    setList(d);
+  }
+  useEffect(() => { load(); }, [slug]);
+
+  async function addDevice(e: React.FormEvent) {
+    e.preventDefault();
+    setErr('');
+    try {
+      await api(`/api/mock/groups/${slug}/devices`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: name.trim(), note }),
+      });
+      setName(''); setNote('');
+      load();
+    } catch (e: any) { setErr(e?.message ?? '保存に失敗しました'); }
+  }
+
+  return (
+    <section>
+      <h2 className="text-xl font-semibold mb-3">機器</h2>
+      <ul className="mb-4 space-y-2">
+        {list.map(d => (
+          <li key={d.id} className="rounded border p-3">
+            <div className="font-medium">{d.name}</div>
+            {d.note && <div className="text-sm text-gray-500">{d.note}</div>}
+            <div className="text-xs text-gray-400">ID: {d.id}</div>
+          </li>
+        ))}
+        {!list.length && <div className="text-gray-500">まだ登録がありません。</div>}
+      </ul>
+
+      <form onSubmit={addDevice} className="space-y-2 max-w-md">
+        <div className="font-medium">機器を登録</div>
+        <input className="w-full rounded border px-3 py-2" placeholder="例：蛍光測定器"
+               value={name} onChange={e=>setName(e.target.value)} required />
+        <input className="w-full rounded border px-3 py-2" placeholder="備考（任意）"
+               value={note} onChange={e=>setNote(e.target.value)} />
+        {err && <div className="text-sm text-red-600">{err}</div>}
+        <button className="rounded bg-black text-white px-4 py-2">追加</button>
+      </form>
+    </section>
+  );
+}
+
+export function ReservationsSection({ slug, members }:{ slug:string; members:string[] }) {
+  const [devices, setDevices] = useState<any[]>([]);
+  const [rows, setRows] = useState<any[]>([]);
+  const [err, setErr] = useState('');
+
+  const [deviceId, setDeviceId] = useState('');
+  const [user, setUser] = useState(members[0] ?? '');
+  const [start, setStart] = useState('');
+  const [end, setEnd] = useState('');
+  const [purpose, setPurpose] = useState('');
+
+  async function load() {
+    const [d, r] = await Promise.all([
+      api(`/api/mock/groups/${slug}/devices`),
+      api(`/api/mock/groups/${slug}/reservations`),
+    ]);
+    setDevices(d); setRows(r);
+    if (!deviceId && d[0]) setDeviceId(d[0].id);
+  }
+  useEffect(() => { load(); /* eslint-disable-next-line */ }, [slug]);
+
+  async function createReservation(e: React.FormEvent) {
+    e.preventDefault();
+    setErr('');
+    try {
+      await api(`/api/mock/groups/${slug}/reservations`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deviceId, user, start, end, purpose }),
+      });
+      setPurpose(''); setStart(''); setEnd('');
+      load();
+    } catch (e: any) { setErr(e?.message ?? '予約に失敗しました'); }
+  }
+
+  const rowsSorted = useMemo(
+    () => [...rows].sort((a,b)=> new Date(a.start).getTime() - new Date(b.start).getTime()),
+    [rows]
+  );
+
+  return (
+    <section>
+      <h2 className="text-xl font-semibold mb-3">予約</h2>
+
+      <form onSubmit={createReservation} className="grid gap-2 md:grid-cols-2 max-w-3xl mb-5">
+        <select className="rounded border px-3 py-2" value={deviceId} onChange={e=>setDeviceId(e.target.value)} required>
+          {devices.map(d => <option key={d.id} value={d.id}>{d.name}</option>)}
+        </select>
+        <select className="rounded border px-3 py-2" value={user} onChange={e=>setUser(e.target.value)} required>
+          {members.map(m => <option key={m} value={m}>{m}</option>)}
+        </select>
+        <input type="datetime-local" className="rounded border px-3 py-2" value={start} onChange={e=>setStart(e.target.value)} required />
+        <input type="datetime-local" className="rounded border px-3 py-2" value={end} onChange={e=>setEnd(e.target.value)} required />
+        <input className="md:col-span-2 rounded border px-3 py-2" placeholder="用途（任意）" value={purpose} onChange={e=>setPurpose(e.target.value)} />
+        {err && <div className="md:col-span-2 text-sm text-red-600">{err}</div>}
+        <div className="md:col-span-2">
+          <button className="rounded bg-black text-white px-4 py-2">予約追加</button>
+        </div>
+      </form>
+
+      <div className="space-y-2">
+        {rowsSorted.map(r => {
+          const d = devices.find(x => x.id === r.deviceId);
+          return (
+            <div key={r.id} className="rounded border p-3">
+              <div className="font-medium">{d?.name ?? r.deviceId}</div>
+              <div className="text-sm text-gray-600">
+                {new Date(r.start).toLocaleString()} – {new Date(r.end).toLocaleString()} / 利用者: {r.user}
+              </div>
+              {r.purpose && <div className="text-sm text-gray-500">目的: {r.purpose}</div>}
+            </div>
+          );
+        })}
+        {!rowsSorted.length && <div className="text-gray-500">まだ予約がありません。</div>}
+      </div>
+    </section>
+  );
+}

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -1,36 +1,25 @@
-import { getGroup } from '@/lib/api';
-import ErrorView from '@/components/ErrorView';
-import type { Device } from '@/lib/types';
+import { api } from '@/lib/api';
+import { DevicesSection, ReservationsSection } from './components';
 
-export default async function GroupDetail({ params: { slug } }: { params: { slug: string } }) {
-  try {
-    const g = await getGroup(slug);
-    return (
-      <main className="space-y-4">
-        <h1 className="text-2xl font-bold">{g.name}</h1>
-        <div>
-          <h2 className="text-lg font-semibold mt-4">機器</h2>
-          <ul className="list-disc pl-5 space-y-1">
-            {g.devices.map((d: Device) => (
-              <li key={d.id}>{d.name}</li>
-            ))}
-          </ul>
-        </div>
-      </main>
-    );
-  } catch (e: any) {
-    const msg = (e?.message ?? '') as string;
-    const isNotFound = /API 404/.test(msg) || /not found/.test(msg);
-    return (
-      <ErrorView
-        title="エラーが発生しました"
-        detail={
-          isNotFound
-            ? `グループ ${slug} が見つかりません。作成/参加が成功しているか確認してください。`
-            : msg
-        }
-        retryHref="/groups"
-      />
-    );
-  }
+export default async function GroupDetail({ params, searchParams }:{
+  params: { slug: string }, searchParams: { [k: string]: string }
+}) {
+  const group = await api(`/api/mock/groups/${params.slug}`);
+  const joined = searchParams?.joined === '1';
+
+  return (
+    <div className="mx-auto max-w-3xl py-8 px-4 space-y-8">
+      {joined && <div className="rounded border bg-green-50 p-3">✅ 参加が完了しました</div>}
+      <header>
+        <h1 className="text-3xl font-bold">{group.name}</h1>
+        <div className="text-sm text-gray-500">slug: <code>{group.slug}</code> / メンバー: {group.members?.length ?? 0}</div>
+      </header>
+
+      {/* 機器エリア */}
+      <DevicesSection slug={group.slug} />
+
+      {/* 予約エリア */}
+      <ReservationsSection slug={group.slug} members={group.members} />
+    </div>
+  );
 }

--- a/web/src/app/groups/page.tsx
+++ b/web/src/app/groups/page.tsx
@@ -8,7 +8,7 @@ export default async function GroupsPage() {
       <h1 className="text-2xl font-bold">グループ一覧</h1>
       <ul className="list-disc pl-5 space-y-1">
         {groups.map((g:any)=>(
-          <li key={g.id}><Link href={`/groups/${g.slug}`} className="text-blue-600 hover:underline">{g.name}</Link></li>
+          <li key={g.slug}><Link href={`/groups/${g.slug}`} className="text-blue-600 hover:underline">{g.name}</Link></li>
         ))}
       </ul>
     </main>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Group, Member, Device, Reservation } from './types';
+import type { Device, Reservation } from './types';
 
 function getBaseUrl() {
   const env = process.env.NEXT_PUBLIC_BASE_URL?.trim();
@@ -36,19 +36,12 @@ export async function api<T>(path: string, init?: RequestInit): Promise<T> {
 }
 
 // Groups
-export const listGroups = () => api<Group[]>('/groups');
-export const getGroup = (slug: string) =>
-  api<
-    Group & {
-      members: Member[];
-      devices: Device[];
-      counts: { members: number; devices: number };
-    }
-  >(`/groups/${slug}`);
-export const createGroup = (p: { name: string; slug: string; password: string }) =>
-  api<Group>('/groups', { method: 'POST', body: JSON.stringify(p) });
+export const listGroups = () => api<any[]>('/groups');
+export const getGroup = (slug: string) => api<any>(`/groups/${slug}`);
+export const createGroup = (p: { name: string; slug: string; password?: string }) =>
+  api<any>('/groups', { method: 'POST', body: JSON.stringify(p) });
 export const joinGroup = (p: { identifier: string; password: string }) =>
-  api<{ group: Group; member: Member }>('/api/mock/groups/join', {
+  api<any>('/api/mock/groups/join', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(p),
@@ -70,4 +63,3 @@ export const listReservations = (q: {
 }) => api<Reservation[]>(`/reservations?${new URLSearchParams(q as any)}`);
 export const createReservation = (p: Omit<Reservation, 'id'>) =>
   api<Reservation>('/reservations', { method: 'POST', body: JSON.stringify(p) });
-

--- a/web/src/lib/mockdb.ts
+++ b/web/src/lib/mockdb.ts
@@ -1,0 +1,43 @@
+export type MemberId = string;
+
+export type Device = {
+  id: string;
+  name: string;
+  note?: string;
+};
+
+export type Reservation = {
+  id: string;
+  deviceId: string;
+  user: MemberId;       // 誰が使うか
+  start: string;        // ISO文字列
+  end: string;          // ISO文字列
+  purpose?: string;
+};
+
+export type Group = {
+  slug: string;
+  name: string;
+  password?: string;
+  members: MemberId[];
+  devices: Device[];
+  reservations: Reservation[];
+};
+
+type DB = { groups: Group[] };
+
+const g = globalThis as any;
+if (!g.__MOCK_DB__) g.__MOCK_DB__ = { groups: [] } as DB;
+
+export function loadDB(): DB {
+  return g.__MOCK_DB__ as DB;
+}
+export function saveDB(_db: DB) { /* メモリなのでnoop */ }
+
+export const uid = () =>
+  'id_' + Math.random().toString(36).slice(2, 8) + Date.now().toString(36);
+
+// 予約の重複判定
+export function overlap(aStart: string, aEnd: string, bStart: string, bEnd: string) {
+  return new Date(aStart) < new Date(bEnd) && new Date(bStart) < new Date(aEnd);
+}


### PR DESCRIPTION
## Summary
- add in-memory mock DB storing devices and reservations in each group
- expose device and reservation APIs for groups
- expand group detail page with device management and reservation UI

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `pnpm typecheck` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a62d21abc88323b5e1b3c5f30467ff