### PR TITLE
feat: add authentication system

### DIFF
--- a/web/.env.local
+++ b/web/.env.local
@@ -1,6 +1,9 @@
 # ブラウザ/サーバー共通で使うベース。未設定なら相対URLになる
 # NEXT_PUBLIC_API_BASE=
 
+# JWT 認証用のシークレット
+AUTH_SECRET=dev-secret-change-me
+
 # サーバー側で絶対URLが必要なときのフォールバック
 INTERNAL_API_BASE=http://localhost:3000
 

--- a/web/src/app/api/auth/login/route.ts
+++ b/web/src/app/api/auth/login/route.ts
@@ -1,19 +1,14 @@
 import { NextResponse } from 'next/server';
-import { db } from '@/lib/mock-db';
-import { createSession } from '@/lib/auth';
+import { signToken, setAuthCookie } from '@/lib/auth';
 
 export async function POST(req: Request) {
-  const body = await req.json();
-  const { identifier, username, password } = body;
-  const ident = identifier ?? username;
-  const g = db.groups.find(
-    (x) => x.slug === ident || x.name === ident
-  );
-  if (!g)
-    return NextResponse.json({ ok: false, error: 'group not found' }, { status: 404 });
-  if (g.passwordHash && g.passwordHash !== password)
-    return NextResponse.json({ ok: false, error: 'invalid password' }, { status: 403 });
-
-  await createSession({ groupId: g.id, groupSlug: g.slug, groupName: g.name });
-  return NextResponse.json({ ok: true, data: { slug: g.slug, name: g.name } });
+  const { username, password } = await req.json().catch(() => ({}));
+  // デモ: demo/demo 固定。ここをFastAPIに差し替え予定
+  if (username === 'demo' && password === 'demo') {
+    const token = await signToken({ id: 'u-demo', name: 'demo' });
+    await setAuthCookie(token);
+    return NextResponse.json({ ok: true });
+  }
+  return NextResponse.json({ ok: false, error: 'invalid credentials' }, { status: 401 });
 }
+

--- a/web/src/app/api/auth/logout/route.ts
+++ b/web/src/app/api/auth/logout/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
-import { clearSession } from '@/lib/auth';
+import { clearAuthCookie } from '@/lib/auth';
 
 export async function POST() {
-  clearSession();
+  await clearAuthCookie();
   return NextResponse.json({ ok: true });
 }
+

--- a/web/src/app/api/auth/me/route.ts
+++ b/web/src/app/api/auth/me/route.ts
@@ -1,9 +1,8 @@
 import { NextResponse } from 'next/server';
-import { getSession } from '@/lib/auth';
+import { readUserFromCookie } from '@/lib/auth';
 
 export async function GET() {
-  const session = await getSession();
-  if (!session)
-    return NextResponse.json({ ok: false, error: 'unauthenticated' }, { status: 401 });
-  return NextResponse.json({ ok: true, data: session });
+  const me = await readUserFromCookie();
+  return NextResponse.json({ ok: !!me, user: me });
 }
+

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -1,17 +1,17 @@
 import { getGroup, listDevices, listReservations } from '@/lib/server-api';
 import { notFound } from 'next/navigation';
 import GroupScreenClient from './GroupScreenClient';
-import { getSession } from '@/lib/auth';
+import { readUserFromCookie } from '@/lib/auth';
 
 export default async function GroupPage({ params }: { params: { slug: string } }) {
   const groupRes = await getGroup(params.slug);
   const group = groupRes.data;
   if (!groupRes.ok || !group) return notFound();
 
-  const [devicesRes, reservationsRes, session] = await Promise.all([
+  const [devicesRes, reservationsRes, me] = await Promise.all([
     listDevices(group.slug),
     listReservations(group.slug),
-    getSession(),
+    readUserFromCookie(),
   ]);
 
   return (
@@ -19,7 +19,7 @@ export default async function GroupPage({ params }: { params: { slug: string } }
       initialGroup={group}
       initialDevices={devicesRes.data || []}
       initialReservations={reservationsRes.data || []}
-      defaultReserver={session?.groupName}
+      defaultReserver={me?.name}
     />
   );
 }

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,42 +1,14 @@
-import "./globals.css";
-import type { Metadata } from "next";
-import Link from "next/link";
-import { cookies } from "next/headers";
-import { verifyToken } from "@/lib/auth";
-
-export const metadata: Metadata = { title: "Lab Yoyaku" };
-
-async function HeaderRight() {
-  const token = cookies().get("auth_token")?.value;
-  const authed = token ? !!(await verifyToken(token)) : false;
-  return (
-    <nav className="flex gap-6 text-sm text-neutral-600">
-      <Link href="/dashboard" className="hover:text-neutral-900">ダッシュボード</Link>
-      <Link href="/groups" className="hover:text-neutral-900">グループ</Link>
-      {authed ? (
-        <form action="/api/auth/logout" method="post">
-          <button className="hover:text-neutral-900">ログアウト</button>
-        </form>
-      ) : (
-        <Link href="/login" className="hover:text-neutral-900">ログイン</Link>
-      )}
-    </nav>
-  );
-}
+import './globals.css';
+import Header from '@/components/Header';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja">
-      <body className="min-h-screen bg-white text-neutral-900 antialiased">
-        <header className="border-b">
-          <div className="mx-auto max-w-[1040px] px-4 sm:px-6 py-3 flex items-center justify-between">
-            <Link href="/" className="text-lg font-bold">Lab Yoyaku</Link>
-            {/* @ts-expect-error Server Component */}
-            <HeaderRight />
-          </div>
-        </header>
-        <main className="mx-auto max-w-[1040px] px-4 sm:px-6 py-8">{children}</main>
+      <body>
+        <Header />
+        <main>{children}</main>
       </body>
     </html>
   );
 }
+

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,93 +1,64 @@
-"use client";
-
-import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+'use client';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useState } from 'react';
 
 export default function LoginPage() {
-  const [username, setU] = useState("");
-  const [password, setP] = useState("");
-  const [loading, setL] = useState(false);
-  const [error, setE] = useState("");
   const router = useRouter();
   const sp = useSearchParams();
-  const next = sp.get("next") || "/";
+  const next = sp.get('next') || '/';
 
-  const onSubmit = async (e: React.FormEvent) => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [err, setErr] = useState('');
+
+  async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
-    setE("");
-    setL(true);
-    try {
-      const res = await fetch("/api/auth/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ username, password }),
-      });
-      const json = await res.json();
-      if (!res.ok || !json?.ok) throw new Error(json?.error || "ログインに失敗しました");
-      router.push(next);
-      router.refresh();
-    } catch (err: any) {
-      setE(err.message || "ログインに失敗しました");
-    } finally {
-      setL(false);
-    }
-  };
+    setErr('');
+    const res = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+    if (res.ok) router.replace(next);
+    else setErr('ユーザー名またはパスワードが違います');
+  }
 
   return (
-    <main className="mx-auto max-w-[680px] px-4 sm:px-6 py-10 space-y-8">
-      <header>
+    <div className="mx-auto max-w-3xl px-4 py-10 space-y-8">
+      <header className="text-center">
         <h1 className="text-3xl font-bold">Lab Yoyaku へようこそ</h1>
-        <p className="text-neutral-600 mt-2">
-          研究室の機器をグループ単位で管理し、QRコードから利用状況やカレンダーを確認・予約できます。
+        <p className="text-gray-600 mt-2">
+          研究室の機器をグループ単位で管理し、利用状況や予約をカレンダーで可視化。QRコードで機器別ページにアクセスできます。
         </p>
       </header>
 
-      <section className="grid sm:grid-cols-3 gap-4">
-        <Card title="① グループを作成" desc="研究室/班をグループとして立ち上げ、メンバーを招待します。" />
-        <Card title="② グループに参加" desc="招待リンク or コードから参加。機器一覧とカレンダーが使えます。" />
-        <Card title="③ 機器登録 & カレンダー" desc="機器ごとのQRを発行し、予約・使用中がひと目で分かります。" />
-      </section>
+      {/* 説明カード */}
+      <div className="grid gap-4 md:grid-cols-3">
+        {[
+          {t:'① グループを作成', d:'研究室/班ごとにグループ化して立ち上げ、メンバーを招待します。'},
+          {t:'② グループに参加', d:'招待リンク/QRコードから参加。機器一覧とカレンダーが使えます。'},
+          {t:'③ 機器登録 & カレンダー', d:'機器ごとにQRを発行し、予約・使用中がひと目で分かります。'},
+        ].map((c,i)=>(
+          <div key={i} className="rounded-xl border p-4">
+            <div className="font-semibold mb-1">{c.t}</div>
+            <div className="text-sm text-gray-600">{c.d}</div>
+          </div>
+        ))}
+      </div>
 
+      {/* ログイン */}
       <section className="max-w-md">
         <h2 className="text-xl font-semibold mb-3">ログイン</h2>
         <form onSubmit={onSubmit} className="space-y-3">
-          <input
-            className="w-full border rounded px-3 py-2"
-            placeholder="ユーザー名"
-            value={username}
-            onChange={(e) => setU(e.target.value)}
-            required
-          />
-          <input
-            className="w-full border rounded px-3 py-2"
-            placeholder="パスワード"
-            type="password"
-            value={password}
-            onChange={(e) => setP(e.target.value)}
-            required
-          />
-          {error && <p className="text-sm text-red-600">{error}</p>}
-          <button
-            disabled={loading}
-            className="px-4 py-2 rounded bg-black text-white disabled:opacity-60"
-          >
-            {loading ? "ログイン中…" : "ログイン"}
-          </button>
+          <input className="w-full rounded border px-3 py-2" placeholder="ユーザー名"
+                 value={username} onChange={e=>setUsername(e.target.value)} />
+          <input className="w-full rounded border px-3 py-2" type="password" placeholder="パスワード"
+                 value={password} onChange={e=>setPassword(e.target.value)} />
+          {err && <div className="text-sm text-red-600">{err}</div>}
+          <button className="rounded bg-black text-white px-4 py-2">ログイン</button>
         </form>
-        <p className="text-xs text-neutral-500 mt-2">
-          デモ環境では <code>demo / demo</code> など固定ユーザーに合わせてください（
-          <code>src/app/api/auth/login/route.ts</code> の条件）。
-        </p>
+        <p className="text-xs text-gray-500 mt-2">デモ環境では <b>demo / demo</b> でログインできます。</p>
       </section>
-    </main>
-  );
-}
-
-function Card({ title, desc }: { title: string; desc: string }) {
-  return (
-    <div className="rounded-2xl border p-5">
-      <p className="font-semibold">{title}</p>
-      <p className="text-sm text-neutral-600 mt-1">{desc}</p>
     </div>
   );
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,14 +1,12 @@
-import { cookies } from 'next/headers'
-import { verifyToken } from '@/lib/auth'
-import HomeDashboard from './_parts/HomeDashboard'
-import LoginEmbed from './_parts/LoginEmbed'
+import { readUserFromCookie } from '@/lib/auth';
+import HomeDashboard from './_parts/HomeDashboard';
+import LoginEmbed from './_parts/LoginEmbed';
 
 export default async function Page() {
-  const token = cookies().get('auth_token')?.value
-  const authed = token ? !!(await verifyToken(token)) : false
+  const me = await readUserFromCookie();
 
-  if (authed) {
-    return <HomeDashboard />
+  if (me) {
+    return <HomeDashboard />;
   }
-  return <LoginEmbed />
+  return <LoginEmbed />;
 }

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -1,0 +1,23 @@
+import { readUserFromCookie } from '@/lib/auth';
+
+export default async function Header() {
+  const me = await readUserFromCookie();
+  return (
+    <header className="border-b">
+      <div className="mx-auto max-w-5xl px-4 h-12 flex items-center justify-between">
+        <a href="/" className="font-semibold">Lab Yoyaku</a>
+        <nav className="flex items-center gap-6 text-sm">
+          {me && <>
+            <a href="/">ダッシュボード</a>
+            <a href="/groups">グループ</a>
+            <form action="/api/auth/logout" method="post">
+              <button className="text-gray-600 hover:underline">ログアウト</button>
+            </form>
+          </>}
+          {!me && <a href="/login">ログイン</a>}
+        </nav>
+      </div>
+    </header>
+  );
+}
+


### PR DESCRIPTION
## Summary
- implement cookie-based auth utilities and demo login/logout/me API routes
- protect pages with middleware and display login form
- add header showing login state

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aab93a44808323b71e767f32929aa6