### PR TITLE
Improve calendar printing and device management

### DIFF
--- a/web/src/app/api/mock/devices/route.ts
+++ b/web/src/app/api/mock/devices/route.ts
@@ -26,3 +26,21 @@ export async function POST(req: Request) {
   return NextResponse.json({ ok: true, data: d });
 }
 
+export async function DELETE(req: Request) {
+  const body = await req.json();
+  const { slug, id } = body || {};
+  if (!slug || !id)
+    return NextResponse.json({ ok: false, error: 'invalid request' }, { status: 400 });
+  const db = loadDB();
+  const g = db.groups.find((x: any) => x.slug === slug);
+  if (!g) return NextResponse.json({ ok: false, error: 'group not found' }, { status: 404 });
+  const idx = (g.devices ?? []).findIndex((d: any) => d.id === id);
+  if (idx === -1)
+    return NextResponse.json({ ok: false, error: 'device not found' }, { status: 404 });
+  const removed = g.devices.splice(idx, 1)[0];
+  if (g.reservations)
+    g.reservations = g.reservations.filter((r: any) => r.deviceId !== removed.id);
+  saveDB(db);
+  return NextResponse.json({ ok: true });
+}
+

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -15,6 +15,7 @@ a:focus-visible { box-shadow: 0 0 0 3px rgba(59,130,246,.5); border-radius: .5re
 /* 任意: 簡易ユーティリティ */
 .input { @apply border rounded px-3 py-2 w-full; }
 .btn-primary { @apply inline-flex items-center justify-center rounded px-4 py-2 bg-indigo-600 text-white hover:bg-indigo-700; }
+.btn-danger { @apply inline-flex items-center justify-center rounded px-4 py-2 bg-red-600 text-white hover:bg-red-700; }
 
 @media print {
   @page { size: A4; margin: 20mm; }
@@ -22,4 +23,5 @@ a:focus-visible { box-shadow: 0 0 0 3px rgba(59,130,246,.5); border-radius: .5re
   .max-w-6xl,
   .max-w-4xl,
   .max-w-3xl { max-width: 100% !important; }
+  * { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
 }

--- a/web/src/app/groups/[slug]/GroupScreenClient.tsx
+++ b/web/src/app/groups/[slug]/GroupScreenClient.tsx
@@ -13,7 +13,8 @@ export default function GroupScreenClient({
   defaultReserver?: string;
 }) {
   const group = initialGroup;
-  const [devices] = useState<any[]>(initialDevices);
+  const [devices, setDevices] = useState<any[]>(initialDevices);
+  const [removingId, setRemovingId] = useState<string | null>(null);
 
   const [deviceId, setDeviceId] = useState('');
   const reserver = defaultReserver || '';
@@ -92,6 +93,24 @@ export default function GroupScreenClient({
     }
   }
 
+  async function handleDeleteDevice(id: string) {
+    if (!confirm('この機器を削除しますか？')) return;
+    setRemovingId(id);
+    try {
+      const r = await fetch('/api/mock/devices', {
+        method: 'DELETE',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ slug: group.slug, id }),
+      });
+      if (!r.ok) throw new Error('failed');
+      setDevices((prev) => prev.filter((d) => d.id !== id));
+    } catch (e) {
+      alert('削除に失敗しました');
+    } finally {
+      setRemovingId(null);
+    }
+  }
+
   return (
     <div className="max-w-4xl mx-auto space-y-8">
       <header className="space-y-1">
@@ -113,14 +132,23 @@ export default function GroupScreenClient({
                 </a>
                 <div className="text-xs text-neutral-500">ID: {d.id}</div>
               </div>
-              <a
-                href={`/api/mock/devices/${d.slug}/qr`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="btn-primary"
-              >
-                QRコード
-              </a>
+              <div className="flex gap-2">
+                <a
+                  href={`/api/mock/devices/${d.slug}/qr`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="btn-primary"
+                >
+                  QRコード
+                </a>
+                <button
+                  onClick={() => handleDeleteDevice(d.id)}
+                  className="btn-danger"
+                  disabled={removingId === d.id}
+                >
+                  削除
+                </button>
+              </div>
             </li>
           ))}
         </ul>

--- a/web/src/components/CalendarWithBars.tsx
+++ b/web/src/components/CalendarWithBars.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useMemo, useState } from 'react';
+import clsx from 'clsx';
 
 export type Span = {
   id: string;
@@ -49,16 +50,30 @@ export default function CalendarWithBars({
       <div className="grid grid-cols-7 gap-1">
         {weeks.flat().map((d,i)=>{
           const todays = map.get(d.toDateString()) ?? [];
+          const isToday = d.toDateString() === new Date().toDateString();
+          const isSun = d.getDay() === 0;
+          const isSat = d.getDay() === 6;
           return (
-            <button key={i} className="h-16 rounded-lg border relative text-left px-1"
-                    onClick={()=>setSel(d)}>
+            <button
+              key={i}
+              className={clsx(
+                'h-16 rounded-lg border relative text-left px-1',
+                isSun && 'bg-red-50',
+                isSat && 'bg-blue-50',
+                isToday && 'border-2 border-indigo-500'
+              )}
+              onClick={()=>setSel(d)}
+            >
               <div className="absolute left-1 top-1 text-xs">{d.getDate()}</div>
               <div className="absolute left-1 right-1 bottom-2 space-y-1">
                 {todays.slice(0,2).map((s)=>(
-                  <div key={s.id} className="h-4 rounded-sm flex items-center px-1"
-                       style={{backgroundColor:s.color, color:'#fff'}}>
+                  <div
+                    key={s.id}
+                    className="h-4 rounded-sm flex items-center px-1 text-white print:text-black"
+                    style={{backgroundColor:s.color}}
+                  >
                     <span className="text-[10px] leading-none truncate">
-                      {short(`${s.name}（${labelForDay(d, s.start, s.end)}） / ${s.by}`, 22)}
+                      {short(`${s.name}（${labelForDay(d, s.start, s.end)}） / ${s.by}`, 28)}
                     </span>
                   </div>
                 ))}


### PR DESCRIPTION
## Summary
- Ensure calendar colors print and show weekend/today highlights
- Add ability to delete devices from groups and clean up reservations
- Provide red danger button and print color adjustments

## Testing
- `pnpm -F web lint` *(fails: Error when performing request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `./node_modules/.bin/eslint .`
- `./node_modules/.bin/tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b5e7e3f4508323a6005849fe80a0f9