### PR TITLE
Add device QR code API and mock fields

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "react-dom": "18.2.0",
     "clsx": "^2.1.0",
     "qrcode.react": "^3.1.0",
+    "qrcode": "^1.5.3",
     "bcryptjs": "^2.4.3"
   },
   "devDependencies": {

--- a/web/src/app/api/mock/devices/[slug]/qr/route.ts
+++ b/web/src/app/api/mock/devices/[slug]/qr/route.ts
@@ -1,0 +1,15 @@
+import { db } from '@/lib/mock-db';
+import QRCode from 'qrcode';
+
+export async function GET(_req: Request, { params }: { params: { slug: string } }) {
+  const device = db.groups.flatMap((g) => g.devices).find((d) => d.slug === params.slug);
+  if (!device) {
+    return new Response('device not found', { status: 404 });
+  }
+  const base = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+  const url = `${base}/d/${device.slug}?t=${device.qrToken}`;
+  const png = await QRCode.toBuffer(url, { width: 512, margin: 1 });
+  return new Response(png, {
+    headers: { 'Content-Type': 'image/png' },
+  });
+}

--- a/web/src/app/api/mock/devices/route.ts
+++ b/web/src/app/api/mock/devices/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/mock-db';
 import { uuid } from '@/lib/uuid';
+import { makeSlug } from '@/lib/slug';
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
@@ -13,10 +14,11 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   const body = await req.json();
-  const { slug, name, note } = body;
+  const { slug, name, note, deviceSlug } = body;
   const g = db.groups.find((x) => x.slug === slug);
   if (!g) return NextResponse.json({ ok: false, error: 'group not found' }, { status: 404 });
-  const d = { id: uuid(), name, note };
+  const dSlug = deviceSlug || makeSlug(name);
+  const d = { id: uuid(), slug: dSlug, name, note, qrToken: uuid().replace(/-/g, '') };
   g.devices.push(d);
   return NextResponse.json({ ok: true, data: d });
 }

--- a/web/src/lib/mock-db.ts
+++ b/web/src/lib/mock-db.ts
@@ -5,7 +5,7 @@ export type DB = {
     name: string;
     passwordHash?: string;
     members: Array<{ id: string; name: string; role: 'admin' | 'member' }>;
-    devices: Array<{ id: string; name: string; note?: string }>;
+    devices: Array<{ id: string; slug: string; name: string; note?: string; qrToken: string }>;
     reservations: Array<{
       id: string;
       deviceId: string;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,7 +1,9 @@
 export type Device = {
   id: string;
+  slug: string;
   name: string;
   note?: string;
+  qrToken: string;
 };
 
 export type Reservation = {


### PR DESCRIPTION
## Summary
- add `qrcode` dependency and QR code route for devices
- expand mock DB/types with slug and qrToken
- update device API to generate slugs and qr tokens

## Testing
- `pnpm --filter web lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68aa963ae1f48323bce6388a7fa7ff73