### PR TITLE
chore: make group lookup case-insensitive

### DIFF
--- a/web/src/app/api/mock/devices/[slug]/qr/route.ts
+++ b/web/src/app/api/mock/devices/[slug]/qr/route.ts
@@ -6,7 +6,10 @@ import QRCode from 'qrcode';
 export const runtime = 'nodejs';
 
 export async function GET(_req: Request, { params }: { params: { slug: string } }) {
-  const device = db.groups.flatMap((g) => g.devices).find((d) => d.slug === params.slug);
+  const slugLc = params.slug.toLowerCase();
+  const device = db.groups
+    .flatMap((g) => g.devices)
+    .find((d) => d.slug.toLowerCase() === slugLc);
   if (!device) return new Response('Not found', { status: 404 });
 
   const base = process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000';

--- a/web/src/app/api/mock/devices/route.ts
+++ b/web/src/app/api/mock/devices/route.ts
@@ -7,7 +7,8 @@ export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const slug = searchParams.get('slug');
   if (!slug) return NextResponse.json({ ok: false, error: 'slug required' }, { status: 400 });
-  const g = db.groups.find((x) => x.slug === slug);
+  const slugLc = slug.toLowerCase();
+  const g = db.groups.find((x) => x.slug.toLowerCase() === slugLc);
   if (!g) return NextResponse.json({ ok: false, error: 'group not found' }, { status: 404 });
   return NextResponse.json({ ok: true, data: g.devices });
 }
@@ -15,7 +16,8 @@ export async function GET(req: Request) {
 export async function POST(req: Request) {
   const body = await req.json();
   const { slug, name, note, deviceSlug } = body;
-  const g = db.groups.find((x) => x.slug === slug);
+  const slugLc = slug.toLowerCase();
+  const g = db.groups.find((x) => x.slug.toLowerCase() === slugLc);
   if (!g) return NextResponse.json({ ok: false, error: 'group not found' }, { status: 404 });
   const dSlug = deviceSlug || makeSlug(name);
   const d = { id: uuid(), slug: dSlug, name, note, qrToken: uuid().replace(/-/g, '') };

--- a/web/src/app/api/mock/groups/[slug]/route.ts
+++ b/web/src/app/api/mock/groups/[slug]/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from 'next/server';
 import { db } from '@/lib/mock-db';
 
 export async function GET(_req: Request, { params }: { params: { slug: string } }) {
-  const g = db.groups.find((x) => x.slug === params.slug);
+  const slugLc = params.slug.toLowerCase();
+  const g = db.groups.find((x) => x.slug.toLowerCase() === slugLc);
   if (!g) return NextResponse.json({ ok: false, error: 'group not found' }, { status: 404 });
   return NextResponse.json({ ok: true, data: g });
 }

--- a/web/src/app/api/mock/groups/join/route.ts
+++ b/web/src/app/api/mock/groups/join/route.ts
@@ -4,8 +4,10 @@ import { db } from '@/lib/mock-db';
 export async function POST(req: Request) {
   const body = await req.json();
   const { identifier, password } = body;
+  // normalize both identifier and stored names/slugs for case-insensitive comparison
+  const id = identifier.toLowerCase();
   const g = db.groups.find(
-    (x) => x.slug === identifier || x.name === identifier
+    (x) => x.slug.toLowerCase() === id || x.name.toLowerCase() === id
   );
   if (!g) return NextResponse.json({ ok: false, error: 'group not found' }, { status: 404 });
   if (g.passwordHash && g.passwordHash !== password) {

--- a/web/src/app/api/mock/groups/route.ts
+++ b/web/src/app/api/mock/groups/route.ts
@@ -12,7 +12,8 @@ export async function POST(req: Request) {
   if (!name || !slug) {
     return NextResponse.json({ ok: false, error: 'invalid request' }, { status: 400 });
   }
-  if (db.groups.find((g) => g.slug === slug)) {
+  const slugLc = slug.toLowerCase();
+  if (db.groups.find((g) => g.slug.toLowerCase() === slugLc)) {
     return NextResponse.json({ ok: false, error: 'slug already exists' }, { status: 409 });
   }
   const g = {

--- a/web/src/app/api/mock/reservations/route.ts
+++ b/web/src/app/api/mock/reservations/route.ts
@@ -7,7 +7,8 @@ export async function GET(req: Request) {
   const slug = searchParams.get('slug');
   if (!slug) return NextResponse.json({ ok: false, error: 'slug required' }, { status: 400 });
   const deviceId = searchParams.get('deviceId');
-  const g = db.groups.find((x) => x.slug === slug);
+  const slugLc = slug.toLowerCase();
+  const g = db.groups.find((x) => x.slug.toLowerCase() === slugLc);
   if (!g) return NextResponse.json({ ok: false, error: 'group not found' }, { status: 404 });
   const list = deviceId
     ? g.reservations.filter((r) => r.deviceId === deviceId)
@@ -18,7 +19,8 @@ export async function GET(req: Request) {
 export async function POST(req: Request) {
   const body = await req.json();
   const { slug, deviceId, start, end, reserver, title, scope, memberId } = body;
-  const g = db.groups.find((x) => x.slug === slug);
+  const slugLc = slug.toLowerCase();
+  const g = db.groups.find((x) => x.slug.toLowerCase() === slugLc);
   if (!g) return NextResponse.json({ ok: false, error: 'group not found' }, { status: 404 });
   if (!g.devices.find((d) => d.id === deviceId)) {
     return NextResponse.json({ ok: false, error: 'unknown device' }, { status: 400 });

--- a/web/src/app/d/[slug]/page.tsx
+++ b/web/src/app/d/[slug]/page.tsx
@@ -9,8 +9,9 @@ export default function DeviceQRPage({
   searchParams: { t?: string };
 }) {
   const token = searchParams?.t;
-  const group = db.groups.find((g) => g.devices.some((d) => d.slug === params.slug));
-  const device = group?.devices.find((d) => d.slug === params.slug);
+  const slugLc = params.slug.toLowerCase();
+  const group = db.groups.find((g) => g.devices.some((d) => d.slug.toLowerCase() === slugLc));
+  const device = group?.devices.find((d) => d.slug.toLowerCase() === slugLc);
   if (!group || !device || !token || token !== device.qrToken) {
     notFound();
   }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -18,6 +18,7 @@ export const listGroups = () => api('/api/mock/groups');
 export const createGroup = (body: any) =>
   api('/api/mock/groups', { method: 'POST', body: JSON.stringify(body) });
 export const getGroup = (slug: string) => api(`/api/mock/groups/${slug}`);
+// identifier may be group name or slug; comparison is case-insensitive
 export const joinGroup = (payload: any) =>
   api('/api/mock/groups/join', { method: 'POST', body: JSON.stringify(payload) });
 

--- a/web/src/lib/server-api.ts
+++ b/web/src/lib/server-api.ts
@@ -25,6 +25,7 @@ export const listGroups = () => api('/api/mock/groups');
 export const createGroup = (body: any) =>
   api('/api/mock/groups', { method: 'POST', body: JSON.stringify(body) });
 export const getGroup = (slug: string) => api(`/api/mock/groups/${slug}`);
+// identifier may be group name or slug; comparison is case-insensitive
 export const joinGroup = (payload: any) =>
   api('/api/mock/groups/join', { method: 'POST', body: JSON.stringify(payload) });
 


### PR DESCRIPTION
## Summary
- normalize group join identifier and stored values to lowercase
- ensure all mock API slug lookups are case-insensitive
- document case-insensitive matching in API helpers

## Testing
- `pnpm -F web lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `pnpm -F web typecheck` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68aaaa916bdc8323888194cb1ea29b97