### PR TITLE
Sync calendar with reservation updates and add reminder hooks

### DIFF
--- a/web/src/app/page.client.tsx
+++ b/web/src/app/page.client.tsx
@@ -1,31 +1,87 @@
 'use client';
 import { useMemo, useState } from 'react';
+import UpcomingReservations, { Item } from './_parts/UpcomingReservations';
 import CalendarWithBars, { Span } from '@/components/CalendarWithBars';
 import { addMonths, buildWeeks, firstOfMonth } from '@/lib/date-cal';
 
-export default function RightCalendarClient({ spans }: { spans: Span[] }) {
+const short = (s: string, len = 10) => (s.length <= len ? s : s.slice(0, len - 1) + '…');
+function colorFromString(s: string) {
+  const palette = ['#2563eb', '#16a34a', '#f59e0b', '#ef4444', '#7c3aed', '#0ea5e9', '#f97316', '#14b8a6'];
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
+  return palette[h % palette.length];
+}
+
+export default function DashboardClient({ initialItems, initialSpans }: { initialItems: Item[]; initialSpans: Span[] }) {
+  const [spans, setSpans] = useState<Span[]>(initialSpans);
   const today = new Date();
   const [anchor, setAnchor] = useState(firstOfMonth(today.getFullYear(), today.getMonth()));
 
-  const { month, weeks, monthSpans } = useMemo(()=>{
+  const { month, weeks, monthSpans } = useMemo(() => {
     const m = anchor.getMonth();
     const w = buildWeeks(anchor);
-    // 選択中の月にかかる予約だけ抽出（端はOK）
-    const ms = spans.filter(s =>
-      s.start <= new Date(anchor.getFullYear(), anchor.getMonth()+1, 1) &&
-      s.end   >= new Date(anchor.getFullYear(), anchor.getMonth(),   1)
+    const ms = spans.filter(
+      (s) =>
+        s.start <= new Date(anchor.getFullYear(), anchor.getMonth() + 1, 1) &&
+        s.end >= new Date(anchor.getFullYear(), anchor.getMonth(), 1)
     );
     return { month: m, weeks: w, monthSpans: ms };
-  },[anchor, spans]);
+  }, [anchor, spans]);
+
+  const legend = useMemo(
+    () => Array.from(new Map(spans.map((s) => [s.name, s.color])).entries()),
+    [spans]
+  );
+
+  const handleLoaded = (j: any) => {
+    const all = (j.all ?? []) as any[];
+    const updated: Span[] = all.map((r: any) => ({
+      id: r.id,
+      name: r.deviceName ?? r.deviceId,
+      start: new Date(r.start),
+      end: new Date(r.end),
+      color: colorFromString(r.deviceId),
+      groupSlug: r.groupSlug,
+      by: r.userName || r.user,
+      participants: r.participants ?? [],
+    }));
+    setSpans(updated);
+  };
+
+  const card = 'rounded-xl border border-gray-200 bg-white p-5 shadow-sm';
 
   return (
-    <div>
-      <div className="flex items-center justify-between mb-2">
-        <button className="px-2 py-1 rounded border" onClick={()=>setAnchor(a=>addMonths(a,-1))}>‹</button>
-        <div className="font-medium">{anchor.getFullYear()}年 {anchor.getMonth()+1}月</div>
-        <button className="px-2 py-1 rounded border" onClick={()=>setAnchor(a=>addMonths(a, 1))}>›</button>
-      </div>
-      <CalendarWithBars weeks={weeks} month={month} spans={monthSpans}/>
+    <div className="grid gap-6 md:grid-cols-3">
+      <section className={`md:col-span-2 ${card}`}>
+        <UpcomingReservations initialItems={initialItems} onLoaded={handleLoaded} />
+      </section>
+
+      <section className={card}>
+        <div className="flex items-center justify-between mb-2">
+          <button className="px-2 py-1 rounded border" onClick={() => setAnchor((a) => addMonths(a, -1))}>
+            ‹
+          </button>
+          <div className="font-medium">
+            {anchor.getFullYear()}年 {anchor.getMonth() + 1}月
+          </div>
+          <button className="px-2 py-1 rounded border" onClick={() => setAnchor((a) => addMonths(a, 1))}>
+            ›
+          </button>
+        </div>
+        <CalendarWithBars weeks={weeks} month={month} spans={monthSpans} />
+        {legend.length > 0 && (
+          <div className="mt-4">
+            <div className="text-xs text-gray-500 mb-1">色の対応</div>
+            <div className="flex flex-wrap gap-3">
+              {legend.map(([name, color]) => (
+                <span key={name} className="inline-flex items-center gap-1.5 text-sm">
+                  <i className="inline-block h-2.5 w-2.5 rounded-full" style={{ backgroundColor: color }} /> {short(name)}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+      </section>
     </div>
   );
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -2,8 +2,7 @@ import { readUserFromCookie } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import type { Span } from '@/components/CalendarWithBars';
 import { getBaseUrl } from '@/lib/config';
-import RightCalendarClient from './page.client';
-import UpcomingReservations from './_parts/UpcomingReservations';
+import DashboardClient from './page.client';
 
 type Mine = {
   id:string; deviceId:string; deviceName?:string; user:string; userName?:string;
@@ -42,9 +41,6 @@ export default async function Home() {
     participants: r.participants ?? [],
   }));
 
-  const legend = Array.from(new Map(spans.map(s=>[s.name, s.color])).entries());
-  const card = "rounded-xl border border-gray-200 bg-white p-5 shadow-sm";
-
   return (
     <div className="mx-auto max-w-6xl px-6 py-8 space-y-6">
       <div className="flex items-center justify-between">
@@ -55,27 +51,7 @@ export default async function Home() {
         </div>
       </div>
 
-      <div className="grid gap-6 md:grid-cols-3">
-        <section className={`md:col-span-2 ${card}`}>
-          <UpcomingReservations initialItems={upcoming} />
-        </section>
-
-        <section className={card}>
-          <RightCalendarClient spans={spans} />
-          {legend.length>0 && (
-            <div className="mt-4">
-              <div className="text-xs text-gray-500 mb-1">色の対応</div>
-              <div className="flex flex-wrap gap-3">
-                {legend.map(([name,color])=>(
-                  <span key={name} className="inline-flex items-center gap-1.5 text-sm">
-                    <i className="inline-block h-2.5 w-2.5 rounded-full" style={{backgroundColor:color}}/> {short(name)}
-                  </span>
-                ))}
-              </div>
-            </div>
-          )}
-        </section>
-      </div>
+      <DashboardClient initialItems={upcoming} initialSpans={spans} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- refresh dashboard calendar when reservation list updates
- show reservation details in modal when clicking an item
- send reminder email via optional MAIL_WEBHOOK after reservation creation

## Testing
- `npm --prefix web run lint`
- `npm --prefix web run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b507e0d08083238c275ad01df7ab17