### PR TITLE
feat(web): add JWT session auth and protected group routes

### DIFF
--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { jwtVerify } from 'jose';
+
+const secret = new TextEncoder().encode(process.env.AUTH_SECRET || 'secret');
+const COOKIE = 'session';
+
+async function isValid(token?: string) {
+  if (!token) return false;
+  try {
+    await jwtVerify(token, secret);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+  if (pathname.startsWith('/groups/join')) return NextResponse.next();
+
+  const token = req.cookies.get(COOKIE)?.value;
+  if (!(await isValid(token))) {
+    const url = new URL('/groups/join', req.url);
+    return NextResponse.redirect(url);
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/groups/:path*'],
+};

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,8 @@
     "clsx": "^2.1.0",
     "qrcode.react": "^3.1.0",
     "qrcode": "^1.5.3",
-    "bcryptjs": "^2.4.3"
+    "bcryptjs": "^2.4.3",
+    "jose": "^5.2.2"
   },
   "devDependencies": {
     "@types/react": "18.2.21",

--- a/web/src/app/api/auth/login/route.ts
+++ b/web/src/app/api/auth/login/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/mock-db';
+import { createSession } from '@/lib/auth';
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const { identifier, password } = body;
+  const g = db.groups.find(
+    (x) => x.slug === identifier || x.name === identifier
+  );
+  if (!g)
+    return NextResponse.json({ ok: false, error: 'group not found' }, { status: 404 });
+  if (g.passwordHash && g.passwordHash !== password)
+    return NextResponse.json({ ok: false, error: 'invalid password' }, { status: 403 });
+
+  await createSession({ groupId: g.id, groupSlug: g.slug, groupName: g.name });
+  return NextResponse.json({ ok: true, data: { slug: g.slug, name: g.name } });
+}

--- a/web/src/app/api/auth/logout/route.ts
+++ b/web/src/app/api/auth/logout/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { clearSession } from '@/lib/auth';
+
+export async function POST() {
+  clearSession();
+  return NextResponse.json({ ok: true });
+}

--- a/web/src/app/api/auth/me/route.ts
+++ b/web/src/app/api/auth/me/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth';
+
+export async function GET() {
+  const session = await getSession();
+  if (!session)
+    return NextResponse.json({ ok: false, error: 'unauthenticated' }, { status: 401 });
+  return NextResponse.json({ ok: true, data: session });
+}

--- a/web/src/app/groups/[slug]/GroupScreenClient.tsx
+++ b/web/src/app/groups/[slug]/GroupScreenClient.tsx
@@ -13,10 +13,12 @@ export default function GroupScreenClient({
   initialGroup,
   initialDevices,
   initialReservations,
+  defaultReserver,
 }: {
   initialGroup: any;
   initialDevices: any[];
   initialReservations: any[];
+  defaultReserver?: string;
 }) {
   const [group] = useState(initialGroup);
   const [devices, setDevices] = useState<any[]>(initialDevices);
@@ -25,7 +27,7 @@ export default function GroupScreenClient({
   const [reservations, setReservations] = useState<any[]>(initialReservations);
 
   const [deviceId, setDeviceId] = useState('');
-  const [reserver, setReserver] = useState('');
+  const [reserver, setReserver] = useState(defaultReserver || '');
   const [start, setStart] = useState('');
   const [end, setEnd] = useState('');
   const [title, setTitle] = useState('');

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -1,20 +1,25 @@
 import { getGroup, listDevices, listReservations } from '@/lib/server-api';
 import { notFound } from 'next/navigation';
 import GroupScreenClient from './GroupScreenClient';
+import { getSession } from '@/lib/auth';
 
 export default async function GroupPage({ params }: { params: { slug: string } }) {
   const groupRes = await getGroup(params.slug);
   const group = groupRes.data;
   if (!groupRes.ok || !group) return notFound();
 
-  const devicesRes = await listDevices(group.slug);
-  const reservationsRes = await listReservations(group.slug);
+  const [devicesRes, reservationsRes, session] = await Promise.all([
+    listDevices(group.slug),
+    listReservations(group.slug),
+    getSession(),
+  ]);
 
   return (
     <GroupScreenClient
       initialGroup={group}
       initialDevices={devicesRes.data || []}
       initialReservations={reservationsRes.data || []}
+      defaultReserver={session?.groupName}
     />
   );
 }

--- a/web/src/app/groups/join/page.tsx
+++ b/web/src/app/groups/join/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { joinGroup } from '@/lib/api';
 
 export default function GroupJoinPage() {
   const [group, setGroup] = useState(""); // name or slug
@@ -16,11 +15,15 @@ export default function GroupJoinPage() {
     setErr(null);
     setLoading(true);
     try {
-      const res = await joinGroup({ identifier: group, password });
-      if (res?.ok && res.data) {
-        router.push(`/groups/${res.data.slug}`);
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        body: JSON.stringify({ identifier: group, password }),
+      });
+      const data = await res.json().catch(() => null);
+      if (res.ok && data?.ok && data.data) {
+        router.push(`/groups/${data.data.slug}`);
       } else {
-        throw new Error(res?.error || 'failed');
+        throw new Error(data?.error || 'failed');
       }
     } catch (e: any) {
       setErr(e.message);

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,0 +1,56 @@
+import { SignJWT, jwtVerify } from 'jose';
+import { cookies } from 'next/headers';
+
+const secret = new TextEncoder().encode(process.env.AUTH_SECRET || 'secret');
+export const SESSION_COOKIE_NAME = 'session';
+
+export type Session = {
+  groupId: string;
+  groupSlug: string;
+  groupName: string;
+};
+
+export async function createSession(payload: Session) {
+  const token = await new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime('7d')
+    .sign(secret);
+
+  cookies().set({
+    name: SESSION_COOKIE_NAME,
+    value: token,
+    httpOnly: true,
+    path: '/',
+    maxAge: 60 * 60 * 24 * 7,
+  });
+}
+
+export async function getSession(): Promise<Session | null> {
+  const token = cookies().get(SESSION_COOKIE_NAME)?.value;
+  if (!token) return null;
+  try {
+    const { payload } = await jwtVerify(token, secret);
+    return payload as Session;
+  } catch {
+    return null;
+  }
+}
+
+export function clearSession() {
+  cookies().set({
+    name: SESSION_COOKIE_NAME,
+    value: '',
+    path: '/',
+    maxAge: 0,
+  });
+}
+
+export async function verifyToken(token: string): Promise<Session | null> {
+  try {
+    const { payload } = await jwtVerify(token, secret);
+    return payload as Session;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add `auth.ts` helpers for JWT cookie sessions
- create auth API routes for login/logout/me
- protect group pages with middleware redirecting to join
- redirect join form through new login endpoint and hydrate group pages with session data

## Testing
- `pnpm lint` *(fails: request to pnpm registry blocked)*
- `pnpm typecheck` *(fails: request to pnpm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68aaaa8c421c83238e2677bbec44a62e