### PR TITLE
refactor: split calendar client component

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,12 +1,13 @@
 import { readUserFromCookie } from '@/lib/auth';
 import { redirect } from 'next/navigation';
+import CalendarWithBars, { Span } from '@/components/CalendarWithBars';
 
-/* ---------- 型 & ユーティリティ ---------- */
 type Mine = {
-  id: string; deviceId: string; deviceName?: string; user: string;
-  start: string; end: string; purpose?: string; groupSlug: string; groupName: string;
+  id:string; deviceId:string; deviceName?:string; user:string;
+  start:string; end:string; purpose?:string; groupSlug:string; groupName:string;
 };
-const pad = (n:number)=>n.toString().padStart(2,'0');
+
+const pad = (n:number)=> n.toString().padStart(2,'0');
 const fmtRange = (s:string,e:string)=>{
   const S=new Date(s), E=new Date(e);
   const same = S.toDateString()===E.toDateString();
@@ -17,25 +18,23 @@ const fmtRange = (s:string,e:string)=>{
 function buildMonth(base=new Date()){
   const y=base.getFullYear(), m=base.getMonth();
   const first = new Date(y,m,1);
-  const start = new Date(first); start.setDate(first.getDate()-((first.getDay()+6)%7)); // 月曜はじまり
-  const weeks: Date[][]=[]; for(let w=0;w<6;w++){ const row:Date[]=[]; for(let i=0;i<7;i++){ row.push(new Date(start)); start.setDate(start.getDate()+1);} weeks.push(row);}
-  return { weeks, month:m, year:y };
+  const start = new Date(first); start.setDate(first.getDate()-((first.getDay()+6)%7));
+  const weeks: Date[][]=[]; for(let w=0;w<6;w++){ const row:Date[]=[]; for(let i=0;i<7;i++){ row.push(new Date(start)); start.setDate(start.getDate()+1);} weeks.push(row); }
+  return { weeks, month:m };
 }
-/* 機器ごとに安定カラー */
 function colorFromString(s:string){
   const palette=['#2563eb','#16a34a','#f59e0b','#ef4444','#7c3aed','#0ea5e9','#f97316','#14b8a6'];
   let h=0; for(let i=0;i<s.length;i++) h=(h*31+s.charCodeAt(i))>>>0;
   return palette[h%palette.length];
 }
-const short = (s:string,len=8)=> s.length<=len ? s : s.slice(0,len-1)+'…';
+const short = (s:string,len=10)=> s.length<=len ? s : s.slice(0,len-1)+'…';
 
-/* ---------- サーバーコンポーネント ---------- */
 export default async function Home() {
   const me = await readUserFromCookie();
   if (!me) redirect('/login?next=/');
 
   const base = process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000';
-  const res  = await fetch(`${base}/api/me/reservations`, { cache:'no-store' });
+  const res = await fetch(`${base}/api/me/reservations`, { cache:'no-store' });
   const mine: Mine[] = (await res.json()).data ?? [];
   mine.sort((a,b)=> new Date(a.start).getTime() - new Date(b.start).getTime());
 
@@ -43,17 +42,18 @@ export default async function Home() {
   const upcoming = mine.filter(r=> new Date(r.end)>=now).slice(0,10);
   const { weeks, month } = buildMonth(now);
 
-  // カレンダー帯用（当月にかかる自分の予約）
-  const spans = mine.map(r => ({
-    id:r.id, name:r.deviceName ?? r.deviceId,
-    start:new Date(r.start), end:new Date(r.end),
-    color: colorFromString(r.deviceId), groupSlug:r.groupSlug
+  const spans: Span[] = mine.map(r=>({
+    id:r.id,
+    name:r.deviceName ?? r.deviceId,
+    start:new Date(r.start),
+    end:new Date(r.end),
+    color: colorFromString(r.deviceId),
+    groupSlug: r.groupSlug
   }));
 
-  // レジェンド（機器名→色）
   const legend = Array.from(new Map(spans.map(s=>[s.name, s.color])).entries());
-
   const card = "rounded-xl border border-gray-200 bg-white p-5 shadow-sm";
+
   return (
     <div className="mx-auto max-w-6xl px-4 py-8 space-y-6">
       <div className="flex items-center justify-between">
@@ -65,7 +65,6 @@ export default async function Home() {
       </div>
 
       <div className="grid gap-6 md:grid-cols-3">
-        {/* 直近の自分の予約（機器名・時間・用途） */}
         <section className={`md:col-span-2 ${card}`}>
           <div className="flex items-center justify-between mb-3">
             <div className="font-medium">直近の自分の予約</div>
@@ -89,123 +88,21 @@ export default async function Home() {
           </ul>
         </section>
 
-        {/* 今月の予定（帯＋クリックで詳細） */}
         <section className={card}>
-          <CalendarWithBars weeks={weeks} month={month} spans={spans} />
-          {/* レジェンド */}
+          <CalendarWithBars weeks={weeks} month={month} spans={spans}/>
           {legend.length>0 && (
             <div className="mt-4">
               <div className="text-xs text-gray-500 mb-1">色の対応</div>
               <div className="flex flex-wrap gap-3">
                 {legend.map(([name,color])=>(
                   <span key={name} className="inline-flex items-center gap-1.5 text-sm">
-                    <i className="inline-block h-2.5 w-2.5 rounded-full" style={{backgroundColor:color}}/> {short(name,10)}
+                    <i className="inline-block h-2.5 w-2.5 rounded-full" style={{backgroundColor:color}}/> {short(name)}
                   </span>
                 ))}
               </div>
             </div>
           )}
         </section>
-      </div>
-    </div>
-  );
-}
-
-/* ---------- クライアント部：帯＋モーダル ---------- */
-'use client';
-import { useMemo, useState } from 'react';
-function strip(d:Date){ return new Date(d.getFullYear(),d.getMonth(),d.getDate()); }
-function add(d:Date,n:number){ const x=new Date(d); x.setDate(x.getDate()+n); return x; }
-function overlaps(day:Date, s:Date, e:Date){ return day>=strip(s) && day<strip(add(e,1)); }
-
-type Span = { id:string; name:string; start:Date; end:Date; color:string; groupSlug:string };
-
-function CalendarWithBars({ weeks, month, spans }:{
-  weeks: Date[][]; month:number; spans: Span[];
-}){
-  const [sel, setSel] = useState<Date|null>(null);
-
-  // 各セルに、その日に関係する予約
-  const map = useMemo(()=>{
-    const m = new Map<string, Span[]>();
-    weeks.flat().forEach(d=>{
-      const key=d.toDateString();
-      m.set(key, spans.filter(s=>overlaps(d,s.start,s.end)));
-    });
-    return m;
-  },[weeks,spans]);
-
-  return (
-    <>
-      <div className="font-medium mb-3">今月の予定 <span className="text-gray-400 text-sm">({month+1}月)</span></div>
-      <div className="grid grid-cols-7 text-center text-xs text-gray-500 mb-2">
-        {['月','火','水','木','金','土','日'].map(d=><div key={d} className="py-1">{d}</div>)}
-      </div>
-
-      <div className="grid grid-cols-7 gap-1">
-        {weeks.flat().map((d,i)=>{
-          const inMonth = d.getMonth()===month;
-          const todays = map.get(d.toDateString()) ?? [];
-          return (
-            <button
-              key={i}
-              className={`h-16 rounded-lg border relative text-left px-1 ${inMonth?'bg-white':'bg-gray-50 text-gray-400'}`}
-              onClick={()=>setSel(d)}
-              title={`${d.getMonth()+1}/${d.getDate()}`}
-            >
-              <div className="absolute right-1 top-1 text-xs">{d.getDate()}</div>
-
-              {/* 帯（最大2本、テキスト付き） */}
-              <div className="absolute left-1 right-1 bottom-2 space-y-1">
-                {todays.slice(0,2).map((s)=>(
-                  <div key={s.id} className="h-4 rounded-sm flex items-center px-1"
-                       style={{backgroundColor:s.color, color:'#fff'}}>
-                    <span className="text-[10px] leading-none truncate">{short(s.name,8)}</span>
-                  </div>
-                ))}
-                {todays.length>2 && <div className="text-[10px] text-gray-500">+{todays.length-2}</div>}
-              </div>
-            </button>
-          );
-        })}
-      </div>
-
-      {/* モーダル：その日の一覧 */}
-      {sel && (
-        <DayModal
-          date={sel}
-          items={(map.get(sel.toDateString()) ?? []).sort((a,b)=>a.start.getTime()-b.start.getTime())}
-          onClose={()=>setSel(null)}
-        />
-      )}
-    </>
-  );
-}
-
-function DayModal({ date, items, onClose }:{
-  date:Date; items:Span[]; onClose:()=>void;
-}){
-  const t = (d:Date)=>`${pad(d.getHours())}:${pad(d.getMinutes())}`;
-  return (
-    <div className="fixed inset-0 bg-black/30 flex items-end sm:items-center justify-center z-50">
-      <div className="bg-white rounded-t-2xl sm:rounded-2xl shadow-lg w-full max-w-lg p-5">
-        <div className="flex items-center justify-between mb-3">
-          <div className="font-semibold">{date.getMonth()+1}月{date.getDate()}日の予約</div>
-          <button onClick={onClose} className="text-sm text-gray-500 hover:underline">閉じる</button>
-        </div>
-        {!items.length && <div className="text-sm text-gray-500">この日の予約はありません。</div>}
-        <ul className="space-y-2">
-          {items.map((s)=>(
-            <li key={s.id} className="rounded-lg border p-3">
-              <div className="flex items-center gap-2">
-                <span className="inline-block h-2.5 w-2.5 rounded-full" style={{backgroundColor:s.color}}/>
-                <div className="font-medium">{s.name}</div>
-              </div>
-              <div className="text-sm text-gray-600 mt-1">{t(s.start)} – {t(s.end)}</div>
-              <a href={`/groups/${s.groupSlug}`} className="text-sm text-gray-500 hover:underline mt-1 inline-block">グループページへ</a>
-            </li>
-          ))}
-        </ul>
       </div>
     </div>
   );

--- a/web/src/components/CalendarWithBars.tsx
+++ b/web/src/components/CalendarWithBars.tsx
@@ -1,70 +1,40 @@
 'use client';
-
 import { useMemo, useState } from 'react';
 
-export type Span = {
-  id:string; deviceName:string; start:Date; end:Date; color:string; groupSlug:string;
-};
+export type Span = { id:string; name:string; start:Date; end:Date; color:string; groupSlug:string };
 
-function overlaps(d:Date, s:Date, e:Date){ // [s,e) と d の重なり
-  return d >= stripTime(s) && d < stripTime(addDays(e,1));
-}
-function stripTime(d:Date){ return new Date(d.getFullYear(), d.getMonth(), d.getDate()); }
-function addDays(d:Date, n:number){ const x=new Date(d); x.setDate(x.getDate()+n); return x; }
-function timeStr(d:Date){ return `${d.getHours().toString().padStart(2,'0')}:${d.getMinutes().toString().padStart(2,'0')}`; }
+function strip(d:Date){ return new Date(d.getFullYear(),d.getMonth(),d.getDate()); }
+function add(d:Date,n:number){ const x=new Date(d); x.setDate(x.getDate()+n); return x; }
+function overlaps(day:Date, s:Date, e:Date){ return day>=strip(s) && day<strip(add(e,1)); }
+const pad = (n:number)=> n.toString().padStart(2,'0');
+const t = (d:Date)=>`${pad(d.getHours())}:${pad(d.getMinutes())}`;
+const short = (s:string,len=8)=> s.length<=len ? s : s.slice(0,len-1)+'…';
 
-function DayModal({ date, items, onClose }:{
-  date: Date; items: Span[]; onClose: ()=>void;
-}){
-  return (
-    <div className="fixed inset-0 bg-black/30 flex items-end sm:items-center justify-center z-50">
-      <div className="bg-white rounded-t-2xl sm:rounded-2xl shadow-lg w-full max-w-lg p-5">
-        <div className="flex items-center justify-between mb-3">
-          <div className="font-semibold">{date.getMonth()+1}月{date.getDate()}日の予約</div>
-          <button className="text-sm text-gray-500 hover:underline" onClick={onClose}>閉じる</button>
-        </div>
-        {!items.length && <div className="text-sm text-gray-500">この日の予約はありません。</div>}
-        <ul className="space-y-2">
-          {items.map((s)=>(
-            <li key={s.id} className="rounded-lg border p-3">
-              <div className="flex items-center gap-2">
-                <span className="inline-block h-2.5 w-2.5 rounded-full" style={{backgroundColor:s.color}} />
-                <div className="font-medium">{s.deviceName}</div>
-              </div>
-              <div className="text-sm text-gray-600 mt-1">
-                {timeStr(s.start)} – {timeStr(s.end)}
-              </div>
-              <a className="text-sm text-gray-500 hover:underline mt-1 inline-block" href={`/groups/${s.groupSlug}`}>グループページへ</a>
-            </li>
-          ))}
-        </ul>
-      </div>
-    </div>
-  );
-}
+export default function CalendarWithBars({
+  weeks, month, spans,
+}:{
+  weeks: Date[][];
+  month: number;
+  spans: Span[];
+}) {
+  const [sel, setSel] = useState<Date|null>(null);
 
-export default function CalendarWithBars({ weeks, month, spans }:{
-  weeks: Date[][]; month: number; spans: Span[];
-}){
-  const [selected, setSelected] = useState<Date|null>(null);
-
-  // 日付 → その日に関係する予約
-  const map = useMemo(()=> {
+  const map = useMemo(()=>{
     const m = new Map<string, Span[]>();
     weeks.flat().forEach(d=>{
-      const key = d.toDateString();
-      const arr = spans.filter(s => overlaps(d, s.start, s.end));
-      m.set(key, arr);
+      const key=d.toDateString();
+      m.set(key, spans.filter(s=>overlaps(d,s.start,s.end)));
     });
     return m;
-  }, [weeks, spans]);
+  },[weeks,spans]);
 
   return (
     <>
       <div className="font-medium mb-3">今月の予定 <span className="text-gray-400 text-sm">({month+1}月)</span></div>
       <div className="grid grid-cols-7 text-center text-xs text-gray-500 mb-2">
-        {['月','火','水','木','金','土','日'].map(d => <div key={d} className="py-1">{d}</div>)}
+        {['月','火','水','木','金','土','日'].map(d=><div key={d} className="py-1">{d}</div>)}
       </div>
+
       <div className="grid grid-cols-7 gap-1">
         {weeks.flat().map((d,i)=>{
           const inMonth = d.getMonth()===month;
@@ -72,36 +42,63 @@ export default function CalendarWithBars({ weeks, month, spans }:{
           return (
             <button
               key={i}
-              className={`h-16 rounded-lg border text-sm relative text-left px-1 ${inMonth? 'bg-white': 'bg-gray-50 text-gray-400'}`}
-              onClick={()=> setSelected(d)}
+              className={`h-16 rounded-lg border relative text-left px-1 ${inMonth?'bg-white':'bg-gray-50 text-gray-400'}`}
+              onClick={()=>setSel(d)}
+              title={`${d.getMonth()+1}/${d.getDate()}`}
             >
               <div className="absolute right-1 top-1 text-xs">{d.getDate()}</div>
-              {/* 帯（最大3本表示、超過は…） */}
-              <div className="absolute left-1 right-1 bottom-1 space-y-1">
-                {todays.slice(0,3).map((s,idx)=>(
-                  <div
-                    key={s.id+idx}
-                    className="h-1.5 rounded-sm"
-                    style={{ backgroundColor: s.color }}
-                    title={s.deviceName}
-                  />
+              <div className="absolute left-1 right-1 bottom-2 space-y-1">
+                {todays.slice(0,2).map((s)=>(
+                  <div key={s.id} className="h-4 rounded-sm flex items-center px-1"
+                       style={{backgroundColor:s.color, color:'#fff'}}>
+                    <span className="text-[10px] leading-none truncate">{short(s.name,8)}</span>
+                  </div>
                 ))}
-                {todays.length>3 && <div className="text-[10px] text-gray-400">+{todays.length-3}</div>}
+                {todays.length>2 && <div className="text-[10px] text-gray-500">+{todays.length-2}</div>}
               </div>
             </button>
           );
         })}
       </div>
 
-      {/* モーダル：その日の予約詳細 */}
-      {selected && (
+      {sel && (
         <DayModal
-          date={selected}
-          items={(map.get(selected.toDateString()) ?? []).sort((a,b)=>a.start.getTime()-b.start.getTime())}
-          onClose={()=>setSelected(null)}
+          date={sel}
+          items={(map.get(sel.toDateString()) ?? []).sort((a,b)=>a.start.getTime()-b.start.getTime())}
+          onClose={()=>setSel(null)}
         />
       )}
     </>
+  );
+}
+
+function DayModal({ date, items, onClose }:{
+  date:Date; items:Span[]; onClose:()=>void;
+}){
+  return (
+    <div className="fixed inset-0 bg-black/30 flex items-end sm:items-center justify-center z-50">
+      <div className="bg-white rounded-t-2xl sm:rounded-2xl shadow-lg w-full max-w-lg p-5">
+        <div className="flex items-center justify-between mb-3">
+          <div className="font-semibold">{date.getMonth()+1}月{date.getDate()}日の予約</div>
+          <button onClick={onClose} className="text-sm text-gray-500 hover:underline">閉じる</button>
+        </div>
+        {!items.length && <div className="text-sm text-gray-500">この日の予約はありません。</div>}
+        <ul className="space-y-2">
+          {items.map((s)=>(
+            <li key={s.id} className="rounded-lg border p-3">
+              <div className="flex items-center gap-2">
+                <span className="inline-block h-2.5 w-2.5 rounded-full" style={{backgroundColor:s.color}}/>
+                <div className="font-medium">{s.name}</div>
+              </div>
+              <div className="text-sm text-gray-600 mt-1">{t(s.start)} – {t(s.end)}</div>
+              <a href={`/groups/${s.groupSlug}`} className="text-sm text-gray-500 hover:underline mt-1 inline-block">
+                グループページへ
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- split CalendarWithBars into client-side component
- remove inline client code from Home page and import CalendarWithBars

## Testing
- `npm --prefix web run lint`
- `npm --prefix web run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ac5301e27083238d2638dee0021768