### PR TITLE
Handle dynamic server port for API requests

### DIFF
--- a/web/src/app/api/mock/devices/[slug]/qr/route.ts
+++ b/web/src/app/api/mock/devices/[slug]/qr/route.ts
@@ -1,5 +1,6 @@
 import { loadDB } from '@/lib/mockdb';
 import QRCode from 'qrcode';
+import { getBaseUrl } from '@/lib/config';
 
 export const runtime = 'nodejs';
 
@@ -10,7 +11,7 @@ export async function GET(_req: Request, { params }: { params: { slug: string } 
     .find((d: any) => d.slug === params.slug);
   if (!device) return new Response('Not found', { status: 404 });
 
-  const base = process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000';
+  const base = getBaseUrl();
   const url = `${base}/devices/${device.slug}?t=${device.qrToken}`;
 
   const dataUrl = await QRCode.toDataURL(url, { margin: 1, scale: 6 });

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import GroupScreenClient from './GroupScreenClient';
 import { readUserFromCookie } from '@/lib/auth';
 import CalendarWithBars, { Span } from '@/components/CalendarWithBars';
+import { getBaseUrl } from '@/lib/config';
 function buildMonth(base = new Date()) {
   const y = base.getFullYear(), m = base.getMonth();
   const first = new Date(y, m, 1);
@@ -28,7 +29,7 @@ function colorFromString(s: string) {
 
 export default async function GroupPage({ params }: { params: { slug: string } }) {
   const { slug } = params;
-  const base = process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000';
+  const base = getBaseUrl();
 
   const gRes = await fetch(`${base}/api/mock/groups/${slug}`, { cache: 'no-store' });
   if (gRes.status === 404) return notFound();

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { readUserFromCookie } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import type { Span } from '@/components/CalendarWithBars';
+import { getBaseUrl } from '@/lib/config';
 import RightCalendarClient from './page.client';
 import UpcomingReservations from './_parts/UpcomingReservations';
 
@@ -21,7 +22,7 @@ export default async function Home() {
   const me = await readUserFromCookie();
   if (!me) redirect('/login?next=/');
 
-  const base = process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000';
+  const base = getBaseUrl();
   const res = await fetch(`${base}/api/me/reservations`, { cache:'no-store' });
   const json = await res.json();
 

--- a/web/src/components/DevicePoster.tsx
+++ b/web/src/components/DevicePoster.tsx
@@ -1,8 +1,9 @@
+import { getBaseUrl } from '@/lib/config';
 // eslint-disable-next-line import/no-unresolved
 const { QRCodeCanvas } = require('qrcode.react');
 
 export default function DevicePoster({ device }: { device: any }) {
-  const url = `${process.env.NEXT_PUBLIC_BASE_URL}/devices/${device.device_uid}?from=qr`;
+  const url = `${getBaseUrl()}/devices/${device.device_uid}?from=qr`;
   return (
     <div className="mx-auto w-[794px] h-[1123px] p-10 border rounded bg-white">
       <h1 className="text-3xl font-bold mb-6">Lab Yoyaku</h1>

--- a/web/src/lib/config.ts
+++ b/web/src/lib/config.ts
@@ -1,0 +1,15 @@
+export function getBaseUrl() {
+  const port = process.env.PORT ?? '3000';
+  const env = process.env.NEXT_PUBLIC_BASE_URL;
+  if (env) {
+    try {
+      const url = new URL(env);
+      if (url.hostname !== 'localhost' || url.port === port) {
+        return env;
+      }
+    } catch {
+      // ignore invalid URL in env
+    }
+  }
+  return `http://localhost:${port}`;
+}


### PR DESCRIPTION
## Summary
- add utility to derive base URL from env or current port
- use the dynamic base URL in pages, API route and device poster

## Testing
- `pnpm --filter web lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `pnpm --filter web typecheck` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68b50615d3a48323a336f75775d1ff73