### PR TITLE
Improve reservation matching and calendar navigation

### DIFF
--- a/web/src/app/api/me/reservations/route.ts
+++ b/web/src/app/api/me/reservations/route.ts
@@ -2,30 +2,46 @@ import { NextResponse } from 'next/server';
 import { readUserFromCookie } from '@/lib/auth';
 import { loadDB } from '@/lib/mockdb';
 
+const norm = (v?:string) => (v ?? '').trim().toLowerCase();
+
+// 予約の「このユーザーが関与しているか」判定
+function involved(r:any, meKeys:Set<string>) {
+  const pool:string[] = [];
+  if (r.user) pool.push(r.user);
+  if (r.userName) pool.push(r.userName);
+  if (Array.isArray(r.participants)) pool.push(...r.participants);
+  // 将来の互換用フィールドがあっても拾えるように
+  if (Array.isArray(r.participantNames)) pool.push(...r.participantNames);
+  return pool.map(norm).some(k => meKeys.has(k));
+}
+
 export async function GET() {
   const me = await readUserFromCookie();
   if (!me) return NextResponse.json({ ok:false }, { status:401 });
 
-  const meKeys = [me.email, me.name].filter(Boolean);
-  const isMe = (v?:string)=> !!v && meKeys.includes(v);
+  // 照合キー：email と name の両方（大小無視）
+  const meKeys = new Set([norm(me.email), norm(me.name)]);
 
   const db = loadDB();
+  const mine = (db.groups ?? []).flatMap((g:any) => {
+    const reservations = g.reservations ?? [];
+    const withDevice = reservations.map((r:any) => {
+      const dev = (g.devices ?? []).find((d:any)=> d.id === r.deviceId);
+      return {
+        ...r,
+        deviceName: dev?.name ?? r.deviceId,
+        groupSlug: g.slug,
+        groupName: g.name,
+      };
+    });
+    return withDevice.filter((r:any)=> involved(r, meKeys));
+  });
 
-  const mine = db.groups.flatMap(g =>
-    (g.reservations ?? [])
-      .filter(r => isMe(r.user) || (Array.isArray(r.participants) && r.participants.some(isMe)))
-      .map(r => {
-        const dev = (g.devices ?? []).find(d=>d.id===r.deviceId);
-        return {
-          ...r,
-          deviceName: dev?.name ?? r.deviceId,
-          groupSlug: g.slug,
-          groupName: g.name,
-        };
-      })
-  );
-
-  // “終了が今-1分以降”だけ返す（過去で欠落しないよう微調整）
+  // 「直近」= 終了が今-1分 以降（タイムゾーン誤差のバッファ）
   const nowSlack = Date.now() - 60*1000;
-  return NextResponse.json({ ok:true, data: mine.filter(r => new Date(r.end).getTime() >= nowSlack) });
+  const upcoming = mine.filter((r:any)=> new Date(r.end).getTime() >= nowSlack);
+
+  // 右側の月カレンダー用に全件も返すと後段のUIが楽になる
+  return NextResponse.json({ ok:true, data: upcoming, all: mine });
 }
+

--- a/web/src/app/api/mock/reservations/route.ts
+++ b/web/src/app/api/mock/reservations/route.ts
@@ -67,7 +67,9 @@ export async function POST(req: Request) {
   const db = loadDB();
 
   const participants: string[] = Array.isArray(body.participants) ? body.participants.slice() : [];
-  if (!participants.includes(me.email)) participants.push(me.email);
+  const add = (v?:string)=> { const x=(v??'').trim(); if(x && !participants.includes(x)) participants.push(x); };
+  add(me.email);
+  add(me.name);
 
   const record = {
     ...body,

--- a/web/src/app/page.client.tsx
+++ b/web/src/app/page.client.tsx
@@ -1,0 +1,32 @@
+'use client';
+import { useMemo, useState } from 'react';
+import CalendarWithBars, { Span } from '@/components/CalendarWithBars';
+import { addMonths, buildWeeks, firstOfMonth } from '@/lib/date-cal';
+
+export default function RightCalendarClient({ spans }: { spans: Span[] }) {
+  const today = new Date();
+  const [anchor, setAnchor] = useState(firstOfMonth(today.getFullYear(), today.getMonth()));
+
+  const { month, weeks, monthSpans } = useMemo(()=>{
+    const m = anchor.getMonth();
+    const w = buildWeeks(anchor);
+    // 選択中の月にかかる予約だけ抽出（端はOK）
+    const ms = spans.filter(s =>
+      s.start <= new Date(anchor.getFullYear(), anchor.getMonth()+1, 1) &&
+      s.end   >= new Date(anchor.getFullYear(), anchor.getMonth(),   1)
+    );
+    return { month: m, weeks: w, monthSpans: ms };
+  },[anchor, spans]);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <button className="px-2 py-1 rounded border" onClick={()=>setAnchor(a=>addMonths(a,-1))}>‹</button>
+        <div className="font-medium">{anchor.getFullYear()}年 {anchor.getMonth()+1}月</div>
+        <button className="px-2 py-1 rounded border" onClick={()=>setAnchor(a=>addMonths(a, 1))}>›</button>
+      </div>
+      <CalendarWithBars weeks={weeks} month={month} spans={monthSpans}/>
+    </div>
+  );
+}
+

--- a/web/src/lib/date-cal.ts
+++ b/web/src/lib/date-cal.ts
@@ -1,0 +1,25 @@
+export const strip = (d:Date)=> new Date(d.getFullYear(), d.getMonth(), d.getDate());
+export const firstOfMonth = (y:number, m:number)=> new Date(y, m, 1);
+export const addMonths = (d:Date, n:number)=> new Date(d.getFullYear(), d.getMonth()+n, 1);
+
+export function buildWeeks(anchor: Date) {
+  // anchor はその月の1日を推奨
+  const start = new Date(anchor);
+  start.setDate(1);
+  const firstDow = (start.getDay() + 6) % 7; // 月=0, …, 日=6
+  const begin = new Date(start);
+  begin.setDate(start.getDate() - firstDow);
+
+  const weeks: Date[][] = [];
+  let cur = new Date(begin);
+  for (let w=0; w<6; w++) {
+    const row: Date[] = [];
+    for (let d=0; d<7; d++) {
+      row.push(new Date(cur));
+      cur.setDate(cur.getDate()+1);
+    }
+    weeks.push(row);
+  }
+  return weeks;
+}
+


### PR DESCRIPTION
## Summary
- Normalize reservation lookup to match user across multiple fields and return all matching data
- Add reusable date helpers and client-side calendar with month navigation
- Ensure reservation saves include user's display name in participants

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm run test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68ae81a9982883239119273b3f1bbd26