### PR TITLE
Add usage guide and device registration pages

### DIFF
--- a/web/src/app/devices/new/page.tsx
+++ b/web/src/app/devices/new/page.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { createDevice } from '@/lib/api';
+import QRCode from 'qrcode.react';
+
+export default function NewDevicePage() {
+  const search = useSearchParams();
+  const [group, setGroup] = useState('');
+  const [name, setName] = useState('');
+  const [note, setNote] = useState('');
+  const [existing, setExisting] = useState('');
+  const [result, setResult] = useState<any>(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const g = search.get('group');
+    if (g) setGroup(g);
+  }, [search]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    try {
+      const payload: any = { slug: group, name, note };
+      if (existing) payload.deviceSlug = existing;
+      const r = await createDevice(payload);
+      setResult(r.data || r);
+    } catch (err: any) {
+      setError(err?.message || '登録に失敗しました');
+      setResult(null);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="p-4 max-w-lg space-y-4">
+      <h1 className="text-2xl font-bold">機器登録</h1>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input
+          value={group}
+          onChange={(e) => setGroup(e.target.value)}
+          placeholder="グループslug"
+          className="input w-full"
+          required
+        />
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="機器名"
+          className="input w-full"
+          required
+        />
+        <textarea
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="使用上の注意"
+          className="input w-full"
+        />
+        <input
+          value={existing}
+          onChange={(e) => setExisting(e.target.value)}
+          placeholder="既存の機器コード（任意）"
+          className="input w-full"
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          className="btn-primary"
+        >
+          登録
+        </button>
+      </form>
+      {error && <div className="text-sm text-red-600">{error}</div>}
+      {result && (
+        <div className="space-y-2 border rounded p-3">
+          <p>
+            機器コード: <span className="font-mono">{result.slug}</span>
+          </p>
+          <QRCode value={result.slug} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/devices/page.tsx
+++ b/web/src/app/devices/page.tsx
@@ -1,0 +1,19 @@
+import Image from 'next/image';
+
+export default function DevicesPage() {
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">機器の管理</h1>
+      <p>下の画像をクリックして新しい機器を登録します。</p>
+      <a href="/devices/new">
+        <Image
+          src="https://via.placeholder.com/300x200?text=Register+Device"
+          alt="register device"
+          width={300}
+          height={200}
+          className="border rounded"
+        />
+      </a>
+    </div>
+  );
+}

--- a/web/src/app/groups/[slug]/GroupScreenClient.tsx
+++ b/web/src/app/groups/[slug]/GroupScreenClient.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
-import { createDevice, listDevices } from '@/lib/api';
 
 export default function GroupScreenClient({
   initialGroup,
@@ -14,11 +13,7 @@ export default function GroupScreenClient({
   defaultReserver?: string;
 }) {
   const group = initialGroup;
-  const [devices, setDevices] = useState<any[]>(initialDevices);
-  const [deviceName, setDeviceName] = useState('');
-  const [note, setNote] = useState('');
-  const [deviceError, setDeviceError] = useState<string | null>(null);
-  const [addingDevice, setAddingDevice] = useState(false);
+  const [devices] = useState<any[]>(initialDevices);
 
   const [deviceId, setDeviceId] = useState('');
   const reserver = defaultReserver || '';
@@ -36,23 +31,6 @@ export default function GroupScreenClient({
     if (preselect) setDeviceId(preselect);
   }, [searchParams]);
 
-
-  async function handleAddDevice() {
-    if (!deviceName.trim()) return;
-    setAddingDevice(true);
-    setDeviceError(null);
-    try {
-      await createDevice({ slug: group.slug, name: deviceName, note });
-      const updated = await listDevices(group.slug);
-      setDevices(updated.data || []);
-      setDeviceName('');
-      setNote('');
-    } catch (err: any) {
-      setDeviceError(err?.message || 'Failed to add device');
-    } finally {
-      setAddingDevice(false);
-    }
-  }
 
   async function handleAddReservation(e: React.FormEvent) {
     e.preventDefault();
@@ -144,30 +122,12 @@ export default function GroupScreenClient({
             </li>
           ))}
         </ul>
-        <div className="grid gap-2 sm:grid-cols-2 max-w-xl">
-          <input
-            value={deviceName}
-            onChange={(e) => setDeviceName(e.target.value)}
-            placeholder="例：蛍光測定器"
-            className="input"
-          />
-          <input
-            value={note}
-            onChange={(e) => setNote(e.target.value)}
-            placeholder="備考（任意）"
-            className="input"
-          />
-          <button
-            onClick={handleAddDevice}
-            disabled={addingDevice}
-            className="btn-primary sm:col-span-2 w-24"
-          >
-            追加
-          </button>
-          {deviceError && (
-            <div className="text-sm text-red-600 sm:col-span-2">{deviceError}</div>
-          )}
-        </div>
+        <a
+          href={`/devices/new?group=${encodeURIComponent(group.slug)}`}
+          className="btn-primary inline-block"
+        >
+          機器を追加
+        </a>
       </section>
 
       <section className="space-y-3">

--- a/web/src/app/usage/page.tsx
+++ b/web/src/app/usage/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+export default function UsagePage() {
+  return (
+    <div className="max-w-3xl p-4 space-y-4">
+      <h1 className="text-2xl font-bold">アプリの使い方</h1>
+      <ol className="list-decimal ml-6 space-y-2">
+        <li>グループを作成するか、既存のグループに参加します。</li>
+        <li>機器登録ページから機器を登録し、生成された機器コードを共有します。</li>
+        <li>カレンダーから機器の予約を追加・確認します。</li>
+      </ol>
+      <p className="text-sm text-neutral-500">
+        複数のグループで同じ機器を利用する場合は、機器コードを入力して登録してください。
+      </p>
+    </div>
+  );
+}

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -7,10 +7,12 @@ export default async function Header() {
       <div className="mx-auto max-w-6xl px-6 h-12 flex items-center justify-between">
         <a href="/" className="font-semibold tracking-tight">Lab Yoyaku</a>
         <nav className="flex items-center gap-4 text-sm">
+          <a className="hover:underline" href="/usage">使い方</a>
           {me ? (
             <>
               <a className="hover:underline" href="/">ダッシュボード</a>
               <a className="hover:underline" href="/groups">グループ</a>
+              <a className="hover:underline" href="/devices">機器</a>
               <span className="hidden sm:inline text-gray-500">{me.name || me.email}</span>
               <form action="/api/auth/logout" method="post">
                 <button className="rounded border px-3 py-1 hover:bg-gray-50">ログアウト</button>


### PR DESCRIPTION
## Summary
- add usage guide page and navigation links
- create device management and registration pages with QR codes
- link group screens to new registration flow

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b5d928a44c8323a3e8d5c2f3abbd9f