### PR TITLE
feat: clarify password policy and refresh reservations

### DIFF
--- a/api/app/schemas/auth.py
+++ b/api/app/schemas/auth.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel, constr, validator
+import re
+
+_password_re = re.compile(r'^(?=.*[A-Za-z])(?=.*\d)[^\s]{8,64}$')
+
+
+class RegisterIn(BaseModel):
+    name: constr(strip_whitespace=True, min_length=1, max_length=32)
+    email: constr(strip_whitespace=True)
+    password: str
+
+    @validator('password')
+    def validate_password(cls, v: str) -> str:
+        if not _password_re.match(v):
+            raise ValueError('パスワードは8〜64文字で英字と数字を各1文字以上含み、空白は不可です。')
+        return v

--- a/web/src/app/_parts/UpcomingReservations.tsx
+++ b/web/src/app/_parts/UpcomingReservations.tsx
@@ -1,0 +1,100 @@
+'use client';
+import { useState } from 'react';
+
+type Item = {
+  id: string;
+  deviceId: string;
+  deviceName?: string;
+  start: string;
+  end: string;
+  purpose?: string;
+  groupSlug: string;
+  groupName: string;
+};
+
+function pad(n: number) {
+  return n.toString().padStart(2, '0');
+}
+function fmtRange(s: string, e: string) {
+  const S = new Date(s), E = new Date(e);
+  const same = S.toDateString() === E.toDateString();
+  const d = (x: Date) => `${x.getMonth() + 1}/${x.getDate()} ${pad(x.getHours())}:${pad(x.getMinutes())}`;
+  return same
+    ? `${d(S)}–${pad(E.getHours())}:${pad(E.getMinutes())}`
+    : `${d(S)} → ${d(E)}`;
+}
+function colorFromString(s: string) {
+  const palette = ['#2563eb', '#16a34a', '#f59e0b', '#ef4444', '#7c3aed', '#0ea5e9', '#f97316', '#14b8a6'];
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
+  return palette[h % palette.length];
+}
+
+export default function UpcomingReservations({ initialItems }: { initialItems: Item[] }) {
+  const [items, setItems] = useState<Item[]>(initialItems);
+  const [loading, setLoading] = useState(false);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const r = await fetch('/api/me/reservations', { cache: 'no-store' });
+      const j = await r.json();
+      const arr: Item[] = (j.data ?? []).sort((a: any, b: any) =>
+        new Date(a.start).getTime() - new Date(b.start).getTime()
+      ).slice(0, 10);
+      setItems(arr);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="flex items-center justify-between mb-3">
+        <div className="font-medium">直近の自分の予約</div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={load}
+            className="border rounded px-3 py-1 text-sm"
+            disabled={loading}
+            aria-label="予約を更新"
+            title="予約を更新"
+          >
+            {loading ? '更新中…' : '更新'}
+          </button>
+          <a className="text-sm text-gray-500 hover:underline" href="/groups">すべてのグループへ</a>
+        </div>
+      </div>
+
+      {!items.length ? (
+        <div className="text-gray-500 text-sm">直近の予約はありません。右上の「グループ参加」から始めましょう。</div>
+      ) : (
+        <ul className="space-y-2">
+          {items.map((r) => (
+            <li key={r.id} className="rounded-lg border px-3 py-2 flex items-start gap-3">
+              <span
+                className="inline-block h-2.5 w-2.5 rounded-full mt-2"
+                style={{ backgroundColor: colorFromString(r.deviceId) }}
+              />
+              <div className="flex-1">
+                <div className="text-sm text-gray-600">
+                  {fmtRange(r.start, r.end)}（{r.groupName}）
+                </div>
+                <div className="font-medium mt-0.5">機器：{r.deviceName ?? r.deviceId}</div>
+                {r.purpose && (
+                  <div className="text-sm text-gray-500">用途：{r.purpose}</div>
+                )}
+              </div>
+              <a
+                className="text-sm text-gray-500 hover:underline"
+                href={`/groups/${r.groupSlug}`}
+              >
+                詳細
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  );
+}

--- a/web/src/app/groups/[slug]/GroupScreenClient.tsx
+++ b/web/src/app/groups/[slug]/GroupScreenClient.tsx
@@ -60,17 +60,27 @@ export default function GroupScreenClient({
     setAddingReservation(true);
     setErrorMsg('');
     try {
-      const payload = {
+      const me = await fetch('/api/auth/me', { cache: 'no-store' }).then((r) =>
+        r.json()
+      );
+
+      const record = {
         groupSlug: group.slug,
         deviceId,
         start,
         end,
         title: title || undefined,
+        user: me.email,
+        userName: me.name || me.email,
+        participants: Array.from(
+          new Set([me.email, me.name || me.email])
+        ),
       };
+
       const r = await fetch('/api/mock/reservations', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify(payload),
+        body: JSON.stringify(record),
       });
 
       if (r.status === 409) {

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
+import { PASSWORD_HINT, passwordRegex } from '@/utils/password';
 
 type Tab = 'login' | 'register';
 
@@ -48,6 +49,10 @@ export default function LoginPage() {
     setRErr('');
     if (rpass !== rpass2) {
       setRErr('確認用パスワードが一致しません');
+      return;
+    }
+    if (!passwordRegex.test(rpass)) {
+      setRErr(PASSWORD_HINT);
       return;
     }
     setLoadingReg(true);
@@ -167,9 +172,9 @@ export default function LoginPage() {
                 required
               />
               <input
-                className={input}
+              className={input}
                 type="password"
-                placeholder="パスワード（6文字以上）"
+                placeholder="パスワード"
                 value={rpass}
                 onChange={e => setRPass(e.target.value)}
                 required
@@ -182,6 +187,7 @@ export default function LoginPage() {
                 onChange={e => setRPass2(e.target.value)}
                 required
               />
+              <p className="text-sm text-gray-500 mt-1">{PASSWORD_HINT}</p>
               {rerr && <div className="text-sm text-red-600">{rerr}</div>}
               <button
                 className="w-full rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 disabled:opacity-60"

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -2,6 +2,7 @@ import { readUserFromCookie } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import type { Span } from '@/components/CalendarWithBars';
 import RightCalendarClient from './page.client';
+import UpcomingReservations from './_parts/UpcomingReservations';
 
 type Mine = {
   id:string; deviceId:string; deviceName?:string; user:string; userName?:string;
@@ -9,13 +10,6 @@ type Mine = {
   start:string; end:string; purpose?:string; groupSlug:string; groupName:string;
 };
 
-const pad = (n:number)=> n.toString().padStart(2,'0');
-const fmtRange = (s:string,e:string)=>{
-  const S=new Date(s), E=new Date(e);
-  const same = S.toDateString()===E.toDateString();
-  const d =(x:Date)=>`${x.getMonth()+1}/${x.getDate()} ${pad(x.getHours())}:${pad(x.getMinutes())}`;
-  return same ? `${d(S)}–${pad(E.getHours())}:${pad(E.getMinutes())}` : `${d(S)} → ${d(E)}`;
-};
 function colorFromString(s:string){
   const palette=['#2563eb','#16a34a','#f59e0b','#ef4444','#7c3aed','#0ea5e9','#f97316','#14b8a6'];
   let h=0; for(let i=0;i<s.length;i++) h=(h*31+s.charCodeAt(i))>>>0;
@@ -62,26 +56,7 @@ export default async function Home() {
 
       <div className="grid gap-6 md:grid-cols-3">
         <section className={`md:col-span-2 ${card}`}>
-          <div className="flex items-center justify-between mb-3">
-            <div className="font-medium">直近の自分の予約</div>
-            <a className="text-sm text-gray-500 hover:underline" href="/groups">すべてのグループへ</a>
-          </div>
-          {!upcoming.length && (
-            <div className="text-gray-500 text-sm">直近の予約はありません。右上の「グループ参加」から始めましょう。</div>
-          )}
-          <ul className="space-y-2">
-            {upcoming.map(r=>(
-              <li key={r.id} className="rounded-lg border px-3 py-2 flex items-start gap-3">
-                <span className="inline-block h-2.5 w-2.5 rounded-full mt-2" style={{backgroundColor:colorFromString(r.deviceId)}}/>
-                <div className="flex-1">
-                  <div className="text-sm text-gray-600">{fmtRange(r.start,r.end)}（{r.groupName}）</div>
-                  <div className="font-medium mt-0.5">機器：{r.deviceName ?? r.deviceId}</div>
-                  {r.purpose && <div className="text-sm text-gray-500">用途：{r.purpose}</div>}
-                </div>
-                <a className="text-sm text-gray-500 hover:underline" href={`/groups/${r.groupSlug}`}>詳細</a>
-              </li>
-            ))}
-          </ul>
+          <UpcomingReservations initialItems={upcoming} />
         </section>
 
         <section className={card}>

--- a/web/src/utils/password.ts
+++ b/web/src/utils/password.ts
@@ -1,0 +1,5 @@
+export const PASSWORD_HINT =
+  '8〜64文字、英字と数字をそれぞれ1文字以上含め、空白は不可（記号OK）';
+
+export const passwordRegex =
+  /^(?=.*[A-Za-z])(?=.*\d)[^\s]{8,64}$/;


### PR DESCRIPTION
## Summary
- clarify password requirements for client and API
- include user info when saving reservations
- show recent reservations on dashboard with refresh button

## Testing
- `pnpm -F web lint` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm -F web typecheck` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `python -m py_compile api/app/schemas/auth.py`


------
https://chatgpt.com/codex/tasks/task_e_68b48e650ba883239b9f66e3f23e5c14