### PR TITLE
docs: clarify API helper modules

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,3 +1,4 @@
+// Client-side API helpers built on top of the shared core
 import { createApi } from './api-core';
 
 function getBaseURL() {

--- a/web/src/lib/server-api.ts
+++ b/web/src/lib/server-api.ts
@@ -1,3 +1,4 @@
+// Server-side API helpers using runtime headers to determine base URL
 import { headers } from 'next/headers';
 import { createApi } from './api-core';
 


### PR DESCRIPTION
## Summary
- document client-side API helpers
- document server-side API helpers

## Testing
- `pnpm --filter web lint` *(fails: Proxy response (403) when downloading pnpm)*
- `pnpm --filter web typecheck` *(fails: Proxy response (403) when downloading pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_68aaafb1828c832393be9b5bd59f359e