### PR TITLE
fix: replace sqlite3 with better-sqlite3

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,7 @@
     "qrcode": "^1.5.3",
     "bcryptjs": "^2.4.3",
     "jose": "^5.2.2",
-    "sqlite3": "^5.1.7"
+    "better-sqlite3": "^9.4.0"
   },
   "devDependencies": {
     "@types/react": "18.2.21",

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -1,36 +1,23 @@
 import 'server-only';
-import sqlite3 from 'sqlite3';
+import Database from 'better-sqlite3';
 import path from 'path';
 import { UserRecord } from './mockdb';
 
-const sqlite = sqlite3.verbose();
 const DB_PATH = process.env.DATABASE_PATH || path.join(process.cwd(), 'data.db');
-const db = new sqlite.Database(DB_PATH);
+const db = new Database(DB_PATH);
+db.exec(`CREATE TABLE IF NOT EXISTS users (
+  id TEXT PRIMARY KEY,
+  email TEXT UNIQUE NOT NULL,
+  name TEXT,
+  passHash TEXT NOT NULL
+)`);
 
-db.serialize(() => {
-  db.run(`CREATE TABLE IF NOT EXISTS users (
-    id TEXT PRIMARY KEY,
-    email TEXT UNIQUE NOT NULL,
-    name TEXT,
-    passHash TEXT NOT NULL
-  )`);
-});
-
-export function loadUsers(): Promise<UserRecord[]> {
-  return new Promise((resolve, reject) => {
-    db.all<UserRecord[]>('SELECT id, email, name, passHash FROM users', (err, rows) => {
-      if (err) reject(err);
-      else resolve(rows as UserRecord[]);
-    });
-  });
+export async function loadUsers(): Promise<UserRecord[]> {
+  return db.prepare('SELECT id, email, name, passHash FROM users').all() as UserRecord[];
 }
 
-export function saveUser(user: UserRecord): Promise<void> {
-  return new Promise((resolve, reject) => {
-    db.run(
-      'INSERT INTO users (id, email, name, passHash) VALUES (?, ?, ?, ?)',
-      [user.id, user.email, user.name, user.passHash],
-      err => (err ? reject(err) : resolve())
-    );
-  });
+export async function saveUser(user: UserRecord): Promise<void> {
+  db
+    .prepare('INSERT INTO users (id, email, name, passHash) VALUES (?, ?, ?, ?)')
+    .run(user.id, user.email, user.name, user.passHash);
 }


### PR DESCRIPTION
## Summary
- use better-sqlite3 instead of sqlite3 to avoid missing bindings
- rewrite db helper to work with better-sqlite3

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module 'better-sqlite3')*


------
https://chatgpt.com/codex/tasks/task_e_68b04deb00b883238622a6f4b36df6bb