### PR TITLE
feat(web): add jose and nanoid dependencies

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,9 @@
     "clsx": "^2.1.0",
     "qrcode.react": "^3.1.0",
     "qrcode": "^1.5.3",
-    "bcryptjs": "^2.4.3"
+    "bcryptjs": "^2.4.3",
+    "jose": "^5.2.0",
+    "nanoid": "^5.0.0"
   },
   "devDependencies": {
     "@types/react": "18.2.21",


### PR DESCRIPTION
## Summary
- add jose and nanoid dependencies to web package

## Testing
- `pnpm install --filter web...` (fails: Proxy response (403) !== 200 when HTTP Tunneling)


------
https://chatgpt.com/codex/tasks/task_e_68aaaa8d70148323b13c3c55a55bb393