### PR TITLE
feat: add email-based auth and registration

### DIFF
--- a/web/src/app/api/auth/register/route.ts
+++ b/web/src/app/api/auth/register/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { hashPassword, signToken, setAuthCookie } from '@/lib/auth';
+import { isEmail, loadDB, saveDB, uid } from '@/lib/mockdb';
+
+export async function POST(req: Request) {
+  const { email, password, name } = await req.json().catch(() => ({}));
+  if (!email || !password) {
+    return NextResponse.json({ ok:false, error:'email and password required' }, { status:400 });
+  }
+  if (!isEmail(email)) {
+    return NextResponse.json({ ok:false, error:'invalid email' }, { status:400 });
+  }
+  if (String(password).length < 6) {
+    return NextResponse.json({ ok:false, error:'password too short' }, { status:400 });
+  }
+  const db = loadDB();
+  if (db.users.some(u => u.email.toLowerCase() === String(email).toLowerCase())) {
+    return NextResponse.json({ ok:false, error:'email already registered' }, { status:409 });
+  }
+
+  const user = {
+    id: uid(),
+    email: String(email),
+    name: name ? String(name) : String(email).split('@')[0],
+    passHash: hashPassword(String(password)),
+  };
+  db.users.push(user);
+  saveDB(db);
+
+  // 自動ログイン
+  const token = await signToken({ id: user.id, name: user.name || '', email: user.email });
+  await setAuthCookie(token);
+  return NextResponse.json({ ok:true });
+}

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -2,29 +2,53 @@
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 
+type Tab = 'login' | 'register';
+
 export default function LoginPage() {
   const router = useRouter();
   const sp = useSearchParams();
   const next = sp.get('next') || '/';
+  const [tab, setTab] = useState<Tab>('login');
 
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const [err, setErr] = useState('');
+  // login state
+  const [lemail, setLEmail] = useState('');
+  const [lpass, setLPass] = useState('');
+  const [lerr, setLErr] = useState('');
 
-  async function onSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    setErr('');
+  // register state
+  const [rname, setRName] = useState('');
+  const [remail, setREmail] = useState('');
+  const [rpass, setRPass] = useState('');
+  const [rpass2, setRPass2] = useState('');
+  const [rerr, setRErr] = useState('');
+
+  async function submitLogin(e: React.FormEvent) {
+    e.preventDefault(); setLErr('');
     const res = await fetch('/api/auth/login', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, password })
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({ email: lemail, password: lpass })
     });
     if (res.ok) router.replace(next);
-    else setErr('ユーザー名またはパスワードが違います');
+    else setLErr('メールまたはパスワードが違います');
+  }
+
+  async function submitRegister(e: React.FormEvent) {
+    e.preventDefault(); setRErr('');
+    if (rpass !== rpass2) { setRErr('確認用パスワードが一致しません'); return; }
+    const res = await fetch('/api/auth/register', {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({ email: remail, password: rpass, name: rname })
+    });
+    if (res.ok) router.replace(next);
+    else {
+      const t = await res.text();
+      setRErr(/already/.test(t) ? 'このメールアドレスは既に登録されています' : '登録に失敗しました');
+    }
   }
 
   return (
     <div className="mx-auto max-w-3xl px-4 py-10 space-y-8">
+      {/* 説明 */}
       <header className="text-center">
         <h1 className="text-3xl font-bold">Lab Yoyaku へようこそ</h1>
         <p className="text-gray-600 mt-2">
@@ -32,11 +56,10 @@ export default function LoginPage() {
         </p>
       </header>
 
-      {/* 説明カード */}
       <div className="grid gap-4 md:grid-cols-3">
         {[
-          {t:'① グループを作成', d:'研究室/班ごとにグループ化して立ち上げ、メンバーを招待します。'},
-          {t:'② グループに参加', d:'招待リンク/QRコードから参加。機器一覧とカレンダーが使えます。'},
+          {t:'① グループを作成', d:'研究室/班ごとにグループ化し、メンバーを招待します。'},
+          {t:'② グループに参加', d:'招待リンク/QRから参加。機器一覧とカレンダーが使えます。'},
           {t:'③ 機器登録 & カレンダー', d:'機器ごとにQRを発行し、予約・使用中がひと目で分かります。'},
         ].map((c,i)=>(
           <div key={i} className="rounded-xl border p-4">
@@ -46,20 +69,46 @@ export default function LoginPage() {
         ))}
       </div>
 
-      {/* ログイン */}
-      <section className="max-w-md">
-        <h2 className="text-xl font-semibold mb-3">ログイン</h2>
-        <form onSubmit={onSubmit} className="space-y-3">
-          <input className="w-full rounded border px-3 py-2" placeholder="ユーザー名"
-                 value={username} onChange={e=>setUsername(e.target.value)} />
-          <input className="w-full rounded border px-3 py-2" type="password" placeholder="パスワード"
-                 value={password} onChange={e=>setPassword(e.target.value)} />
-          {err && <div className="text-sm text-red-600">{err}</div>}
-          <button className="rounded bg-black text-white px-4 py-2">ログイン</button>
-        </form>
-        <p className="text-xs text-gray-500 mt-2">デモ環境では <b>demo / demo</b> でログインできます。</p>
-      </section>
+      {/* タブ */}
+      <div className="max-w-xl mx-auto">
+        <div className="flex border-b mb-4">
+          <button
+            className={`px-4 py-2 ${tab==='login' ? 'border-b-2 border-black font-semibold' : 'text-gray-500'}`}
+            onClick={()=>setTab('login')}
+          >ログイン</button>
+          <button
+            className={`px-4 py-2 ${tab==='register' ? 'border-b-2 border-black font-semibold' : 'text-gray-500'}`}
+            onClick={()=>setTab('register')}
+          >新規作成</button>
+        </div>
+
+        {tab==='login' && (
+          <form onSubmit={submitLogin} className="space-y-3">
+            <input className="w-full rounded border px-3 py-2" placeholder="メールアドレス"
+                   value={lemail} onChange={e=>setLEmail(e.target.value)} />
+            <input className="w-full rounded border px-3 py-2" type="password" placeholder="パスワード"
+                   value={lpass} onChange={e=>setLPass(e.target.value)} />
+            {lerr && <div className="text-sm text-red-600">{lerr}</div>}
+            <button className="rounded bg-black text-white px-4 py-2">ログイン</button>
+            <p className="text-xs text-gray-500 mt-2">デモ: <b>demo / demo</b> でもログインできます。</p>
+          </form>
+        )}
+
+        {tab==='register' && (
+          <form onSubmit={submitRegister} className="space-y-3">
+            <input className="w-full rounded border px-3 py-2" placeholder="表示名（任意）"
+                   value={rname} onChange={e=>setRName(e.target.value)} />
+            <input className="w-full rounded border px-3 py-2" placeholder="メールアドレス"
+                   value={remail} onChange={e=>setREmail(e.target.value)} required />
+            <input className="w-full rounded border px-3 py-2" type="password" placeholder="パスワード（6文字以上）"
+                   value={rpass} onChange={e=>setRPass(e.target.value)} required />
+            <input className="w-full rounded border px-3 py-2" type="password" placeholder="パスワード（確認）"
+                   value={rpass2} onChange={e=>setRPass2(e.target.value)} required />
+            {rerr && <div className="text-sm text-red-600">{rerr}</div>}
+            <button className="rounded bg-black text-white px-4 py-2">アカウントを作成</button>
+          </form>
+        )}
+      </div>
     </div>
   );
 }
-

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -10,6 +10,7 @@ export default async function Header() {
           {me && <>
             <a href="/">ダッシュボード</a>
             <a href="/groups">グループ</a>
+            <span className="text-gray-500">{me.name || me.email}</span>
             <form action="/api/auth/logout" method="post">
               <button className="text-gray-600 hover:underline">ログアウト</button>
             </form>

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,41 +1,41 @@
 import 'server-only';
 import { SignJWT, jwtVerify } from 'jose';
 import { cookies } from 'next/headers';
+import { createHash } from 'crypto';
+import { loadDB } from './mockdb';
 
 const secret = new TextEncoder().encode(process.env.AUTH_SECRET || 'dev-secret');
 const COOKIE = 'labyoyaku_token';
 
-export type User = { id: string; name: string };
+export type User = { id: string; name: string; email: string };
+
+export const hashPassword = (pw: string) =>
+  createHash('sha256').update(pw).digest('hex');
 
 export async function signToken(user: User) {
-  return await new SignJWT(user)
-    .setProtectedHeader({ alg: 'HS256' })
-    .setIssuedAt()
-    .setExpirationTime('7d')
-    .sign(secret);
+  return await new SignJWT(user).setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt().setExpirationTime('7d').sign(secret);
 }
 
 export async function readUserFromCookie(): Promise<User | null> {
-  const token = cookies().get(COOKIE)?.value;
+  const token = (await cookies()).get(COOKIE)?.value;
   if (!token) return null;
   try {
     const { payload } = await jwtVerify(token, secret);
-    return { id: String(payload.id), name: String(payload.name) };
-  } catch {
-    return null;
-  }
+    return { id: String(payload.id), name: String(payload.name), email: String(payload.email) };
+  } catch { return null; }
 }
 
 export async function setAuthCookie(token: string) {
-  cookies().set(COOKIE, token, {
-    httpOnly: true,
-    sameSite: 'lax',
-    path: '/',
-    maxAge: 60 * 60 * 24 * 7,
+  (await cookies()).set(COOKIE, token, {
+    httpOnly: true, sameSite: 'lax', path: '/', maxAge: 60 * 60 * 24 * 7,
   });
 }
+export async function clearAuthCookie() { (await cookies()).delete(COOKIE); }
 
-export async function clearAuthCookie() {
-  cookies().delete(COOKIE);
+/** emailでユーザーを探す（モックDB） */
+export function findUserByEmail(email: string) {
+  const db = loadDB();
+  return db.users.find(u => u.email.toLowerCase() === email.toLowerCase()) || null;
 }
 

--- a/web/src/lib/mockdb.ts
+++ b/web/src/lib/mockdb.ts
@@ -1,0 +1,33 @@
+export type MemberId = string;
+
+export type Device = { id: string; name: string; note?: string };
+export type Reservation = {
+  id: string; deviceId: string; user: MemberId;
+  start: string; end: string; purpose?: string;
+};
+export type Group = {
+  slug: string; name: string; password?: string;
+  members: MemberId[]; devices: Device[]; reservations: Reservation[];
+};
+
+/** ← 追加：ユーザー */
+export type UserRecord = {
+  id: string;
+  email: string;
+  name?: string;
+  passHash: string; // sha256
+};
+
+type DB = { groups: Group[]; users: UserRecord[] };
+
+const g = globalThis as any;
+if (!g.__MOCK_DB__) g.__MOCK_DB__ = { groups: [], users: [] } as DB;
+
+export function loadDB(): DB { return g.__MOCK_DB__ as DB; }
+export function saveDB(_db: DB) { /* メモリなのでnoop */ }
+
+export const uid = () =>
+  'id_' + Math.random().toString(36).slice(2, 8) + Date.now().toString(36);
+
+/** ざっくりemail判定 */
+export const isEmail = (v: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v);


### PR DESCRIPTION
## Summary
- add in-memory user store and helpers
- support email/password login with SHA256 hashing
- implement registration and login UI tabs

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aabd1b8dc88323a53e80e1083c0864