### PR TITLE
feat: redesign landing login and dashboard

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,8 @@
     "qrcode.react": "^3.1.0",
     "qrcode": "^1.5.3",
     "bcryptjs": "^2.4.3",
-    "jose": "^5.2.2"
+    "jose": "^5.2.2",
+    "lucide-react": "^0.417.0"
   },
   "devDependencies": {
     "@types/react": "18.2.21",

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
+import { LogIn, UserPlus } from 'lucide-react'; // npm i lucide-react
 
 type Tab = 'login' | 'register';
 
@@ -10,104 +11,142 @@ export default function LoginPage() {
   const next = sp.get('next') || '/';
   const [tab, setTab] = useState<Tab>('login');
 
-  // login state
+  // login
   const [lemail, setLEmail] = useState('');
   const [lpass, setLPass] = useState('');
   const [lerr, setLErr] = useState('');
+  const [loadingLogin, setLoadingLogin] = useState(false);
 
-  // register state
+  // register
   const [rname, setRName] = useState('');
   const [remail, setREmail] = useState('');
   const [rpass, setRPass] = useState('');
   const [rpass2, setRPass2] = useState('');
   const [rerr, setRErr] = useState('');
+  const [loadingReg, setLoadingReg] = useState(false);
 
   async function submitLogin(e: React.FormEvent) {
-    e.preventDefault(); setLErr('');
-    const res = await fetch('/api/auth/login', {
-      method:'POST', headers:{'Content-Type':'application/json'},
-      body: JSON.stringify({ email: lemail, password: lpass })
-    });
-    if (res.ok) router.replace(next);
-    else setLErr('メールまたはパスワードが違います');
+    e.preventDefault(); setLErr(''); setLoadingLogin(true);
+    try {
+      const res = await fetch('/api/auth/login', {
+        method:'POST', headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({ email: lemail, password: lpass })
+      });
+      if (!res.ok) throw new Error();
+      // ✅ 成功したらホームへ（next があれば next、なければ /）
+      router.replace(next || '/');
+    } catch {
+      setLErr('メールまたはパスワードが違います');
+    } finally {
+      setLoadingLogin(false);
+    }
   }
 
   async function submitRegister(e: React.FormEvent) {
     e.preventDefault(); setRErr('');
     if (rpass !== rpass2) { setRErr('確認用パスワードが一致しません'); return; }
-    const res = await fetch('/api/auth/register', {
-      method:'POST', headers:{'Content-Type':'application/json'},
-      body: JSON.stringify({ email: remail, password: rpass, name: rname })
-    });
-    if (res.ok) router.replace(next);
-    else {
-      const t = await res.text();
-      setRErr(/already/.test(t) ? 'このメールアドレスは既に登録されています' : '登録に失敗しました');
+    setLoadingReg(true);
+    try {
+      const res = await fetch('/api/auth/register', {
+        method:'POST', headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({ email: remail, password: rpass, name: rname })
+      });
+      if (!res.ok) {
+        const t = await res.text();
+        throw new Error(/already/.test(t) ? 'このメールは登録済みです' : '登録に失敗しました');
+      }
+      // ✅ 成功したらホームへ
+      router.replace('/');
+    } catch (e: any) {
+      setRErr(e?.message ?? '登録に失敗しました');
+    } finally {
+      setLoadingReg(false);
     }
   }
 
   return (
-    <div className="mx-auto max-w-3xl px-4 py-10 space-y-8">
-      {/* 説明 */}
-      <header className="text-center">
-        <h1 className="text-3xl font-bold">Lab Yoyaku へようこそ</h1>
-        <p className="text-gray-600 mt-2">
-          研究室の機器をグループ単位で管理し、利用状況や予約をカレンダーで可視化。QRコードで機器別ページにアクセスできます。
-        </p>
-      </header>
+    <div className="min-h-[calc(100vh-48px)] bg-gradient-to-b from-sky-50 to-white">
+      <div className="mx-auto max-w-4xl px-4 py-12">
+        {/* ヒーロー */}
+        <header className="text-center mb-8">
+          <h1 className="text-3xl font-extrabold tracking-tight">Lab Yoyaku へようこそ</h1>
+          <p className="text-gray-600 mt-2">
+            研究室の機器をグループで管理し、予約と使用状況をカレンダーで可視化。QRコードで機器ページへも即アクセス。
+          </p>
+        </header>
 
-      <div className="grid gap-4 md:grid-cols-3">
-        {[
-          {t:'① グループを作成', d:'研究室/班ごとにグループ化し、メンバーを招待します。'},
-          {t:'② グループに参加', d:'招待リンク/QRから参加。機器一覧とカレンダーが使えます。'},
-          {t:'③ 機器登録 & カレンダー', d:'機器ごとにQRを発行し、予約・使用中がひと目で分かります。'},
-        ].map((c,i)=>(
-          <div key={i} className="rounded-xl border p-4">
-            <div className="font-semibold mb-1">{c.t}</div>
-            <div className="text-sm text-gray-600">{c.d}</div>
-          </div>
-        ))}
-      </div>
-
-      {/* タブ */}
-      <div className="max-w-xl mx-auto">
-        <div className="flex border-b mb-4">
-          <button
-            className={`px-4 py-2 ${tab==='login' ? 'border-b-2 border-black font-semibold' : 'text-gray-500'}`}
-            onClick={()=>setTab('login')}
-          >ログイン</button>
-          <button
-            className={`px-4 py-2 ${tab==='register' ? 'border-b-2 border-black font-semibold' : 'text-gray-500'}`}
-            onClick={()=>setTab('register')}
-          >新規作成</button>
+        {/* 説明カード */}
+        <div className="grid gap-4 md:grid-cols-3 mb-10">
+          {[
+            {t:'① グループを作成', d:'研究室/班ごとに立ち上げ、メンバーを招待。'},
+            {t:'② グループに参加', d:'招待リンク/QRから参加。機器一覧とカレンダーを共有。'},
+            {t:'③ 機器登録 & 予約', d:'機器ごとにQR発行、予約・使用中がすぐ分かる。'},
+          ].map((c,i)=>(
+            <div key={i} className="rounded-2xl border shadow-sm bg-white p-4">
+              <div className="font-semibold mb-1">{c.t}</div>
+              <div className="text-sm text-gray-600">{c.d}</div>
+            </div>
+          ))}
         </div>
 
-        {tab==='login' && (
-          <form onSubmit={submitLogin} className="space-y-3">
-            <input className="w-full rounded border px-3 py-2" placeholder="メールアドレス"
-                   value={lemail} onChange={e=>setLEmail(e.target.value)} />
-            <input className="w-full rounded border px-3 py-2" type="password" placeholder="パスワード"
-                   value={lpass} onChange={e=>setLPass(e.target.value)} />
-            {lerr && <div className="text-sm text-red-600">{lerr}</div>}
-            <button className="rounded bg-black text-white px-4 py-2">ログイン</button>
-            <p className="text-xs text-gray-500 mt-2">デモ: <b>demo / demo</b> でもログインできます。</p>
-          </form>
-        )}
+        {/* タブ */}
+        <div className="mx-auto max-w-xl bg-white rounded-2xl border shadow-sm p-6">
+          <div className="inline-flex rounded-full bg-gray-100 p-1 mb-6">
+            <button
+              className={`px-4 py-2 rounded-full text-sm transition ${
+                tab==='login' ? 'bg-white shadow-sm font-semibold' : 'text-gray-500'
+              }`}
+              onClick={()=>setTab('login')}
+            >
+              <span className="inline-flex items-center gap-2"><LogIn size={16}/> ログイン</span>
+            </button>
+            <button
+              className={`px-4 py-2 rounded-full text-sm transition ${
+                tab==='register' ? 'bg-white shadow-sm font-semibold' : 'text-gray-500'
+              }`}
+              onClick={()=>setTab('register')}
+            >
+              <span className="inline-flex items-center gap-2"><UserPlus size={16}/> 新規作成</span>
+            </button>
+          </div>
 
-        {tab==='register' && (
-          <form onSubmit={submitRegister} className="space-y-3">
-            <input className="w-full rounded border px-3 py-2" placeholder="表示名（任意）"
-                   value={rname} onChange={e=>setRName(e.target.value)} />
-            <input className="w-full rounded border px-3 py-2" placeholder="メールアドレス"
-                   value={remail} onChange={e=>setREmail(e.target.value)} required />
-            <input className="w-full rounded border px-3 py-2" type="password" placeholder="パスワード（6文字以上）"
-                   value={rpass} onChange={e=>setRPass(e.target.value)} required />
-            <input className="w-full rounded border px-3 py-2" type="password" placeholder="パスワード（確認）"
-                   value={rpass2} onChange={e=>setRPass2(e.target.value)} required />
-            {rerr && <div className="text-sm text-red-600">{rerr}</div>}
-            <button className="rounded bg-black text-white px-4 py-2">アカウントを作成</button>
-          </form>
-        )}
+          {tab==='login' && (
+            <form onSubmit={submitLogin} className="space-y-3">
+              <input className="w-full rounded-xl border px-3 py-2" placeholder="メールアドレス"
+                     value={lemail} onChange={e=>setLEmail(e.target.value)} required />
+              <input className="w-full rounded-xl border px-3 py-2" type="password" placeholder="パスワード"
+                     value={lpass} onChange={e=>setLPass(e.target.value)} required />
+              {lerr && <div className="text-sm text-red-600">{lerr}</div>}
+              <button
+                className="w-full rounded-xl bg-sky-600 text-white px-4 py-2 font-semibold hover:bg-sky-700 transition disabled:opacity-60"
+                disabled={loadingLogin}
+              >
+                {loadingLogin ? 'ログイン中…' : 'ログイン'}
+              </button>
+              <p className="text-xs text-gray-500 text-center">デモ: <b>demo / demo</b> でもログインできます。</p>
+            </form>
+          )}
+
+          {tab==='register' && (
+            <form onSubmit={submitRegister} className="space-y-3">
+              <input className="w-full rounded-xl border px-3 py-2" placeholder="表示名（任意）"
+                     value={rname} onChange={e=>setRName(e.target.value)} />
+              <input className="w-full rounded-xl border px-3 py-2" placeholder="メールアドレス"
+                     value={remail} onChange={e=>setREmail(e.target.value)} required />
+              <input className="w-full rounded-xl border px-3 py-2" type="password" placeholder="パスワード（6文字以上）"
+                     value={rpass} onChange={e=>setRPass(e.target.value)} required />
+              <input className="w-full rounded-xl border px-3 py-2" type="password" placeholder="パスワード（確認）"
+                     value={rpass2} onChange={e=>setRPass2(e.target.value)} required />
+              {rerr && <div className="text-sm text-red-600">{rerr}</div>}
+              <button
+                className="w-full rounded-xl bg-indigo-600 text-white px-4 py-2 font-semibold hover:bg-indigo-700 transition disabled:opacity-60"
+                disabled={loadingReg}
+              >
+                {loadingReg ? '作成中…' : 'アカウントを作成'}
+              </button>
+            </form>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,12 +1,24 @@
 import { readUserFromCookie } from '@/lib/auth';
-import HomeDashboard from './_parts/HomeDashboard';
-import LoginEmbed from './_parts/LoginEmbed';
 
-export default async function Page() {
+export default async function Home() {
   const me = await readUserFromCookie();
-
-  if (me) {
-    return <HomeDashboard />;
-  }
-  return <LoginEmbed />;
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-8 space-y-6">
+      <h1 className="text-2xl font-bold">ダッシュボード</h1>
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="rounded-2xl border bg-white p-4 shadow-sm">
+          <div className="font-semibold mb-1">ようこそ</div>
+          <div className="text-gray-600 text-sm">{me?.name || me?.email}</div>
+        </div>
+        <a href="/groups" className="rounded-2xl border bg-white p-4 shadow-sm hover:shadow transition">
+          <div className="font-semibold mb-1">グループ</div>
+          <div className="text-gray-600 text-sm">作成 / 参加 / 一覧</div>
+        </a>
+        <a href="/groups/new" className="rounded-2xl border bg-white p-4 shadow-sm hover:shadow transition">
+          <div className="font-semibold mb-1">新しいグループ</div>
+          <div className="text-gray-600 text-sm">すぐに立ち上げ</div>
+        </a>
+      </div>
+    </div>
+  );
 }

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -3,22 +3,24 @@ import { readUserFromCookie } from '@/lib/auth';
 export default async function Header() {
   const me = await readUserFromCookie();
   return (
-    <header className="border-b">
-      <div className="mx-auto max-w-5xl px-4 h-12 flex items-center justify-between">
-        <a href="/" className="font-semibold">Lab Yoyaku</a>
-        <nav className="flex items-center gap-6 text-sm">
-          {me && <>
-            <a href="/">ダッシュボード</a>
-            <a href="/groups">グループ</a>
-            <span className="text-gray-500">{me.name || me.email}</span>
-            <form action="/api/auth/logout" method="post">
-              <button className="text-gray-600 hover:underline">ログアウト</button>
-            </form>
-          </>}
-          {!me && <a href="/login">ログイン</a>}
+    <header className="border-b bg-white/70 backdrop-blur supports-[backdrop-filter]:bg-white/60 sticky top-0 z-50">
+      <div className="mx-auto max-w-6xl px-4 h-12 flex items-center justify-between">
+        <a href="/" className="font-extrabold tracking-tight">Lab Yoyaku</a>
+        <nav className="flex items-center gap-3 text-sm">
+          {me ? (
+            <>
+              <a className="hover:underline" href="/">ダッシュボード</a>
+              <a className="hover:underline" href="/groups">グループ</a>
+              <span className="hidden sm:inline text-gray-500">/ {me.name || me.email}</span>
+              <form action="/api/auth/logout" method="post">
+                <button className="rounded-full px-3 py-1 border hover:bg-gray-50">ログアウト</button>
+              </form>
+            </>
+          ) : (
+            <a className="rounded-full px-3 py-1 border hover:bg-gray-50" href="/login">ログイン</a>
+          )}
         </nav>
       </div>
     </header>
   );
 }
-


### PR DESCRIPTION
## Summary
- redesign login and registration landing with tabs and success redirects
- apply casual header and simple dashboard home
- add lucide icons dependency

## Testing
- `npm --prefix web run lint`
- `npm --prefix web run typecheck` *(fails: Cannot find module 'lucide-react')*


------
https://chatgpt.com/codex/tasks/task_e_68aabfb069888323bd79d98473acdc9d