### PR TITLE
refactor: centralize API request logic

### DIFF
--- a/web/src/lib/api-core.ts
+++ b/web/src/lib/api-core.ts
@@ -1,0 +1,39 @@
+export function createApi(getBaseURL: () => string) {
+  async function api(path: string, init?: RequestInit) {
+    const base = getBaseURL();
+    const url = `${base}${path}`;
+    const res = await fetch(url, { ...init, cache: 'no-store' });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`API ${res.status} ${path} :: ${text || res.statusText}`);
+    }
+    return res.json();
+  }
+
+  return {
+    listGroups: () => api('/api/mock/groups'),
+    createGroup: (body: any) =>
+      api('/api/mock/groups', { method: 'POST', body: JSON.stringify(body) }),
+    getGroup: (slug: string) => api(`/api/mock/groups/${slug}`),
+    joinGroup: (payload: any) =>
+      api('/api/mock/groups/join', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      }),
+    listDevices: (slug: string) =>
+      api(`/api/mock/devices?slug=${encodeURIComponent(slug)}`),
+    createDevice: (body: any) =>
+      api('/api/mock/devices', { method: 'POST', body: JSON.stringify(body) }),
+    listReservations: (slug: string, deviceId?: string) =>
+      api(
+        `/api/mock/reservations?slug=${encodeURIComponent(slug)}${
+          deviceId ? `&deviceId=${encodeURIComponent(deviceId)}` : ''
+        }`
+      ),
+    createReservation: (body: any) =>
+      api('/api/mock/reservations', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      }),
+  };
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,36 +1,16 @@
+import { createApi } from './api-core';
+
 function getBaseURL() {
   return process.env.NEXT_PUBLIC_API_BASE || '';
 }
 
-async function api(path: string, init?: RequestInit) {
-  const base = getBaseURL();
-  const url = `${base}${path}`;
-  const res = await fetch(url, { ...init, cache: 'no-store' });
-  if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    throw new Error(`API ${res.status} ${path} :: ${text || res.statusText}`);
-  }
-  return res.json();
-}
-
-// 以降のヘルパは全部 api('/api/mock/...') を使う
-export const listGroups = () => api('/api/mock/groups');
-export const createGroup = (body: any) =>
-  api('/api/mock/groups', { method: 'POST', body: JSON.stringify(body) });
-export const getGroup = (slug: string) => api(`/api/mock/groups/${slug}`);
-export const joinGroup = (payload: any) =>
-  api('/api/mock/groups/join', { method: 'POST', body: JSON.stringify(payload) });
-
-export const listDevices = (slug: string) =>
-  api(`/api/mock/devices?slug=${encodeURIComponent(slug)}`);
-export const createDevice = (body: any) =>
-  api('/api/mock/devices', { method: 'POST', body: JSON.stringify(body) });
-
-export const listReservations = (slug: string, deviceId?: string) =>
-  api(
-    `/api/mock/reservations?slug=${encodeURIComponent(slug)}${
-      deviceId ? `&deviceId=${encodeURIComponent(deviceId)}` : ''
-    }`
-  );
-export const createReservation = (body: any) =>
-  api('/api/mock/reservations', { method: 'POST', body: JSON.stringify(body) });
+export const {
+  listGroups,
+  createGroup,
+  getGroup,
+  joinGroup,
+  listDevices,
+  createDevice,
+  listReservations,
+  createReservation,
+} = createApi(getBaseURL);

--- a/web/src/lib/server-api.ts
+++ b/web/src/lib/server-api.ts
@@ -1,4 +1,5 @@
 import { headers } from 'next/headers';
+import { createApi } from './api-core';
 
 function getBaseURL() {
   if (process.env.NEXT_PUBLIC_API_BASE) return process.env.NEXT_PUBLIC_API_BASE;
@@ -9,35 +10,13 @@ function getBaseURL() {
   return `${proto}://${host}`;
 }
 
-async function api(path: string, init?: RequestInit) {
-  const base = getBaseURL();
-  const url = `${base}${path}`;
-  const res = await fetch(url, { ...init, cache: 'no-store' });
-  if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    throw new Error(`API ${res.status} ${path} :: ${text || res.statusText}`);
-  }
-  return res.json();
-}
-
-// 以降のヘルパは全部 api('/api/mock/...') を使う
-export const listGroups = () => api('/api/mock/groups');
-export const createGroup = (body: any) =>
-  api('/api/mock/groups', { method: 'POST', body: JSON.stringify(body) });
-export const getGroup = (slug: string) => api(`/api/mock/groups/${slug}`);
-export const joinGroup = (payload: any) =>
-  api('/api/mock/groups/join', { method: 'POST', body: JSON.stringify(payload) });
-
-export const listDevices = (slug: string) =>
-  api(`/api/mock/devices?slug=${encodeURIComponent(slug)}`);
-export const createDevice = (body: any) =>
-  api('/api/mock/devices', { method: 'POST', body: JSON.stringify(body) });
-
-export const listReservations = (slug: string, deviceId?: string) =>
-  api(
-    `/api/mock/reservations?slug=${encodeURIComponent(slug)}${
-      deviceId ? `&deviceId=${encodeURIComponent(deviceId)}` : ''
-    }`
-  );
-export const createReservation = (body: any) =>
-  api('/api/mock/reservations', { method: 'POST', body: JSON.stringify(body) });
+export const {
+  listGroups,
+  createGroup,
+  getGroup,
+  joinGroup,
+  listDevices,
+  createDevice,
+  listReservations,
+  createReservation,
+} = createApi(getBaseURL);

--- a/web/src/types/qrcode.d.ts
+++ b/web/src/types/qrcode.d.ts
@@ -1,0 +1,1 @@
+declare module 'qrcode';


### PR DESCRIPTION
## Summary
- create shared `api-core` utility with common request helper
- refactor client and server wrappers to use new utility
- add stub type for `qrcode` to satisfy type checking

## Testing
- `npx --no-install next lint`
- `npx --no-install tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68aaaa8f4bd08323a5d9059886def841