### PR TITLE
feat: add login flow and home dashboard

### DIFF
--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -1,32 +1,23 @@
-import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
-import { jwtVerify } from 'jose';
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyToken } from '@/lib/auth'
 
-const secret = new TextEncoder().encode(process.env.AUTH_SECRET || 'secret');
-const COOKIE = 'session';
-
-async function isValid(token?: string) {
-  if (!token) return false;
-  try {
-    await jwtVerify(token, secret);
-    return true;
-  } catch {
-    return false;
-  }
-}
+const PROTECTED = [/^\/dashboard/, /^\/groups(\/.*)?$/, /^\/devices(\/.*)?$/]
 
 export async function middleware(req: NextRequest) {
-  const { pathname } = req.nextUrl;
-  if (pathname.startsWith('/groups/join')) return NextResponse.next();
+  const url = req.nextUrl
+  const isProtected = PROTECTED.some((re) => re.test(url.pathname))
 
-  const token = req.cookies.get(COOKIE)?.value;
-  if (!(await isValid(token))) {
-    const url = new URL('/groups/join', req.url);
-    return NextResponse.redirect(url);
+  if (!isProtected) return NextResponse.next()
+
+  const token = req.cookies.get('auth_token')?.value
+  if (!token || !(await verifyToken(token))) {
+    const login = new URL('/login', req.url)
+    login.searchParams.set('next', url.pathname)
+    return NextResponse.redirect(login)
   }
-  return NextResponse.next();
+  return NextResponse.next()
 }
 
 export const config = {
-  matcher: ['/groups/:path*'],
-};
+  matcher: ['/((?!_next|favicon.ico|api).*)'],
+}

--- a/web/src/app/_parts/HomeDashboard.tsx
+++ b/web/src/app/_parts/HomeDashboard.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link"
+import { listMyReservations } from "@/lib/api"
+
+export default async function HomeDashboard() {
+  const res = await listMyReservations().catch(() => ({ ok: false, data: [] as any[] }))
+  const reservations = res.ok ? (res.data as any[]) : []
+
+  return (
+    <main className="mx-auto max-w-[1040px] px-4 sm:px-6 py-10 space-y-8">
+      <h1 className="text-2xl font-bold">ホーム</h1>
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold">あなたの予約（直近）</h2>
+        {reservations.length === 0 ? (
+          <p className="text-neutral-600">直近の予約はありません。</p>
+        ) : (
+          <ul className="divide-y rounded-2xl border">
+            {reservations.map((r, i) => (
+              <li key={i} className="p-3 flex items-center justify-between">
+                <div>
+                  <p className="font-medium">{r.deviceName}</p>
+                  <p className="text-sm text-neutral-600">
+                    {fmt(r.from)} – {fmt(r.to)}（用途: {r.purpose || '—'}）
+                  </p>
+                </div>
+                <Link href={`/devices/${r.deviceSlug}`} className="text-blue-600 hover:underline text-sm">
+                  機器へ
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="space-x-3">
+        <Link className="px-3 py-2 rounded bg-black text-white" href="/groups/new">グループを作成</Link>
+        <Link className="px-3 py-2 rounded border" href="/groups/join">グループに参加</Link>
+        <Link className="px-3 py-2 rounded border" href="/dashboard">ダッシュボード</Link>
+        <Link className="px-3 py-2 rounded border" href="/groups">グループ一覧</Link>
+      </section>
+    </main>
+  )
+}
+
+function fmt(iso: string) {
+  const d = new Date(iso)
+  return `${d.getMonth() + 1}/${d.getDate()} ${d.getHours()}:${String(d.getMinutes()).padStart(2, '0')}`
+}

--- a/web/src/app/_parts/LoginEmbed.tsx
+++ b/web/src/app/_parts/LoginEmbed.tsx
@@ -1,0 +1,5 @@
+"use client";
+import LoginPage from '../login/page'
+export default function LoginEmbed() {
+  return <LoginPage />
+}

--- a/web/src/app/api/auth/login/route.ts
+++ b/web/src/app/api/auth/login/route.ts
@@ -4,9 +4,10 @@ import { createSession } from '@/lib/auth';
 
 export async function POST(req: Request) {
   const body = await req.json();
-  const { identifier, password } = body;
+  const { identifier, username, password } = body;
+  const ident = identifier ?? username;
   const g = db.groups.find(
-    (x) => x.slug === identifier || x.name === identifier
+    (x) => x.slug === ident || x.name === ident
   );
   if (!g)
     return NextResponse.json({ ok: false, error: 'group not found' }, { status: 404 });

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,8 +1,28 @@
 import "./globals.css";
 import type { Metadata } from "next";
 import Link from "next/link";
+import { cookies } from "next/headers";
+import { verifyToken } from "@/lib/auth";
 
 export const metadata: Metadata = { title: "Lab Yoyaku" };
+
+async function HeaderRight() {
+  const token = cookies().get("auth_token")?.value;
+  const authed = token ? !!(await verifyToken(token)) : false;
+  return (
+    <nav className="flex gap-6 text-sm text-neutral-600">
+      <Link href="/dashboard" className="hover:text-neutral-900">ダッシュボード</Link>
+      <Link href="/groups" className="hover:text-neutral-900">グループ</Link>
+      {authed ? (
+        <form action="/api/auth/logout" method="post">
+          <button className="hover:text-neutral-900">ログアウト</button>
+        </form>
+      ) : (
+        <Link href="/login" className="hover:text-neutral-900">ログイン</Link>
+      )}
+    </nav>
+  );
+}
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -11,16 +31,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <header className="border-b">
           <div className="mx-auto max-w-[1040px] px-4 sm:px-6 py-3 flex items-center justify-between">
             <Link href="/" className="text-lg font-bold">Lab Yoyaku</Link>
-            <nav className="flex gap-6 text-sm text-neutral-600">
-              <Link href="/dashboard" className="hover:text-neutral-900">ダッシュボード</Link>
-              <Link href="/dashboard" className="hover:text-neutral-900">機器一覧</Link>
-              <Link href="/groups" className="hover:text-neutral-900">グループ</Link>
-            </nav>
+            {/* @ts-expect-error Server Component */}
+            <HeaderRight />
           </div>
         </header>
-        <main className="mx-auto max-w-[1040px] px-4 sm:px-6 py-8">
-          {children}
-        </main>
+        <main className="mx-auto max-w-[1040px] px-4 sm:px-6 py-8">{children}</main>
       </body>
     </html>
   );

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+
+export default function LoginPage() {
+  const [username, setU] = useState("");
+  const [password, setP] = useState("");
+  const [loading, setL] = useState(false);
+  const [error, setE] = useState("");
+  const router = useRouter();
+  const sp = useSearchParams();
+  const next = sp.get("next") || "/";
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setE("");
+    setL(true);
+    try {
+      const res = await fetch("/api/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json?.ok) throw new Error(json?.error || "ログインに失敗しました");
+      router.push(next);
+      router.refresh();
+    } catch (err: any) {
+      setE(err.message || "ログインに失敗しました");
+    } finally {
+      setL(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto max-w-[680px] px-4 sm:px-6 py-10 space-y-8">
+      <header>
+        <h1 className="text-3xl font-bold">Lab Yoyaku へようこそ</h1>
+        <p className="text-neutral-600 mt-2">
+          研究室の機器をグループ単位で管理し、QRコードから利用状況やカレンダーを確認・予約できます。
+        </p>
+      </header>
+
+      <section className="grid sm:grid-cols-3 gap-4">
+        <Card title="① グループを作成" desc="研究室/班をグループとして立ち上げ、メンバーを招待します。" />
+        <Card title="② グループに参加" desc="招待リンク or コードから参加。機器一覧とカレンダーが使えます。" />
+        <Card title="③ 機器登録 & カレンダー" desc="機器ごとのQRを発行し、予約・使用中がひと目で分かります。" />
+      </section>
+
+      <section className="max-w-md">
+        <h2 className="text-xl font-semibold mb-3">ログイン</h2>
+        <form onSubmit={onSubmit} className="space-y-3">
+          <input
+            className="w-full border rounded px-3 py-2"
+            placeholder="ユーザー名"
+            value={username}
+            onChange={(e) => setU(e.target.value)}
+            required
+          />
+          <input
+            className="w-full border rounded px-3 py-2"
+            placeholder="パスワード"
+            type="password"
+            value={password}
+            onChange={(e) => setP(e.target.value)}
+            required
+          />
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <button
+            disabled={loading}
+            className="px-4 py-2 rounded bg-black text-white disabled:opacity-60"
+          >
+            {loading ? "ログイン中…" : "ログイン"}
+          </button>
+        </form>
+        <p className="text-xs text-neutral-500 mt-2">
+          デモ環境では <code>demo / demo</code> など固定ユーザーに合わせてください（
+          <code>src/app/api/auth/login/route.ts</code> の条件）。
+        </p>
+      </section>
+    </main>
+  );
+}
+
+function Card({ title, desc }: { title: string; desc: string }) {
+  return (
+    <div className="rounded-2xl border p-5">
+      <p className="font-semibold">{title}</p>
+      <p className="text-sm text-neutral-600 mt-1">{desc}</p>
+    </div>
+  );
+}
+

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,55 +1,14 @@
-import Link from "next/link";
+import { cookies } from 'next/headers'
+import { verifyToken } from '@/lib/auth'
+import HomeDashboard from './_parts/HomeDashboard'
+import LoginEmbed from './_parts/LoginEmbed'
 
-export default function Home() {
-  const btn = "inline-flex items-center rounded-2xl px-4 py-2 text-sm border hover:-translate-y-0.5 shadow-sm transition";
+export default async function Page() {
+  const token = cookies().get('auth_token')?.value
+  const authed = token ? !!(await verifyToken(token)) : false
 
-  return (
-    <section className="space-y-12">
-      <div className="space-y-3">
-        <h1 className="text-3xl font-bold">Lab Yoyaku へようこそ</h1>
-        <p className="text-neutral-600">
-          研究室の機器をグループ単位で管理し、QRコードから利用状況やカレンダーを確認・予約できます。
-        </p>
-      </div>
-
-      <div className="grid gap-6 sm:grid-cols-3">
-        <div className="rounded-2xl border p-6">
-          <h2 className="font-semibold mb-2">① グループを作成</h2>
-          <p className="text-sm text-neutral-600 mb-4">研究室/班をグループとして立ち上げ、メンバーを招待します。</p>
-          <Link href="/groups/new" className={`${btn} bg-neutral-900 text-white hover:bg-neutral-800`}>
-            グループを作る
-          </Link>
-        </div>
-        <div className="rounded-2xl border p-6">
-          <h2 className="font-semibold mb-2">② グループに参加</h2>
-          <p className="text-sm text-neutral-600 mb-4">招待リンク or コードから参加。機器一覧とカレンダーが使えます。</p>
-          <Link href="/groups/join" className={btn}>
-            参加する
-          </Link>
-        </div>
-        <div className="rounded-2xl border p-6">
-          <h2 className="font-semibold mb-2">③ 機器登録 & カレンダー</h2>
-          <p className="text-sm text-neutral-600 mb-4">機器ごとのQRを発行し、予約・使用中がひと目で分かります。</p>
-          <Link className="text-blue-600 hover:underline" href="/dashboard">
-            ダッシュボードを見る
-          </Link>
-        </div>
-      </div>
-
-      <div className="space-y-3">
-        <h3 className="text-xl font-semibold">ショートカット</h3>
-        <div className="flex gap-3">
-          <Link href="/groups" className={btn}>
-            グループ一覧
-          </Link>
-          <Link href="/devices" className={btn}>
-            機器一覧
-          </Link>
-          <Link href="/dashboard" className={btn}>
-            ダッシュボード
-          </Link>
-        </div>
-      </div>
-    </section>
-  );
+  if (authed) {
+    return <HomeDashboard />
+  }
+  return <LoginEmbed />
 }

--- a/web/src/lib/api-core.ts
+++ b/web/src/lib/api-core.ts
@@ -35,5 +35,11 @@ export function createApi(getBaseURL: () => string) {
         method: 'POST',
         body: JSON.stringify(body),
       }),
+    listMyReservations: (from?: string, limit?: number) =>
+      api(
+        `/api/mock/reservations?me=1${
+          from ? `&from=${encodeURIComponent(from)}` : ''
+        }${limit ? `&limit=${limit}` : ''}`
+      ),
   };
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -14,4 +14,5 @@ export const {
   createDevice,
   listReservations,
   createReservation,
+  listMyReservations,
 } = createApi(getBaseURL);

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -2,7 +2,7 @@ import { SignJWT, jwtVerify } from 'jose';
 import { cookies } from 'next/headers';
 
 const secret = new TextEncoder().encode(process.env.AUTH_SECRET || 'secret');
-export const SESSION_COOKIE_NAME = 'session';
+export const SESSION_COOKIE_NAME = 'auth_token';
 
 export type Session = {
   groupId: string;

--- a/web/src/lib/server-api.ts
+++ b/web/src/lib/server-api.ts
@@ -20,4 +20,5 @@ export const {
   createDevice,
   listReservations,
   createReservation,
+  listMyReservations,
 } = createApi(getBaseURL);


### PR DESCRIPTION
## Summary
- protect authenticated routes with middleware
- add login page and embedded top-level view
- implement home dashboard with upcoming reservations
- expose listMyReservations helper and API endpoint
- update header to switch login/logout

## Testing
- `pnpm install` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `pnpm typecheck` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68aab37d4cec8323995d9b9b53b4c873