### PR TITLE
Show QR codes only when printing

### DIFF
--- a/web/src/app/devices/[slug]/page.tsx
+++ b/web/src/app/devices/[slug]/page.tsx
@@ -83,7 +83,7 @@ export default async function DevicePage({ params }: { params: { slug: string } 
           alt="QRコード"
           width={128}
           height={128}
-          className="mt-4 ml-auto print:fixed print:right-5 print:bottom-5"
+          className="hidden print:block mt-4 ml-auto print:fixed print:right-5 print:bottom-5"
         />
       </div>
     </div>

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -115,7 +115,7 @@ export default async function GroupPage({ params }: { params: { slug: string } }
           alt="QRコード"
           width={128}
           height={128}
-          className="mt-4 ml-auto print:fixed print:right-5 print:bottom-5"
+          className="hidden print:block mt-4 ml-auto print:fixed print:right-5 print:bottom-5"
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Hide QR codes on group and device pages during normal viewing
- Display QR codes only when printing to keep screen uncluttered

## Testing
- `npx --no-install next lint --max-warnings=0`
- `npx --no-install tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68b8538f03cc8323a0dd5b14768185e5