### PR TITLE
use dynamic crypto import for uuid

### DIFF
--- a/web/src/lib/uuid.ts
+++ b/web/src/lib/uuid.ts
@@ -1,12 +1,19 @@
+let nodeRandomUUID: (() => string) | undefined;
+
+// Node.js 18+ で利用可能な randomUUID を動的に取得
+if ((globalThis as any).process?.versions?.node) {
+  import('crypto')
+    .then(({ randomUUID }) => {
+      if (typeof randomUUID === 'function') nodeRandomUUID = randomUUID;
+    })
+    .catch(() => {});
+}
+
 export function uuid() {
   // ブラウザ/Node の crypto があれば利用
   const c: any = (globalThis as any).crypto;
   if (c?.randomUUID) return c.randomUUID();
-  try {
-    // Node 18+ ならこれで通る
-    const { randomUUID } = require('crypto');
-    if (randomUUID) return randomUUID();
-  } catch {}
+  if (nodeRandomUUID) return nodeRandomUUID();
   // フォールバック
   const s = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (ch) => {
     const r = (Math.random() * 16) | 0;


### PR DESCRIPTION
## Summary
- precompute Node's `crypto.randomUUID` via dynamic import
- fallback to Math.random-based UUID when native implementations are unavailable

## Testing
- `pnpm --filter web lint` *(fails: Error: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `pnpm --filter web typecheck` *(fails: Error: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68aaaa92550c832384d31d2450c0dbb0