### PR TITLE
Show joined groups and improve group printing

### DIFF
--- a/web/src/app/api/me/groups/route.ts
+++ b/web/src/app/api/me/groups/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { readUserFromCookie } from '@/lib/auth';
+import { loadDB } from '@/lib/mockdb';
+
+export async function GET() {
+  const me = await readUserFromCookie();
+  if (!me) return NextResponse.json({ ok: false }, { status: 401 });
+
+  const db = loadDB();
+  const groups = (db.groups ?? [])
+    .filter((g: any) => Array.isArray(g.members) && g.members.includes(me.email))
+    .map((g: any) => ({ slug: g.slug, name: g.name }));
+
+  return NextResponse.json({ ok: true, data: groups });
+}

--- a/web/src/app/api/mock/groups/[slug]/qr/route.ts
+++ b/web/src/app/api/mock/groups/[slug]/qr/route.ts
@@ -1,0 +1,26 @@
+import { loadDB } from '@/lib/mockdb';
+import QRCode from 'qrcode';
+import { getBaseUrl } from '@/lib/config';
+
+export const runtime = 'nodejs';
+
+export async function GET(_req: Request, { params }: { params: { slug: string } }) {
+  const db = loadDB();
+  const group = db.groups.find((g: any) => g.slug === params.slug);
+  if (!group) return new Response('Not found', { status: 404 });
+
+  const base = getBaseUrl();
+  const url = `${base}/groups/${group.slug}`;
+
+  const dataUrl = await QRCode.toDataURL(url, { margin: 1, scale: 6 });
+  const base64 = dataUrl.split(',')[1]!;
+  const buf = Buffer.from(base64, 'base64');
+
+  return new Response(buf, {
+    status: 200,
+    headers: {
+      'Content-Type': 'image/png',
+      'Cache-Control': 'no-store',
+    },
+  });
+}

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -67,9 +67,13 @@ export default async function GroupPage({ params }: { params: { slug: string } }
     };
   });
 
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  const fmt = (d: Date) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+
   return (
     <div className="mx-auto max-w-6xl px-6 py-8">
-      <div className="print:hidden">
+      <div className="print:hidden space-y-4">
+        <a href="/" className="text-blue-600 hover:underline">ホームに戻る</a>
         <GroupScreenClient
           initialGroup={group}
           initialDevices={devices}
@@ -81,6 +85,22 @@ export default async function GroupPage({ params }: { params: { slug: string } }
           <PrintButton className="btn-primary" />
         </div>
         <CalendarWithBars weeks={weeks} month={month} spans={spans} />
+        <div className="hidden print:block mt-4">
+          <h2 className="text-xl font-semibold mb-2">予約一覧</h2>
+          <ul className="list-disc pl-5 space-y-1">
+            {reservations.map((r: any) => {
+              const dev = group.devices.find((d: any) => d.id === r.deviceId);
+              const s = fmt(new Date(r.start));
+              const e = fmt(new Date(r.end));
+              return (
+                <li key={r.id}>{`機器: ${dev?.name ?? r.deviceId} / 予約者: ${r.userName || r.user} / 時間: ${s} - ${e}`}</li>
+              );
+            })}
+          </ul>
+          <div className="mt-4">
+            <img src={`/api/mock/groups/${group.slug}/qr`} alt="QRコード" className="w-32 h-32" />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -25,6 +25,17 @@ export default async function Home() {
   const res = await fetch(`${base}/api/me/reservations`, { cache:'no-store' });
   const json = await res.json();
 
+  let myGroups: { slug: string; name: string }[] = [];
+  try {
+    const gRes = await fetch(`${base}/api/me/groups`, { cache: 'no-store' });
+    if (gRes.ok) {
+      const gJson = await gRes.json();
+      myGroups = gJson.data ?? [];
+    }
+  } catch (_) {
+    // ignore
+  }
+
   const upcomingRaw: Mine[] = json.data ?? [];
   upcomingRaw.sort((a,b)=> new Date(a.start).getTime() - new Date(b.start).getTime());
   const upcoming = upcomingRaw.slice(0,10);
@@ -46,10 +57,25 @@ export default async function Home() {
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">ダッシュボード</h1>
         <div className="flex gap-2">
-          <a href="/groups/new"  className="rounded-lg border px-3 py-2 bg-primary text-white hover:bg-primary-dark">グループ作成</a>
+          <a href="/groups/new" className="rounded-lg border px-3 py-2 bg-primary text-white hover:bg-primary-dark">グループ作成</a>
           <a href="/groups/join" className="rounded-lg border border-primary text-primary px-3 py-2 hover:bg-primary/10">グループ参加</a>
         </div>
       </div>
+
+      {myGroups.length > 0 && (
+        <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+          <h2 className="text-xl font-semibold mb-2">参加グループ</h2>
+          <ul className="list-disc pl-5 space-y-1">
+            {myGroups.map((g) => (
+              <li key={g.slug}>
+                <a href={`/groups/${g.slug}`} className="text-blue-600 hover:underline">
+                  {g.name}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
 
       <DashboardClient initialItems={upcoming} initialSpans={spans} />
     </div>


### PR DESCRIPTION
## Summary
- add API and dashboard section to list groups joined by the current user
- enable printing group calendar with reservation details and a QR code
- add home link on group screen for easier navigation

## Testing
- `pnpm -F web lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `pnpm -F web typecheck` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68b74e88b9a083239c80e352647058b0