### PR TITLE
feat: add month navigation and printable QR codes

### DIFF
--- a/web/src/app/devices/[slug]/page.tsx
+++ b/web/src/app/devices/[slug]/page.tsx
@@ -5,7 +5,6 @@ import { getBaseUrl } from '@/lib/config';
 import PrintButton from '@/components/PrintButton';
 import BackButton from '@/components/BackButton';
 import ReservationList, { ReservationItem } from '@/components/ReservationList';
-import Image from 'next/image';
 
 function buildMonth(base = new Date()) {
   const y = base.getFullYear(), m = base.getMonth();
@@ -24,7 +23,13 @@ function buildMonth(base = new Date()) {
   return { weeks, month: m, year: y };
 }
 
-export default async function DevicePage({ params }: { params: { slug: string } }) {
+export default async function DevicePage({
+  params,
+  searchParams,
+}: {
+  params: { slug: string };
+  searchParams: { month?: string };
+}) {
   const { slug } = params;
   const db = loadDB();
   const group = db.groups.find((g: any) => (g.devices ?? []).some((d: any) => d.slug === slug));
@@ -39,7 +44,20 @@ export default async function DevicePage({ params }: { params: { slug: string } 
   const json = r.ok ? await r.json() : { data: [] };
   const reservations = json.data || [];
 
-  const { weeks, month, year } = buildMonth(new Date());
+  const baseMonth = (() => {
+    if (searchParams?.month) {
+      const [y, m] = searchParams.month.split('-').map(Number);
+      if (!isNaN(y) && !isNaN(m)) return new Date(y, m - 1, 1);
+    }
+    return new Date();
+  })();
+  const { weeks, month, year } = buildMonth(baseMonth);
+  const prev = new Date(baseMonth);
+  prev.setMonth(prev.getMonth() - 1);
+  const next = new Date(baseMonth);
+  next.setMonth(next.getMonth() + 1);
+  const pad2 = (n: number) => n.toString().padStart(2, '0');
+  const toParam = (d: Date) => `${d.getFullYear()}-${pad2(d.getMonth() + 1)}`;
   const spans: Span[] = reservations.map((res: any) => ({
     id: res.id,
     name: device.name,
@@ -68,9 +86,23 @@ export default async function DevicePage({ params }: { params: { slug: string } 
       </div>
       <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm relative">
         <div className="flex justify-between items-center mb-2">
+          <a
+            href={`?month=${toParam(prev)}`}
+            className="px-2 py-1 rounded border print:hidden"
+          >
+            ‹
+          </a>
           <div className="font-semibold">{device.name}　{year}年{month + 1}月</div>
-          <div className="print:hidden">
-            <PrintButton className="btn-primary" />
+          <div className="flex items-center gap-2">
+            <a
+              href={`?month=${toParam(next)}`}
+              className="px-2 py-1 rounded border print:hidden"
+            >
+              ›
+            </a>
+            <div className="print:hidden">
+              <PrintButton className="btn-primary" />
+            </div>
           </div>
         </div>
         <CalendarWithBars weeks={weeks} month={month} spans={spans} />
@@ -78,12 +110,12 @@ export default async function DevicePage({ params }: { params: { slug: string } 
           <h2 className="text-xl font-semibold mb-2">予約一覧</h2>
           <ReservationList items={listItems} />
         </div>
-        <Image
+        <img
           src={`/api/mock/devices/${slug}/qr`}
           alt="QRコード"
           width={128}
           height={128}
-          className="hidden print:block mt-4 ml-auto print:fixed print:right-5 print:bottom-5"
+          className="w-0 h-0 opacity-0 mt-4 ml-auto print:w-32 print:h-32 print:opacity-100 print:block print:fixed print:right-5 print:bottom-5"
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- enable month navigation and preset month via query parameter on group and device pages
- show QR codes on printed pages

## Testing
- `pnpm lint` *(fails: Error when performing request to registry)*
- `pnpm typecheck` *(fails: Error when performing request to registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b883b8121083238921cc46c096cde8