### PR TITLE
feat: fallback to in-memory db when sqlite unavailable

### DIFF
--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -1,23 +1,41 @@
 import 'server-only';
-import Database from 'better-sqlite3';
 import path from 'path';
-import { UserRecord } from './mockdb';
+import { loadDB, UserRecord } from './mockdb';
 
-const DB_PATH = process.env.DATABASE_PATH || path.join(process.cwd(), 'data.db');
-const db = new Database(DB_PATH);
-db.exec(`CREATE TABLE IF NOT EXISTS users (
-  id TEXT PRIMARY KEY,
-  email TEXT UNIQUE NOT NULL,
-  name TEXT,
-  passHash TEXT NOT NULL
-)`);
+// ``better-sqlite3`` はネイティブモジュールのため環境によっては
+// 読み込みに失敗することがある。その場合はメモリ上のモックDBに
+// フォールバックするようにし、開発環境でエラーが出ないようにする。
+
+let db: any = null;
+try {
+  const Database = require('better-sqlite3');
+  const DB_PATH = process.env.DATABASE_PATH || path.join(process.cwd(), 'data.db');
+  db = new Database(DB_PATH);
+  db.exec(`CREATE TABLE IF NOT EXISTS users (
+    id TEXT PRIMARY KEY,
+    email TEXT UNIQUE NOT NULL,
+    name TEXT,
+    passHash TEXT NOT NULL
+  )`);
+} catch (err) {
+  console.warn('Failed to load better-sqlite3, using in-memory DB');
+  db = null;
+}
 
 export async function loadUsers(): Promise<UserRecord[]> {
-  return db.prepare('SELECT id, email, name, passHash FROM users').all() as UserRecord[];
+  if (db) {
+    return db.prepare('SELECT id, email, name, passHash FROM users').all() as UserRecord[];
+  }
+  return loadDB().users;
 }
 
 export async function saveUser(user: UserRecord): Promise<void> {
-  db
-    .prepare('INSERT INTO users (id, email, name, passHash) VALUES (?, ?, ?, ?)')
-    .run(user.id, user.email, user.name, user.passHash);
+  if (db) {
+    db
+      .prepare('INSERT INTO users (id, email, name, passHash) VALUES (?, ?, ?, ?)')
+      .run(user.id, user.email, user.name, user.passHash);
+  } else {
+    const dbData = loadDB();
+    dbData.users.push(user);
+  }
 }


### PR DESCRIPTION
## Summary
- avoid crash when native sqlite bindings are missing
- dynamically require better-sqlite3 and fall back to an in-memory DB

## Testing
- `./node_modules/.bin/eslint . --max-warnings=0`
- `./node_modules/.bin/tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b04fcfa09083239218d7bda187da00