### PR TITLE
Add navigation controls and richer print view

### DIFF
--- a/web/src/components/BackButton.tsx
+++ b/web/src/components/BackButton.tsx
@@ -1,0 +1,12 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import React from 'react';
+
+export default function BackButton({ className, children }: { className?: string; children?: React.ReactNode }) {
+  const router = useRouter();
+  return (
+    <button onClick={() => router.back()} className={className}>
+      {children ?? '戻る'}
+    </button>
+  );
+}

--- a/web/src/components/ReservationList.tsx
+++ b/web/src/components/ReservationList.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+export type ReservationItem = {
+  id: string;
+  deviceName: string;
+  user: string;
+  start: Date;
+  end: Date;
+};
+
+function fmt(d: Date) {
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+export default function ReservationList({ items }: { items: ReservationItem[] }) {
+  if (!items.length) return <p className="text-sm text-neutral-500">予約がありません。</p>;
+  return (
+    <ul className="list-disc pl-5 space-y-1 text-sm">
+      {items.map((i) => (
+        <li key={i.id}>
+          {`機器: ${i.deviceName} / 予約者: ${i.user} / 時間: ${fmt(i.start)} - ${fmt(i.end)}`}
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable BackButton component
- show reservation list and QR code on device/group pages with month heading
- expose reservation list component for re-use

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b7b13732b48323ac891bca946d89ac