### PR TITLE
Simplify login flow and tidy dashboard

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -17,8 +17,7 @@
     "qrcode.react": "^3.1.0",
     "qrcode": "^1.5.3",
     "bcryptjs": "^2.4.3",
-    "jose": "^5.2.2",
-    "lucide-react": "^0.417.0"
+    "jose": "^5.2.2"
   },
   "devDependencies": {
     "@types/react": "18.2.21",

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,9 +1,26 @@
 'use client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
-import { LogIn, UserPlus } from 'lucide-react'; // npm i lucide-react
 
 type Tab = 'login' | 'register';
+
+// シンプルなインラインSVG（外部依存なし）
+const IconLogin = (props: any) => (
+  <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" {...props}>
+    <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
+    <path d="M10 17l5-5-5-5" />
+    <path d="M15 12H3" />
+  </svg>
+);
+
+const IconUserPlus = (props: any) => (
+  <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" {...props}>
+    <path d="M16 21v-2a4 4 0 0 0-4-4H7a4 4 0 0 0-4 4v2" />
+    <circle cx="9" cy="7" r="4" />
+    <path d="M19 8v6" />
+    <path d="M22 11h-6" />
+  </svg>
+);
 
 export default function LoginPage() {
   const router = useRouter();
@@ -26,15 +43,17 @@ export default function LoginPage() {
   const [loadingReg, setLoadingReg] = useState(false);
 
   async function submitLogin(e: React.FormEvent) {
-    e.preventDefault(); setLErr(''); setLoadingLogin(true);
+    e.preventDefault();
+    setLErr('');
+    setLoadingLogin(true);
     try {
       const res = await fetch('/api/auth/login', {
-        method:'POST', headers:{'Content-Type':'application/json'},
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email: lemail, password: lpass })
       });
       if (!res.ok) throw new Error();
-      // ✅ 成功したらホームへ（next があれば next、なければ /）
-      router.replace(next || '/');
+      router.replace(next || '/'); // ✅ 成功後ホームへ
     } catch {
       setLErr('メールまたはパスワードが違います');
     } finally {
@@ -43,20 +62,24 @@ export default function LoginPage() {
   }
 
   async function submitRegister(e: React.FormEvent) {
-    e.preventDefault(); setRErr('');
-    if (rpass !== rpass2) { setRErr('確認用パスワードが一致しません'); return; }
+    e.preventDefault();
+    setRErr('');
+    if (rpass !== rpass2) {
+      setRErr('確認用パスワードが一致しません');
+      return;
+    }
     setLoadingReg(true);
     try {
       const res = await fetch('/api/auth/register', {
-        method:'POST', headers:{'Content-Type':'application/json'},
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email: remail, password: rpass, name: rname })
       });
       if (!res.ok) {
         const t = await res.text();
         throw new Error(/already/.test(t) ? 'このメールは登録済みです' : '登録に失敗しました');
       }
-      // ✅ 成功したらホームへ
-      router.replace('/');
+      router.replace('/'); // ✅ 成功後ホームへ
     } catch (e: any) {
       setRErr(e?.message ?? '登録に失敗しました');
     } finally {
@@ -65,12 +88,12 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="min-h-[calc(100vh-48px)] bg-gradient-to-b from-sky-50 to-white">
+    <div className="min-h-[calc(100vh-48px)] bg-gradient-to-b from-sky-50 via-white to-white">
       <div className="mx-auto max-w-4xl px-4 py-12">
         {/* ヒーロー */}
-        <header className="text-center mb-8">
-          <h1 className="text-3xl font-extrabold tracking-tight">Lab Yoyaku へようこそ</h1>
-          <p className="text-gray-600 mt-2">
+        <header className="text-center mb-10">
+          <h1 className="text-4xl font-extrabold tracking-tight">Lab Yoyaku へようこそ</h1>
+          <p className="text-gray-600 mt-3">
             研究室の機器をグループで管理し、予約と使用状況をカレンダーで可視化。QRコードで機器ページへも即アクセス。
           </p>
         </header>
@@ -78,44 +101,55 @@ export default function LoginPage() {
         {/* 説明カード */}
         <div className="grid gap-4 md:grid-cols-3 mb-10">
           {[
-            {t:'① グループを作成', d:'研究室/班ごとに立ち上げ、メンバーを招待。'},
-            {t:'② グループに参加', d:'招待リンク/QRから参加。機器一覧とカレンダーを共有。'},
-            {t:'③ 機器登録 & 予約', d:'機器ごとにQR発行、予約・使用中がすぐ分かる。'},
-          ].map((c,i)=>(
-            <div key={i} className="rounded-2xl border shadow-sm bg-white p-4">
+            { t: '① グループを作成', d: '研究室/班ごとに立ち上げ、メンバーを招待。' },
+            { t: '② グループに参加', d: '招待リンク/QRから参加。機器一覧とカレンダーを共有。' },
+            { t: '③ 機器登録 & 予約', d: '機器ごとにQR発行、予約・使用中がすぐ分かる。' }
+          ].map((c, i) => (
+            <div key={i} className="rounded-2xl border shadow-sm bg-white p-5 hover:shadow-md transition">
               <div className="font-semibold mb-1">{c.t}</div>
               <div className="text-sm text-gray-600">{c.d}</div>
             </div>
           ))}
         </div>
 
-        {/* タブ */}
+        {/* タブ＋フォーム */}
         <div className="mx-auto max-w-xl bg-white rounded-2xl border shadow-sm p-6">
           <div className="inline-flex rounded-full bg-gray-100 p-1 mb-6">
             <button
-              className={`px-4 py-2 rounded-full text-sm transition ${
-                tab==='login' ? 'bg-white shadow-sm font-semibold' : 'text-gray-500'
-              }`}
-              onClick={()=>setTab('login')}
+              className={`px-4 py-2 rounded-full text-sm transition ${tab === 'login' ? 'bg-white shadow-sm font-semibold' : 'text-gray-500'}`}
+              onClick={() => setTab('login')}
             >
-              <span className="inline-flex items-center gap-2"><LogIn size={16}/> ログイン</span>
+              <span className="inline-flex items-center gap-2">
+                <IconLogin /> ログイン
+              </span>
             </button>
             <button
-              className={`px-4 py-2 rounded-full text-sm transition ${
-                tab==='register' ? 'bg-white shadow-sm font-semibold' : 'text-gray-500'
-              }`}
-              onClick={()=>setTab('register')}
+              className={`px-4 py-2 rounded-full text-sm transition ${tab === 'register' ? 'bg-white shadow-sm font-semibold' : 'text-gray-500'}`}
+              onClick={() => setTab('register')}
             >
-              <span className="inline-flex items-center gap-2"><UserPlus size={16}/> 新規作成</span>
+              <span className="inline-flex items-center gap-2">
+                <IconUserPlus /> 新規作成
+              </span>
             </button>
           </div>
 
-          {tab==='login' && (
+          {tab === 'login' && (
             <form onSubmit={submitLogin} className="space-y-3">
-              <input className="w-full rounded-xl border px-3 py-2" placeholder="メールアドレス"
-                     value={lemail} onChange={e=>setLEmail(e.target.value)} required />
-              <input className="w-full rounded-xl border px-3 py-2" type="password" placeholder="パスワード"
-                     value={lpass} onChange={e=>setLPass(e.target.value)} required />
+              <input
+                className="w-full rounded-xl border border-gray-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-sky-500"
+                placeholder="メールアドレス"
+                value={lemail}
+                onChange={e => setLEmail(e.target.value)}
+                required
+              />
+              <input
+                className="w-full rounded-xl border border-gray-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-sky-500"
+                type="password"
+                placeholder="パスワード"
+                value={lpass}
+                onChange={e => setLPass(e.target.value)}
+                required
+              />
               {lerr && <div className="text-sm text-red-600">{lerr}</div>}
               <button
                 className="w-full rounded-xl bg-sky-600 text-white px-4 py-2 font-semibold hover:bg-sky-700 transition disabled:opacity-60"
@@ -123,20 +157,43 @@ export default function LoginPage() {
               >
                 {loadingLogin ? 'ログイン中…' : 'ログイン'}
               </button>
-              <p className="text-xs text-gray-500 text-center">デモ: <b>demo / demo</b> でもログインできます。</p>
+              <p className="text-xs text-gray-500 text-center">
+                デモ: <b>demo / demo</b> でもログインできます。
+              </p>
             </form>
           )}
 
-          {tab==='register' && (
+          {tab === 'register' && (
             <form onSubmit={submitRegister} className="space-y-3">
-              <input className="w-full rounded-xl border px-3 py-2" placeholder="表示名（任意）"
-                     value={rname} onChange={e=>setRName(e.target.value)} />
-              <input className="w-full rounded-xl border px-3 py-2" placeholder="メールアドレス"
-                     value={remail} onChange={e=>setREmail(e.target.value)} required />
-              <input className="w-full rounded-xl border px-3 py-2" type="password" placeholder="パスワード（6文字以上）"
-                     value={rpass} onChange={e=>setRPass(e.target.value)} required />
-              <input className="w-full rounded-xl border px-3 py-2" type="password" placeholder="パスワード（確認）"
-                     value={rpass2} onChange={e=>setRPass2(e.target.value)} required />
+              <input
+                className="w-full rounded-xl border border-gray-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                placeholder="表示名（任意）"
+                value={rname}
+                onChange={e => setRName(e.target.value)}
+              />
+              <input
+                className="w-full rounded-xl border border-gray-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                placeholder="メールアドレス"
+                value={remail}
+                onChange={e => setREmail(e.target.value)}
+                required
+              />
+              <input
+                className="w-full rounded-xl border border-gray-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                type="password"
+                placeholder="パスワード（6文字以上）"
+                value={rpass}
+                onChange={e => setRPass(e.target.value)}
+                required
+              />
+              <input
+                className="w-full rounded-xl border border-gray-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                type="password"
+                placeholder="パスワード（確認）"
+                value={rpass2}
+                onChange={e => setRPass2(e.target.value)}
+                required
+              />
               {rerr && <div className="text-sm text-red-600">{rerr}</div>}
               <button
                 className="w-full rounded-xl bg-indigo-600 text-white px-4 py-2 font-semibold hover:bg-indigo-700 transition disabled:opacity-60"
@@ -151,3 +208,4 @@ export default function LoginPage() {
     </div>
   );
 }
+

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -3,18 +3,18 @@ import { readUserFromCookie } from '@/lib/auth';
 export default async function Home() {
   const me = await readUserFromCookie();
   return (
-    <div className="mx-auto max-w-5xl px-4 py-8 space-y-6">
+    <div className="mx-auto max-w-6xl px-4 py-10 space-y-6">
       <h1 className="text-2xl font-bold">ダッシュボード</h1>
       <div className="grid gap-4 md:grid-cols-3">
-        <div className="rounded-2xl border bg-white p-4 shadow-sm">
+        <div className="rounded-2xl border bg-white p-5 shadow-sm">
           <div className="font-semibold mb-1">ようこそ</div>
           <div className="text-gray-600 text-sm">{me?.name || me?.email}</div>
         </div>
-        <a href="/groups" className="rounded-2xl border bg-white p-4 shadow-sm hover:shadow transition">
+        <a href="/groups" className="rounded-2xl border bg-white p-5 shadow-sm hover:shadow-md transition">
           <div className="font-semibold mb-1">グループ</div>
           <div className="text-gray-600 text-sm">作成 / 参加 / 一覧</div>
         </a>
-        <a href="/groups/new" className="rounded-2xl border bg-white p-4 shadow-sm hover:shadow transition">
+        <a href="/groups/new" className="rounded-2xl border bg-white p-5 shadow-sm hover:shadow-md transition">
           <div className="font-semibold mb-1">新しいグループ</div>
           <div className="text-gray-600 text-sm">すぐに立ち上げ</div>
         </a>


### PR DESCRIPTION
## Summary
- replace login page with lightweight SVG icons and improved UX
- polish dashboard layout spacing and shadows
- remove lucide-react dependency

## Testing
- `npm --prefix web run lint`
- `npm --prefix web run build`


------
https://chatgpt.com/codex/tasks/task_e_68aac23131d48323823a835f4a57508e