### PR TITLE
feat: refresh color palette and typography

### DIFF
--- a/web/src/app/_parts/HomeDashboard.tsx
+++ b/web/src/app/_parts/HomeDashboard.tsx
@@ -33,7 +33,7 @@ export default async function HomeDashboard() {
       </section>
 
       <section className="space-x-3">
-        <Link className="px-3 py-2 rounded bg-indigo-600 hover:bg-indigo-700 text-white" href="/groups/new">グループを作成</Link>
+        <Link className="px-3 py-2 rounded bg-primary hover:bg-primary-dark text-white" href="/groups/new">グループを作成</Link>
         <Link className="px-3 py-2 rounded border" href="/groups/join">グループに参加</Link>
         <Link className="px-3 py-2 rounded border" href="/dashboard">ダッシュボード</Link>
         <Link className="px-3 py-2 rounded border" href="/groups">グループ一覧</Link>

--- a/web/src/app/_parts/UpcomingReservations.tsx
+++ b/web/src/app/_parts/UpcomingReservations.tsx
@@ -72,12 +72,12 @@ export default function UpcomingReservations({
           >
             {loading ? '更新中…' : '更新'}
           </button>
-          <a className="text-sm text-gray-500 hover:underline" href="/groups">すべてのグループへ</a>
+          <a className="text-sm text-muted hover:underline" href="/groups">すべてのグループへ</a>
         </div>
       </div>
 
       {!items.length ? (
-        <div className="text-gray-500 text-sm">直近の予約はありません。右上の「グループ参加」から始めましょう。</div>
+        <div className="text-muted text-sm">直近の予約はありません。右上の「グループ参加」から始めましょう。</div>
       ) : (
         <ul className="space-y-2">
           {items.map((r) => (
@@ -91,12 +91,12 @@ export default function UpcomingReservations({
                 style={{ backgroundColor: colorFromString(r.deviceId) }}
               />
               <div className="flex-1">
-                <div className="text-sm text-gray-600">
+                <div className="text-sm text-muted">
                   {fmtRange(r.start, r.end)}（{r.groupName}）
                 </div>
                 <div className="font-medium mt-0.5">機器：{r.deviceName ?? r.deviceId}</div>
                 {r.purpose && (
-                  <div className="text-sm text-gray-500">用途：{r.purpose}</div>
+                  <div className="text-sm text-muted">用途：{r.purpose}</div>
                 )}
               </div>
             </li>
@@ -171,14 +171,14 @@ function Modal({
       <div className="bg-white rounded-t-2xl sm:rounded-2xl shadow-lg w-full max-w-lg p-5 space-y-3">
         <div className="flex items-center justify-between mb-2">
           <div className="font-semibold">予約の詳細</div>
-          <button onClick={onClose} className="text-sm text-gray-500 hover:underline">
+          <button onClick={onClose} className="text-sm text-muted hover:underline">
             閉じる
           </button>
         </div>
         <div className="text-sm">{fmtRange(item.start, item.end)}（{item.groupName}）</div>
         <div className="font-medium">機器：{item.deviceName ?? item.deviceId}</div>
         {item.purpose && (
-          <div className="text-sm text-gray-600">用途：{item.purpose}</div>
+          <div className="text-sm text-muted">用途：{item.purpose}</div>
         )}
 
         <div className="mt-2 text-sm">
@@ -199,7 +199,7 @@ function Modal({
         <div className="flex justify-between items-center mt-4">
           <a
             href={`/groups/${item.groupSlug}`}
-            className="text-sm text-indigo-600 hover:underline"
+            className="text-sm text-primary hover:underline"
           >
             グループページへ
           </a>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1,21 +1,26 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Open+Sans:wght@400;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 html, body { height: 100%; }
 
+@layer base {
+  body { @apply bg-background text-gray-900 font-sans; }
+  a { @apply text-primary; outline: none; }
+  a:hover { @apply text-primary-dark; }
+  a:focus-visible { box-shadow: 0 0 0 3px rgba(74,144,226,.5); border-radius: .5rem; }
+}
+
 .app-container {
   @apply max-w-[1040px] mx-auto px-4 sm:px-6;
 }
 
-/* ベースのリンク色とフォーカス見やすく */
-a { outline: none; }
-a:focus-visible { box-shadow: 0 0 0 3px rgba(59,130,246,.5); border-radius: .5rem; }
-
 /* 任意: 簡易ユーティリティ */
-.input { @apply border rounded px-3 py-2 w-full; }
-.btn-primary { @apply inline-flex items-center justify-center rounded px-4 py-2 bg-indigo-600 text-white hover:bg-indigo-700; }
-.btn-danger { @apply inline-flex items-center justify-center rounded px-4 py-2 bg-red-600 text-white hover:bg-red-700; }
+.input { @apply border rounded-md px-3 py-2 w-full focus:border-primary focus:ring-1 focus:ring-primary; }
+.btn-primary { @apply inline-flex items-center justify-center rounded-md px-4 py-2 bg-primary text-white hover:bg-primary-dark; }
+.btn-danger { @apply inline-flex items-center justify-center rounded-md px-4 py-2 bg-red-600 text-white hover:bg-red-700; }
 
 @media print {
   @page { size: A4; margin: 20mm; }

--- a/web/src/app/groups/join/page.tsx
+++ b/web/src/app/groups/join/page.tsx
@@ -69,7 +69,7 @@ export default function GroupJoinPage() {
           </p>
         )}
         <button
-          className="rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white px-5 py-2 disabled:opacity-50 disabled:cursor-not-allowed"
+          className="rounded-xl bg-primary hover:bg-primary-dark text-white px-5 py-2 disabled:opacity-50 disabled:cursor-not-allowed"
           disabled={loading || !group || !password}
           aria-disabled={loading || !group || !password}
         >

--- a/web/src/app/groups/new/page.tsx
+++ b/web/src/app/groups/new/page.tsx
@@ -57,7 +57,7 @@ export default function NewGroupPage() {
         <button
           type="submit"
           disabled={pending}
-          className="rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white px-5 py-2"
+          className="rounded-xl bg-primary hover:bg-primary-dark text-white px-5 py-2"
         >
           作成
         </button>

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -3,10 +3,10 @@ import Header from '@/components/Header';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="ja">
-      <body>
+    <html lang="ja" className="h-full">
+      <body className="min-h-full bg-background text-gray-900 font-sans">
         <Header />
-        <main>{children}</main>
+        <main className="app-container py-8">{children}</main>
       </body>
     </html>
   );

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -147,12 +147,12 @@ export default function LoginPage() {
               />
               {lerr && <div className="text-sm text-red-600">{lerr}</div>}
               <button
-                className="w-full rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 disabled:opacity-60"
+                className="w-full rounded-lg bg-primary hover:bg-primary-dark text-white px-4 py-2 disabled:opacity-60"
                 disabled={loadingLogin}
               >
                 {loadingLogin ? 'ログイン中…' : 'ログイン'}
               </button>
-              <p className="text-xs text-gray-500 text-center">デモ: <b>demo / demo</b> でもログインできます。</p>
+              <p className="text-xs text-muted text-center">デモ: <b>demo / demo</b> でもログインできます。</p>
             </form>
           )}
 
@@ -187,10 +187,10 @@ export default function LoginPage() {
                 onChange={e => setRPass2(e.target.value)}
                 required
               />
-              <p className="text-sm text-gray-500 mt-1">{PASSWORD_HINT}</p>
+              <p className="text-sm text-muted mt-1">{PASSWORD_HINT}</p>
               {rerr && <div className="text-sm text-red-600">{rerr}</div>}
               <button
-                className="w-full rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 disabled:opacity-60"
+                className="w-full rounded-lg bg-primary hover:bg-primary-dark text-white px-4 py-2 disabled:opacity-60"
                 disabled={loadingReg}
               >
                 {loadingReg ? '作成中…' : 'アカウントを作成'}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -46,8 +46,8 @@ export default async function Home() {
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">ダッシュボード</h1>
         <div className="flex gap-2">
-          <a href="/groups/new"  className="rounded-lg border px-3 py-2 bg-indigo-600 text-white hover:bg-indigo-700">グループ作成</a>
-          <a href="/groups/join" className="rounded-lg border px-3 py-2 hover:bg-gray-50">グループ参加</a>
+          <a href="/groups/new"  className="rounded-lg border px-3 py-2 bg-primary text-white hover:bg-primary-dark">グループ作成</a>
+          <a href="/groups/join" className="rounded-lg border border-primary text-primary px-3 py-2 hover:bg-primary/10">グループ参加</a>
         </div>
       </div>
 

--- a/web/src/components/CalendarWithBars.tsx
+++ b/web/src/components/CalendarWithBars.tsx
@@ -60,7 +60,7 @@ export default function CalendarWithBars({
                 'h-16 rounded-lg border relative text-left px-1',
                 isSun && 'bg-red-50',
                 isSat && 'bg-blue-50',
-                isToday && 'border-2 border-indigo-500'
+                isToday && 'border-2 border-primary'
               )}
               onClick={()=>setSel(d)}
             >
@@ -80,7 +80,7 @@ export default function CalendarWithBars({
                     </span>
                   </div>
                 ))}
-                {todays.length>2 && <div className="text-[10px] text-gray-500">+{todays.length-2}</div>}
+                {todays.length>2 && <div className="text-[10px] text-muted">+{todays.length-2}</div>}
               </div>
             </button>
           );
@@ -109,9 +109,9 @@ function DayModal({ date, items, onClose }:{
       <div className="bg-white rounded-t-2xl sm:rounded-2xl shadow-lg w-full max-w-lg p-5">
         <div className="flex items-center justify-between mb-3">
           <div className="font-semibold">{date.getMonth()+1}月{date.getDate()}日の予約</div>
-          <button onClick={onClose} className="text-sm text-gray-500 hover:underline">閉じる</button>
+          <button onClick={onClose} className="text-sm text-muted hover:underline">閉じる</button>
         </div>
-        {!items.length && <div className="text-sm text-gray-500">この日の予約はありません。</div>}
+        {!items.length && <div className="text-sm text-muted">この日の予約はありません。</div>}
         <ul className="space-y-2">
           {items.map((s)=>(
             <li key={s.id} className="rounded-lg border p-3">
@@ -120,9 +120,9 @@ function DayModal({ date, items, onClose }:{
                 {hhmm(s.start)} – {hhmm(s.end)}　/　予約者: <span className="font-medium">{s.by}</span>
               </div>
               {s.participants?.length ? (
-                <div className="text-xs text-gray-500 mt-1">参加者: {s.participants.join(', ')}</div>
+                <div className="text-xs text-muted mt-1">参加者: {s.participants.join(', ')}</div>
               ) : null}
-              <a href={`/groups/${s.groupSlug}`} className="text-sm text-indigo-600 hover:underline mt-2 inline-block">
+              <a href={`/groups/${s.groupSlug}`} className="text-sm text-primary hover:underline mt-2 inline-block">
                 グループページへ
               </a>
             </li>

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -3,7 +3,7 @@ import { readUserFromCookie } from '@/lib/auth';
 export default async function Header() {
   const me = await readUserFromCookie();
   return (
-    <header className="border-b bg-white">
+    <header className="bg-primary text-white shadow">
       <div className="mx-auto max-w-6xl px-6 h-12 flex items-center justify-between">
         <a href="/" className="font-semibold tracking-tight">Lab Yoyaku</a>
         <nav className="flex items-center gap-4 text-sm">
@@ -12,15 +12,15 @@ export default async function Header() {
             <>
               <a className="hover:underline" href="/">ダッシュボード</a>
               <a className="hover:underline" href="/groups">グループ</a>
-              <span className="hidden sm:inline text-gray-500">{me.name || me.email}</span>
+              <span className="hidden sm:inline text-white/80">{me.name || me.email}</span>
               <form action="/api/auth/logout" method="post">
-                <button className="rounded border px-3 py-1 hover:bg-gray-50">ログアウト</button>
+                <button className="rounded-md bg-white/10 px-3 py-1 hover:bg-white/20">ログアウト</button>
               </form>
             </>
           ) : (
             <>
-              <a className="rounded border px-3 py-1 hover:bg-gray-50" href="/login?tab=login">ログイン</a>
-              <a className="rounded border px-3 py-1 hover:bg-gray-50" href="/login?tab=register">新規作成</a>
+              <a className="rounded-md bg-white/10 px-3 py-1 hover:bg-white/20" href="/login?tab=login">ログイン</a>
+              <a className="rounded-md bg-accent px-3 py-1 text-white hover:bg-accent/90" href="/login?tab=register">新規作成</a>
             </>
           )}
         </nav>

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -1,14 +1,22 @@
 "use client";
 import clsx from "clsx";
 export default function Button(
-  {children, className, variant='outline', ...props}:
-  React.ButtonHTMLAttributes<HTMLButtonElement> & {variant?:'primary'|'outline'|'danger'}
+  { children, className, variant = 'outline', ...props }:
+    React.ButtonHTMLAttributes<HTMLButtonElement> & {
+      variant?: 'primary' | 'outline' | 'danger' | 'accent';
+    },
 ){
-  const base="inline-flex items-center justify-center rounded-2xl px-4 py-2 text-sm transition disabled:opacity-50 disabled:cursor-not-allowed";
-  const styles={
-    primary:"bg-indigo-600 text-white hover:bg-indigo-700",
-    outline:"border hover:-translate-y-0.5 shadow-sm",
-    danger:"bg-rose-600 text-white hover:bg-rose-500"
-  };
-  return <button {...props} className={clsx(base, styles[variant], className)}>{children}</button>
+  const base =
+    'inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm transition disabled:opacity-50 disabled:cursor-not-allowed';
+  const styles = {
+    primary: 'bg-primary text-white hover:bg-primary-dark',
+    outline: 'border border-primary text-primary hover:bg-primary/10',
+    danger: 'bg-rose-600 text-white hover:bg-rose-500',
+    accent: 'bg-accent text-white hover:bg-accent/90',
+  } as const;
+  return (
+    <button {...props} className={clsx(base, styles[variant], className)}>
+      {children}
+    </button>
+  );
 }

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,6 +1,23 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ['./src/**/*.{ts,tsx,js,jsx,mdx}'],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      colors: {
+        primary: '#4A90E2',
+        'primary-dark': '#3F7ACC',
+        accent: '#F5A623',
+        success: '#7ED321',
+        background: '#F8F9FA',
+        muted: '#6C757D',
+      },
+      fontFamily: {
+        sans: ['"Open Sans"', '"Noto Sans JP"', 'sans-serif'],
+      },
+      boxShadow: {
+        card: '0 1px 2px rgba(0,0,0,0.05), 0 1px 3px rgba(0,0,0,0.1)',
+      },
+    },
+  },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- add custom color palette and fonts to Tailwind
- apply new background, typography, and link styles across app
- redesign header and button components with primary and accent colors

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b74bae66388323af3c78d57a5a23e8