### PR TITLE
Allow placeholder images and refine layouts

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    domains: ['via.placeholder.com'],
+  },
+};
 
 export default nextConfig;

--- a/web/src/app/devices/new/page.tsx
+++ b/web/src/app/devices/new/page.tsx
@@ -38,7 +38,7 @@ export default function NewDevicePage() {
   }
 
   return (
-    <div className="p-4 max-w-lg space-y-4">
+    <div className="p-4 max-w-lg mx-auto space-y-4">
       <h1 className="text-2xl font-bold">機器登録</h1>
       <form onSubmit={handleSubmit} className="space-y-2">
         <input

--- a/web/src/app/devices/page.tsx
+++ b/web/src/app/devices/page.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 
 export default function DevicesPage() {
   return (
-    <div className="p-4 space-y-4">
+    <div className="p-4 space-y-4 max-w-lg mx-auto">
       <h1 className="text-2xl font-bold">機器の管理</h1>
       <p>下の画像をクリックして新しい機器を登録します。</p>
       <a href="/devices/new">

--- a/web/src/app/groups/[slug]/GroupScreenClient.tsx
+++ b/web/src/app/groups/[slug]/GroupScreenClient.tsx
@@ -93,7 +93,7 @@ export default function GroupScreenClient({
   }
 
   return (
-    <div className="max-w-4xl space-y-8">
+    <div className="max-w-4xl mx-auto space-y-8">
       <header className="space-y-1">
         <h1 className="text-3xl font-bold">{group.name}</h1>
         <p className="text-sm text-neutral-500">slug: {group.slug}</p>

--- a/web/src/components/CalendarWithBars.tsx
+++ b/web/src/components/CalendarWithBars.tsx
@@ -52,7 +52,7 @@ export default function CalendarWithBars({
           return (
             <button key={i} className="h-16 rounded-lg border relative text-left px-1"
                     onClick={()=>setSel(d)}>
-              <div className="absolute right-1 top-1 text-xs">{d.getDate()}</div>
+              <div className="absolute left-1 top-1 text-xs">{d.getDate()}</div>
               <div className="absolute left-1 right-1 bottom-2 space-y-1">
                 {todays.slice(0,2).map((s)=>(
                   <div key={s.id} className="h-4 rounded-sm flex items-center px-1"


### PR DESCRIPTION
## Summary
- configure Next.js to load images from via.placeholder.com
- center device and group pages for more natural alignment
- show calendar day numbers on the left for conventional look

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b5e00c16f48323a54b1a8f76b001b2