### PR TITLE
Add login guard middleware and user dashboard

### DIFF
--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -1,28 +1,32 @@
-import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
 
-export async function middleware(req: NextRequest) {
-  const { pathname } = req.nextUrl;
+export function middleware(req: NextRequest) {
+  const { pathname, search } = req.nextUrl;
 
-  // /login と /api/auth/* は誰でもOK
-  if (pathname.startsWith('/login') || pathname.startsWith('/api/auth')) {
-    return NextResponse.next();
-  }
-  // Next 静的リソースは除外
-  if (pathname.startsWith('/_next') || pathname.startsWith('/favicon')) {
+  // 許可ルート
+  if (
+    pathname.startsWith('/login') ||
+    pathname.startsWith('/api/auth') ||
+    pathname.startsWith('/_next') ||
+    pathname.startsWith('/favicon') ||
+    pathname.startsWith('/public')
+  ) {
     return NextResponse.next();
   }
 
   const token = req.cookies.get('labyoyaku_token')?.value;
   if (!token) {
     const url = new URL('/login', req.url);
-    url.searchParams.set('next', pathname);
+    // 直前の遷移先（ホーム含む）を next で保持
+    const next = pathname + (search || '');
+    url.searchParams.set('next', next || '/');
     return NextResponse.redirect(url);
   }
   return NextResponse.next();
 }
 
 export const config = {
-  matcher: ['/((?!_next|favicon).*)'],
+  matcher: ['/((?!_next|favicon|public).*)'],
 };
 

--- a/web/src/app/api/me/reservations/route.ts
+++ b/web/src/app/api/me/reservations/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { readUserFromCookie } from '@/lib/auth';
+import { loadDB } from '@/lib/mockdb';
+
+export async function GET() {
+  const me = await readUserFromCookie();
+  if (!me) return NextResponse.json({ ok:false, error:'unauthorized' }, { status:401 });
+
+  const db = loadDB();
+  // 予約の user は「メール」想定（以前のモックが表示名ならそちらに揃えてOK）
+  const mine = db.groups.flatMap(g =>
+    g.reservations
+      .filter(r => r.user === me.email || r.user === me.name)
+      .map(r => ({ ...r, groupSlug: g.slug, groupName: g.name }))
+  );
+
+  return NextResponse.json({ ok:true, data: mine });
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,26 +1,113 @@
 import { readUserFromCookie } from '@/lib/auth';
+import { redirect } from 'next/navigation';
 
-const card =
-  'rounded-xl border border-gray-200 bg-white p-5 shadow-sm hover:shadow transition';
+type Mine = {
+  id: string; deviceId: string; user: string; start: string; end: string;
+  purpose?: string; groupSlug: string; groupName: string;
+};
+
+function format(dt: string) {
+  const d = new Date(dt);
+  return `${d.getMonth()+1}/${d.getDate()} ${d.getHours().toString().padStart(2,'0')}:${d.getMinutes().toString().padStart(2,'0')}`;
+}
+
+function getMonthMatrix(base = new Date()) {
+  const y = base.getFullYear(), m = base.getMonth();
+  const first = new Date(y, m, 1);
+  const start = new Date(first); start.setDate(first.getDate() - ((first.getDay()+6)%7)); // 月曜始まり
+  const weeks: Date[][] = [];
+  for (let w=0; w<6; w++) {
+    const row: Date[] = [];
+    for (let i=0;i<7;i++) { row.push(new Date(start)); start.setDate(start.getDate()+1); }
+    weeks.push(row);
+  }
+  return { weeks, month: m };
+}
 
 export default async function Home() {
   const me = await readUserFromCookie();
+  if (!me) redirect('/login?next=/');
+
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000'}/api/me/reservations`, { cache:'no-store' });
+  const json = await res.json();
+  const mine: Mine[] = (json?.data ?? []) as Mine[];
+
+  // 直近順
+  mine.sort((a,b)=> new Date(a.start).getTime() - new Date(b.start).getTime());
+  const upcoming = mine.filter(r => new Date(r.end) >= new Date()).slice(0, 6);
+
+  // カレンダー印用の yyyy-mm-dd セット
+  const mark = new Set(
+    mine.map(r => new Date(r.start))
+        .map(d => `${d.getFullYear()}-${(d.getMonth()+1).toString().padStart(2,'0')}-${d.getDate().toString().padStart(2,'0')}`)
+  );
+
+  const { weeks, month } = getMonthMatrix(new Date());
+
+  const card = "rounded-xl border border-gray-200 bg-white p-5 shadow-sm";
   return (
-    <div className="mx-auto max-w-5xl px-4 py-10 space-y-6">
-      <h1 className="text-2xl font-bold">ダッシュボード</h1>
-      <div className="grid gap-4 md:grid-cols-3">
-        <div className={card}>
-          <div className="text-sm text-gray-500">ようこそ</div>
-          <div className="mt-1 font-medium">{me?.name || me?.email}</div>
+    <div className="mx-auto max-w-6xl px-4 py-8 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">ダッシュボード</h1>
+        <div className="flex gap-2">
+          <a href="/groups/new" className="rounded-lg border px-3 py-2 hover:bg-gray-50">グループ作成</a>
+          <a href="/groups/join" className="rounded-lg border px-3 py-2 hover:bg-gray-50">グループ参加</a>
         </div>
-        <a href="/groups" className={card}>
-          <div className="font-medium">グループ</div>
-          <div className="text-sm text-gray-500 mt-1">作成 / 参加 / 一覧</div>
-        </a>
-        <a href="/groups/new" className={card}>
-          <div className="font-medium">新しいグループ</div>
-          <div className="text-sm text-gray-500 mt-1">すぐに立ち上げ</div>
-        </a>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-3">
+        {/* 直近の予約 */}
+        <section className={`md:col-span-2 ${card}`}>
+          <div className="flex items-center justify-between mb-3">
+            <div className="font-medium">直近の自分の予約</div>
+            <a className="text-sm text-gray-500 hover:underline" href="/groups">すべてのグループへ</a>
+          </div>
+
+          {!upcoming.length && (
+            <div className="text-gray-500 text-sm">直近の予約はありません。右上の「グループ参加」から始めましょう。</div>
+          )}
+
+          <ul className="divide-y">
+            {upcoming.map(r => (
+              <li key={r.id} className="py-3 flex items-start gap-3">
+                <div className="mt-1 h-2.5 w-2.5 rounded-full bg-black/80" />
+                <div className="flex-1">
+                  <div className="text-sm text-gray-600">
+                    {format(r.start)} – {format(r.end)} （{r.groupName}）
+                  </div>
+                  <div className="font-medium">機器: {r.deviceId}</div>
+                  {r.purpose && <div className="text-sm text-gray-500">用途: {r.purpose}</div>}
+                </div>
+                <a className="text-sm text-gray-500 hover:underline" href={`/groups/${r.groupSlug}`}>詳細</a>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* ミニカレンダー */}
+        <section className={card}>
+          <div className="font-medium mb-3">
+            今月の予定 <span className="text-gray-400 text-sm">({month+1}月)</span>
+          </div>
+          <div className="grid grid-cols-7 text-center text-xs text-gray-500 mb-2">
+            {['月','火','水','木','金','土','日'].map(d => <div key={d} className="py-1">{d}</div>)}
+          </div>
+          <div className="grid grid-cols-7 gap-1">
+            {weeks.flat().map((d,i) => {
+              const inMonth = d.getMonth() === month;
+              const key = `${d.getFullYear()}-${(d.getMonth()+1).toString().padStart(2,'0')}-${d.getDate().toString().padStart(2,'0')}`;
+              const has = mark.has(key);
+              return (
+                <div key={i} className={`h-12 rounded-lg border text-sm flex items-center justify-center ${inMonth ? '' : 'bg-gray-50 text-gray-400'}`}>
+                  <div className="relative">
+                    {d.getDate()}
+                    {has && <span className="absolute -right-2 -top-1 inline-block h-1.5 w-1.5 rounded-full bg-black" />}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </section>
       </div>
     </div>
   );

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -4,7 +4,7 @@ export default async function Header() {
   const me = await readUserFromCookie();
   return (
     <header className="border-b bg-white">
-      <div className="mx-auto max-w-5xl px-4 h-12 flex items-center justify-between">
+      <div className="mx-auto max-w-6xl px-4 h-12 flex items-center justify-between">
         <a href="/" className="font-semibold tracking-tight">Lab Yoyaku</a>
         <nav className="flex items-center gap-4 text-sm">
           {me ? (
@@ -17,7 +17,10 @@ export default async function Header() {
               </form>
             </>
           ) : (
-            <a className="rounded border px-3 py-1 hover:bg-gray-50" href="/login">ログイン</a>
+            <>
+              <a className="rounded border px-3 py-1 hover:bg-gray-50" href="/login?tab=login">ログイン</a>
+              <a className="rounded border px-3 py-1 hover:bg-gray-50" href="/login?tab=register">新規作成</a>
+            </>
           )}
         </nav>
       </div>


### PR DESCRIPTION
## Summary
- Enforce authentication across site via Next.js middleware
- Add API endpoint to fetch current user's reservations
- Implement dashboard showing upcoming reservations and mini calendar
- Refresh header with login/register links and wider layout

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aaf4de046c83238acd6e999af8c026