### PR TITLE
Improve printing, tutorial, and device workflow

### DIFF
--- a/web/src/app/devices/new/page.tsx
+++ b/web/src/app/devices/new/page.tsx
@@ -1,17 +1,16 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { createDevice } from '@/lib/api';
-import QRCode from 'qrcode.react';
 
 export default function NewDevicePage() {
   const search = useSearchParams();
+  const router = useRouter();
   const [group, setGroup] = useState('');
   const [name, setName] = useState('');
   const [note, setNote] = useState('');
   const [existing, setExisting] = useState('');
-  const [result, setResult] = useState<any>(null);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
@@ -27,11 +26,10 @@ export default function NewDevicePage() {
     try {
       const payload: any = { slug: group, name, note };
       if (existing) payload.deviceSlug = existing;
-      const r = await createDevice(payload);
-      setResult(r.data || r);
+      await createDevice(payload);
+      router.push(`/groups/${group}`);
     } catch (err: any) {
       setError(err?.message || '登録に失敗しました');
-      setResult(null);
     } finally {
       setLoading(false);
     }
@@ -76,14 +74,6 @@ export default function NewDevicePage() {
         </button>
       </form>
       {error && <div className="text-sm text-red-600">{error}</div>}
-      {result && (
-        <div className="space-y-2 border rounded p-3">
-          <p>
-            機器コード: <span className="font-mono">{result.slug}</span>
-          </p>
-          <QRCode value={result.slug} />
-        </div>
-      )}
     </div>
   );
 }

--- a/web/src/app/usage/page.tsx
+++ b/web/src/app/usage/page.tsx
@@ -5,9 +5,27 @@ export default function UsagePage() {
     <div className="max-w-3xl p-4 space-y-4">
       <h1 className="text-2xl font-bold">アプリの使い方</h1>
       <ol className="list-decimal ml-6 space-y-2">
-        <li>グループを作成するか、既存のグループに参加します。</li>
-        <li>機器登録ページから機器を登録し、生成された機器コードを共有します。</li>
-        <li>カレンダーから機器の予約を追加・確認します。</li>
+        <li>
+          <span className="font-medium">グループに参加する：</span>
+          新しくグループを作成するか、共有されたリンクから既存のグループに参加します。
+        </li>
+        <li>
+          <span className="font-medium">機器を登録する：</span>
+          「機器登録」ページで機器名と注意事項を入力して登録します。<br />
+          すでに他のグループで使っている機器は、機器コードを入力して共有できます。
+        </li>
+        <li>
+          <span className="font-medium">予約を追加する：</span>
+          グループページのフォームから開始・終了時刻を指定して予約します。
+        </li>
+        <li>
+          <span className="font-medium">予約の確認と管理：</span>
+          カレンダーから予約状況を確認し、不要になった予約は削除できます。
+        </li>
+        <li>
+          <span className="font-medium">カレンダーの印刷：</span>
+          右上の「印刷」ボタンから、現在の月の予定を印刷できます。
+        </li>
       </ol>
       <p className="text-sm text-neutral-500">
         複数のグループで同じ機器を利用する場合は、機器コードを入力して登録してください。

--- a/web/src/components/CalendarWithBars.tsx
+++ b/web/src/components/CalendarWithBars.tsx
@@ -72,8 +72,11 @@ export default function CalendarWithBars({
                     className="h-4 rounded-sm flex items-center px-1 text-white print:text-black"
                     style={{backgroundColor:s.color}}
                   >
-                    <span className="text-[10px] leading-none truncate">
+                    <span className="text-[10px] leading-none truncate print:hidden">
                       {short(`${s.name}（${labelForDay(d, s.start, s.end)}） / ${s.by}`, 28)}
+                    </span>
+                    <span className="hidden text-[10px] leading-none truncate print:inline">
+                      {short(`${s.name} / ${s.by}`, 28)}
                     </span>
                   </div>
                 ))}


### PR DESCRIPTION
## Summary
- Limit printed calendar labels to device and user names
- Redirect to group page after creating a device
- Expand usage guide with clearer step-by-step instructions

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b5ebbcd9cc83239f603ad0cc0e1ee8