### PR TITLE
Add QR scan redirect and group QR links

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "react-dom": "18.2.0",
     "clsx": "^2.1.0",
     "qrcode.react": "^3.1.0",
+    "qrcode": "^1.5.3",
     "bcryptjs": "^2.4.3"
   },
   "devDependencies": {

--- a/web/src/app/api/mock/devices/[slug]/qr/route.ts
+++ b/web/src/app/api/mock/devices/[slug]/qr/route.ts
@@ -1,0 +1,15 @@
+import { db } from '@/lib/mock-db';
+import QRCode from 'qrcode';
+
+export async function GET(_req: Request, { params }: { params: { slug: string } }) {
+  const device = db.groups.flatMap((g) => g.devices).find((d) => d.slug === params.slug);
+  if (!device) {
+    return new Response('device not found', { status: 404 });
+  }
+  const base = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+  const url = `${base}/d/${device.slug}?t=${device.qrToken}`;
+  const png = await QRCode.toBuffer(url, { width: 512, margin: 1 });
+  return new Response(png, {
+    headers: { 'Content-Type': 'image/png' },
+  });
+}

--- a/web/src/app/api/mock/devices/route.ts
+++ b/web/src/app/api/mock/devices/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/mock-db';
 import { uuid } from '@/lib/uuid';
+import { makeSlug } from '@/lib/slug';
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
@@ -13,10 +14,11 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   const body = await req.json();
-  const { slug, name, note } = body;
+  const { slug, name, note, deviceSlug } = body;
   const g = db.groups.find((x) => x.slug === slug);
   if (!g) return NextResponse.json({ ok: false, error: 'group not found' }, { status: 404 });
-  const d = { id: uuid(), name, note };
+  const dSlug = deviceSlug || makeSlug(name);
+  const d = { id: uuid(), slug: dSlug, name, note, qrToken: uuid().replace(/-/g, '') };
   g.devices.push(d);
   return NextResponse.json({ ok: true, data: d });
 }

--- a/web/src/app/d/[slug]/page.tsx
+++ b/web/src/app/d/[slug]/page.tsx
@@ -1,0 +1,18 @@
+import { db } from '@/lib/mock-db';
+import { notFound, redirect } from 'next/navigation';
+
+export default function DeviceQRPage({
+  params,
+  searchParams,
+}: {
+  params: { slug: string };
+  searchParams: { t?: string };
+}) {
+  const token = searchParams?.t;
+  const group = db.groups.find((g) => g.devices.some((d) => d.slug === params.slug));
+  const device = group?.devices.find((d) => d.slug === params.slug);
+  if (!group || !device || !token || token !== device.qrToken) {
+    notFound();
+  }
+  redirect(`/groups/${group.slug}?device=${device.id}`);
+}

--- a/web/src/app/groups/[slug]/GroupScreenClient.tsx
+++ b/web/src/app/groups/[slug]/GroupScreenClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState, useMemo } from 'react';
-import { useRouter } from 'next/navigation';
+import { useState, useMemo, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import {
   createDevice,
   listDevices,
@@ -31,6 +31,12 @@ export default function GroupScreenClient({
   const [title, setTitle] = useState('');
 
   const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const preselect = searchParams.get('device');
+    if (preselect) setDeviceId(preselect);
+  }, [searchParams]);
 
   const byDate = useMemo(() => {
     const map: Record<string, number> = {};
@@ -81,9 +87,22 @@ export default function GroupScreenClient({
         <h2 className="text-xl font-semibold">機器</h2>
         <ul className="space-y-2">
           {devices.map((d) => (
-            <li key={d.id} className="border rounded p-3">
-              {d.name}
-              <div className="text-xs text-neutral-500">ID: {d.id}</div>
+            <li
+              key={d.id}
+              className="border rounded p-3 flex items-center justify-between"
+            >
+              <div>
+                {d.name}
+                <div className="text-xs text-neutral-500">ID: {d.id}</div>
+              </div>
+              <a
+                href={`/api/mock/devices/${d.slug}/qr`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn-primary"
+              >
+                QRコード
+              </a>
             </li>
           ))}
         </ul>

--- a/web/src/lib/mock-db.ts
+++ b/web/src/lib/mock-db.ts
@@ -5,7 +5,7 @@ export type DB = {
     name: string;
     passwordHash?: string;
     members: Array<{ id: string; name: string; role: 'admin' | 'member' }>;
-    devices: Array<{ id: string; name: string; note?: string }>;
+    devices: Array<{ id: string; slug: string; name: string; note?: string; qrToken: string }>;
     reservations: Array<{
       id: string;
       deviceId: string;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,7 +1,9 @@
 export type Device = {
   id: string;
+  slug: string;
   name: string;
   note?: string;
+  qrToken: string;
 };
 
 export type Reservation = {


### PR DESCRIPTION
## Summary
- redirect QR code scans to group pages after validating tokens
- show QR code links for devices and preselect device from URL

## Testing
- `pnpm --filter web lint` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68aa963ae1f48323bce6388a7fa7ff73