### PR TITLE
Normalize reservation user and refresh group view

### DIFF
--- a/web/src/app/groups/[slug]/GroupScreenClient.tsx
+++ b/web/src/app/groups/[slug]/GroupScreenClient.tsx
@@ -1,23 +1,20 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams, useRouter } from 'next/navigation';
 import {
   createDevice,
   listDevices,
-  listReservations,
   createReservation,
 } from '@/lib/api';
 
 export default function GroupScreenClient({
   initialGroup,
   initialDevices,
-  initialReservations,
   defaultReserver,
 }: {
   initialGroup: any;
   initialDevices: any[];
-  initialReservations: any[];
   defaultReserver?: string;
 }) {
   const group = initialGroup;
@@ -26,7 +23,6 @@ export default function GroupScreenClient({
   const [note, setNote] = useState('');
   const [deviceError, setDeviceError] = useState<string | null>(null);
   const [addingDevice, setAddingDevice] = useState(false);
-  const [reservations, setReservations] = useState<any[]>(initialReservations);
 
   const [deviceId, setDeviceId] = useState('');
   const reserver = defaultReserver || '';
@@ -37,6 +33,7 @@ export default function GroupScreenClient({
   const [addingReservation, setAddingReservation] = useState(false);
 
   const searchParams = useSearchParams();
+  const router = useRouter();
 
   useEffect(() => {
     const preselect = searchParams.get('device');
@@ -76,8 +73,7 @@ export default function GroupScreenClient({
         user: reserver,
         reserver,
       });
-      const updated = await listReservations(group.slug);
-      setReservations(updated.data || []);
+      router.refresh();
       setDeviceId('');
       setStart('');
       setEnd('');

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -57,7 +57,6 @@ export default async function GroupPage({ params }: { params: { slug: string } }
       <GroupScreenClient
         initialGroup={group}
         initialDevices={devices}
-        initialReservations={reservations}
         defaultReserver={me?.email}
       />
       <div className="mt-6 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">


### PR DESCRIPTION
## Summary
- Normalize reservation creation to use authenticated email and ensure self included in participants
- Refresh group page after adding reservation so calendar updates

## Testing
- ⚠️ `pnpm lint` (failed: Error when performing request to registry)
- ✅ `npm run lint`
- ✅ `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ad2e10e0388323b71955745df145df