### PR TITLE
feat: refine layout and calendar

### DIFF
--- a/web/src/app/_parts/HomeDashboard.tsx
+++ b/web/src/app/_parts/HomeDashboard.tsx
@@ -6,7 +6,7 @@ export default async function HomeDashboard() {
   const reservations = res.ok ? (res.data as any[]) : []
 
   return (
-    <main className="mx-auto max-w-[1040px] px-4 sm:px-6 py-10 space-y-8">
+    <main className="mx-auto max-w-6xl px-6 py-10 space-y-8">
       <h1 className="text-2xl font-bold">ホーム</h1>
 
       <section className="space-y-3">
@@ -33,7 +33,7 @@ export default async function HomeDashboard() {
       </section>
 
       <section className="space-x-3">
-        <Link className="px-3 py-2 rounded bg-black text-white" href="/groups/new">グループを作成</Link>
+        <Link className="px-3 py-2 rounded bg-indigo-600 hover:bg-indigo-700 text-white" href="/groups/new">グループを作成</Link>
         <Link className="px-3 py-2 rounded border" href="/groups/join">グループに参加</Link>
         <Link className="px-3 py-2 rounded border" href="/dashboard">ダッシュボード</Link>
         <Link className="px-3 py-2 rounded border" href="/groups">グループ一覧</Link>

--- a/web/src/app/api/me/reservations/route.ts
+++ b/web/src/app/api/me/reservations/route.ts
@@ -7,9 +7,10 @@ export async function GET() {
   if (!me) return NextResponse.json({ ok:false }, { status:401 });
 
   const db = loadDB();
-  const mine = db.groups.flatMap(g =>
-    g.reservations
-      .filter(r => r.user === me.email || r.user === me.name)
+  const isMe = (v?: string) => v === me.email || v === me.name;
+  const mine = db.groups.flatMap(g => {
+    return g.reservations
+      .filter(r => isMe(r.user) || (Array.isArray(r.participants) && r.participants.some(isMe)))
       .map(r => {
         const dev = g.devices.find(d => d.id === r.deviceId);
         return {
@@ -18,8 +19,8 @@ export async function GET() {
           groupSlug: g.slug,
           groupName: g.name,
         };
-      })
-  );
+      });
+  });
 
   return NextResponse.json({ ok:true, data: mine });
 }

--- a/web/src/app/api/mock/reservations/route.ts
+++ b/web/src/app/api/mock/reservations/route.ts
@@ -40,13 +40,37 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   const body = await req.json();
-  const { slug, deviceId, start, end, reserver, title, scope, memberId } = body;
+  const {
+    slug,
+    deviceId,
+    start,
+    end,
+    user,
+    reserver,
+    title,
+    scope,
+    memberId,
+    participants: pBody,
+  } = body;
   const g = db.groups.find((x) => x.slug === slug);
   if (!g) return NextResponse.json({ ok: false, error: 'group not found' }, { status: 404 });
   if (!g.devices.find((d) => d.id === deviceId)) {
     return NextResponse.json({ ok: false, error: 'unknown device' }, { status: 400 });
   }
-  const r = { id: uuid(), deviceId, start, end, reserver, title, scope: scope ?? 'group', memberId };
+  const participants = Array.isArray(pBody) ? pBody : [];
+  if (user && !participants.includes(user)) participants.push(user);
+  const r = {
+    id: uuid(),
+    deviceId,
+    start,
+    end,
+    user,
+    reserver,
+    title,
+    scope: scope ?? 'group',
+    memberId,
+    participants,
+  };
   g.reservations.push(r);
   return NextResponse.json({ ok: true, data: r });
 }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -14,4 +14,4 @@ a:focus-visible { box-shadow: 0 0 0 3px rgba(59,130,246,.5); border-radius: .5re
 
 /* 任意: 簡易ユーティリティ */
 .input { @apply border rounded px-3 py-2 w-full; }
-.btn-primary { @apply inline-flex items-center justify-center bg-neutral-900 text-white rounded px-4 py-2 hover:bg-neutral-800; }
+.btn-primary { @apply inline-flex items-center justify-center rounded px-4 py-2 bg-indigo-600 text-white hover:bg-indigo-700; }

--- a/web/src/app/groups/[slug]/GroupScreenClient.tsx
+++ b/web/src/app/groups/[slug]/GroupScreenClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState, useMemo, useEffect } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useState, useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
 import {
   createDevice,
   listDevices,
@@ -29,14 +29,13 @@ export default function GroupScreenClient({
   const [reservations, setReservations] = useState<any[]>(initialReservations);
 
   const [deviceId, setDeviceId] = useState('');
-  const [reserver, setReserver] = useState(defaultReserver || '');
+  const reserver = defaultReserver || '';
   const [start, setStart] = useState('');
   const [end, setEnd] = useState('');
   const [title, setTitle] = useState('');
   const [reservationError, setReservationError] = useState<string | null>(null);
   const [addingReservation, setAddingReservation] = useState(false);
 
-  const router = useRouter();
   const searchParams = useSearchParams();
 
   useEffect(() => {
@@ -44,14 +43,6 @@ export default function GroupScreenClient({
     if (preselect) setDeviceId(preselect);
   }, [searchParams]);
 
-  const byDate = useMemo(() => {
-    const map: Record<string, number> = {};
-    reservations.forEach((r: any) => {
-      const key = r.start.slice(0, 10);
-      map[key] = (map[key] ?? 0) + 1;
-    });
-    return map;
-  }, [reservations]);
 
   async function handleAddDevice() {
     if (!deviceName.trim()) return;
@@ -82,12 +73,12 @@ export default function GroupScreenClient({
         start,
         end,
         title: title || undefined,
+        user: reserver,
         reserver,
       });
       const updated = await listReservations(group.slug);
       setReservations(updated.data || []);
       setDeviceId('');
-      setReserver('');
       setStart('');
       setEnd('');
       setTitle('');
@@ -154,18 +145,6 @@ export default function GroupScreenClient({
         </div>
       </section>
 
-      <section className="space-y-4">
-        <h2 className="text-xl font-semibold">カレンダー</h2>
-        <MonthCalendar
-          year={new Date().getFullYear()}
-          month={new Date().getMonth()}
-          reservations={{ byDate }}
-          onPickDate={(d) =>
-            router.push(`/groups/${group.slug}?date=${d.toISOString().slice(0, 10)}`)
-          }
-        />
-      </section>
-
       <section className="space-y-3">
         <h2 className="text-xl font-semibold">予約</h2>
         <form
@@ -185,13 +164,6 @@ export default function GroupScreenClient({
               </option>
             ))}
           </select>
-          <input
-            value={reserver}
-            onChange={(e) => setReserver(e.target.value)}
-            placeholder="予約者名（必須）"
-            className="input"
-            required
-          />
           <input
             type="datetime-local"
             value={start}
@@ -228,55 +200,4 @@ export default function GroupScreenClient({
   );
 }
 
-function MonthCalendar({
-  year,
-  month,
-  reservations,
-  onPickDate,
-}: {
-  year: number;
-  month: number;
-  reservations: { byDate: Record<string, number> };
-  onPickDate: (d: Date) => void;
-}) {
-  const first = new Date(year, month, 1);
-  const startW = first.getDay();
-  const daysInMonth = new Date(year, month + 1, 0).getDate();
-  const cells: (Date | null)[] = [];
-  for (let i = 0; i < startW; i++) cells.push(null);
-  for (let d = 1; d <= daysInMonth; d++) cells.push(new Date(year, month, d));
-  while (cells.length % 7 !== 0) cells.push(null);
-
-  return (
-    <div className="grid grid-cols-7 gap-2 border rounded-lg p-4">
-      {['日', '月', '火', '水', '木', '金', '土'].map((w) => (
-        <div key={w} className="text-center text-sm font-medium text-neutral-600">
-          {w}
-        </div>
-      ))}
-      {cells.map((date, i) => {
-        const key = date ? date.toISOString().slice(0, 10) : `x-${i}`;
-        const count = date ? reservations.byDate[key] || 0 : 0;
-        return (
-          <button
-            key={key}
-            disabled={!date}
-            onClick={() => date && onPickDate(date)}
-            className={`h-24 rounded border text-left p-2 ${
-              date ? 'hover:bg-neutral-50' : 'bg-neutral-50/40 cursor-default'
-            }`}
-          >
-            <div className="flex items-center justify-between">
-              <span className="text-sm">{date?.getDate() ?? ''}</span>
-              {date && count > 0 && (
-                <span className="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded-full">
-                  {count}
-                </span>
-              )}
-            </div>
-          </button>
-        );
-      })}
-    </div>
-  );
-}
+// calendar removed; use CalendarWithBars at page level

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -2,6 +2,29 @@ import { getGroup, listDevices, listReservations } from '@/lib/server-api';
 import { notFound } from 'next/navigation';
 import GroupScreenClient from './GroupScreenClient';
 import { readUserFromCookie } from '@/lib/auth';
+import CalendarWithBars, { Span } from '@/components/CalendarWithBars';
+function buildMonth(base = new Date()) {
+  const y = base.getFullYear(), m = base.getMonth();
+  const first = new Date(y, m, 1);
+  const start = new Date(first);
+  start.setDate(first.getDate() - ((first.getDay() + 6) % 7));
+  const weeks: Date[][] = [];
+  for (let w = 0; w < 6; w++) {
+    const row: Date[] = [];
+    for (let i = 0; i < 7; i++) {
+      row.push(new Date(start));
+      start.setDate(start.getDate() + 1);
+    }
+    weeks.push(row);
+  }
+  return { weeks, month: m };
+}
+function colorFromString(s: string) {
+  const palette = ['#2563eb', '#16a34a', '#f59e0b', '#ef4444', '#7c3aed', '#0ea5e9', '#f97316', '#14b8a6'];
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
+  return palette[h % palette.length];
+}
 
 export default async function GroupPage({ params }: { params: { slug: string } }) {
   const groupRes = await getGroup(params.slug);
@@ -14,12 +37,32 @@ export default async function GroupPage({ params }: { params: { slug: string } }
     readUserFromCookie(),
   ]);
 
+  const { weeks, month } = buildMonth(new Date());
+  const devices = devicesRes.data || [];
+  const reservations = reservationsRes.data || [];
+  const spans: Span[] = reservations.map(r => {
+    const dev = devices.find(d => d.id === r.deviceId);
+    return {
+      id: r.id,
+      name: dev?.name ?? r.deviceId,
+      start: new Date(r.start),
+      end: new Date(r.end),
+      color: colorFromString(r.deviceId),
+      groupSlug: group.slug,
+    };
+  });
+
   return (
-    <GroupScreenClient
-      initialGroup={group}
-      initialDevices={devicesRes.data || []}
-      initialReservations={reservationsRes.data || []}
-      defaultReserver={me?.name}
-    />
+    <div className="mx-auto max-w-6xl px-6 py-8">
+      <GroupScreenClient
+        initialGroup={group}
+        initialDevices={devices}
+        initialReservations={reservations}
+        defaultReserver={me?.email}
+      />
+      <div className="mt-6 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+        <CalendarWithBars weeks={weeks} month={month} spans={spans} />
+      </div>
+    </div>
   );
 }

--- a/web/src/app/groups/join/page.tsx
+++ b/web/src/app/groups/join/page.tsx
@@ -33,7 +33,7 @@ export default function GroupJoinPage() {
   }
 
   return (
-    <main className="max-w-2xl p-6 space-y-6">
+    <main className="mx-auto max-w-6xl px-6 py-8 space-y-6">
       <h1 className="text-3xl font-bold">グループに参加</h1>
       <form onSubmit={onSubmit} className="space-y-5">
         <label className="block">
@@ -63,7 +63,7 @@ export default function GroupJoinPage() {
           </p>
         )}
         <button
-          className="rounded-xl bg-black text-white px-5 py-2 disabled:opacity-50 disabled:cursor-not-allowed"
+          className="rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white px-5 py-2 disabled:opacity-50 disabled:cursor-not-allowed"
           disabled={loading || !group || !password}
           aria-disabled={loading || !group || !password}
         >

--- a/web/src/app/groups/new/page.tsx
+++ b/web/src/app/groups/new/page.tsx
@@ -28,7 +28,7 @@ export default function NewGroupPage() {
   }
 
   return (
-    <main className="max-w-2xl p-6 space-y-6">
+    <main className="mx-auto max-w-6xl px-6 py-8 space-y-6">
       <h1 className="text-3xl font-bold">グループ作成</h1>
       <form onSubmit={onSubmit} className="space-y-5">
         <label className="block">
@@ -62,7 +62,7 @@ export default function NewGroupPage() {
         <button
           type="submit"
           disabled={pending}
-          className="rounded-xl bg-black text-white px-5 py-2"
+          className="rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white px-5 py-2"
         >
           作成
         </button>

--- a/web/src/app/groups/page.tsx
+++ b/web/src/app/groups/page.tsx
@@ -5,7 +5,7 @@ export default async function GroupsPage() {
   const res = await listGroups();
   const groups = res.data || [];
   return (
-    <main className="space-y-4">
+    <main className="mx-auto max-w-6xl px-6 py-8 space-y-4">
       <h1 className="text-2xl font-bold">グループ一覧</h1>
       <ul className="list-disc pl-5 space-y-1">
         {groups.map((g:any)=>(

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -75,7 +75,7 @@ export default function LoginPage() {
     'w-full rounded-lg border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-gray-800/10';
 
   return (
-    <div className="mx-auto max-w-5xl px-4 py-10">
+    <div className="mx-auto max-w-6xl px-6 py-10">
       <header className="text-center mb-8">
         <h1 className="text-3xl font-semibold tracking-tight">Lab Yoyaku へようこそ</h1>
         <p className="text-gray-600 mt-2">研究室の機器をグループで管理し、予約と使用状況をカレンダーで可視化します。</p>
@@ -142,7 +142,7 @@ export default function LoginPage() {
               />
               {lerr && <div className="text-sm text-red-600">{lerr}</div>}
               <button
-                className="w-full rounded-lg bg-black text-white px-4 py-2 hover:opacity-90 disabled:opacity-60"
+                className="w-full rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 disabled:opacity-60"
                 disabled={loadingLogin}
               >
                 {loadingLogin ? 'ログイン中…' : 'ログイン'}
@@ -184,7 +184,7 @@ export default function LoginPage() {
               />
               {rerr && <div className="text-sm text-red-600">{rerr}</div>}
               <button
-                className="w-full rounded-lg bg-black text-white px-4 py-2 hover:opacity-90 disabled:opacity-60"
+                className="w-full rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 disabled:opacity-60"
                 disabled={loadingReg}
               >
                 {loadingReg ? '作成中…' : 'アカウントを作成'}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -55,7 +55,7 @@ export default async function Home() {
   const card = "rounded-xl border border-gray-200 bg-white p-5 shadow-sm";
 
   return (
-    <div className="mx-auto max-w-6xl px-4 py-8 space-y-6">
+    <div className="mx-auto max-w-6xl px-6 py-8 space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">ダッシュボード</h1>
         <div className="flex gap-2">

--- a/web/src/components/CalendarWithBars.tsx
+++ b/web/src/components/CalendarWithBars.tsx
@@ -51,7 +51,9 @@ export default function CalendarWithBars({
                 {todays.slice(0,2).map((s)=>(
                   <div key={s.id} className="h-4 rounded-sm flex items-center px-1"
                        style={{backgroundColor:s.color, color:'#fff'}}>
-                    <span className="text-[10px] leading-none truncate">{short(s.name,8)}</span>
+                    <span className="text-[10px] leading-none truncate">
+                      {short(`${s.name} ${pad(s.end.getHours())}:${pad(s.end.getMinutes())}`, 12)}
+                    </span>
                   </div>
                 ))}
                 {todays.length>2 && <div className="text-[10px] text-gray-500">+{todays.length-2}</div>}

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -4,7 +4,7 @@ export default async function Header() {
   const me = await readUserFromCookie();
   return (
     <header className="border-b bg-white">
-      <div className="mx-auto max-w-6xl px-4 h-12 flex items-center justify-between">
+      <div className="mx-auto max-w-6xl px-6 h-12 flex items-center justify-between">
         <a href="/" className="font-semibold tracking-tight">Lab Yoyaku</a>
         <nav className="flex items-center gap-4 text-sm">
           {me ? (

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -6,7 +6,7 @@ export default function Button(
 ){
   const base="inline-flex items-center justify-center rounded-2xl px-4 py-2 text-sm transition disabled:opacity-50 disabled:cursor-not-allowed";
   const styles={
-    primary:"bg-neutral-900 text-white hover:bg-neutral-800",
+    primary:"bg-indigo-600 text-white hover:bg-indigo-700",
     outline:"border hover:-translate-y-0.5 shadow-sm",
     danger:"bg-rose-600 text-white hover:bg-rose-500"
   };

--- a/web/src/lib/mock-db.ts
+++ b/web/src/lib/mock-db.ts
@@ -11,6 +11,8 @@ export type DB = {
       deviceId: string;
       title?: string;
       reserver: string;     // 予約者名
+      user?: string;        // 予約者メール
+      participants?: string[];
       start: string;
       end: string;
       scope: 'group' | 'member';

--- a/web/src/lib/mockdb.ts
+++ b/web/src/lib/mockdb.ts
@@ -4,6 +4,7 @@ export type Device = { id: string; name: string; note?: string };
 export type Reservation = {
   id: string; deviceId: string; user: MemberId;
   start: string; end: string; purpose?: string;
+  participants?: MemberId[];
 };
 export type Group = {
   slug: string; name: string; password?: string;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -13,6 +13,8 @@ export type Reservation = {
   end: string;   // ISO
   title?: string;
   reserver: string; // reserver name
+  user?: string;
+  participants?: string[];
   scope: 'group' | 'member';
   memberId?: string;
 };


### PR DESCRIPTION
## Summary
- center top-level layouts and add consistent margins
- show calendar bars with device names and end times
- include participants when fetching/creating my reservations
- switch primary buttons to indigo accent

## Testing
- `npm run lint --prefix web`
- `npm run typecheck --prefix web`


------
https://chatgpt.com/codex/tasks/task_e_68aca96d9fd483239f980b15256c7082