### PR TITLE
feat(api): add reservation rule validations

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,8 +1,21 @@
 from fastapi import FastAPI
 
+from .rules import check_reservation
+from .schemas import ReservationCheckRequest
+
 app = FastAPI()
 
 
 @app.get('/health')
 async def health() -> dict[str, str]:
   return {'status': 'ok'}
+
+
+@app.post('/rules/validate')
+async def validate_reservation(
+    req: ReservationCheckRequest,
+) -> dict[str, object]:
+  allowed, reasons = check_reservation(
+      req.rule, req.reservation, req.current_reservations, req.weekly_hours
+  )
+  return {'allowed': allowed, 'reasons': reasons}

--- a/api/app/rules.py
+++ b/api/app/rules.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Iterable, List, Tuple
+
+from .schemas.rules import GroupRule, ReservationWindow, TimeRange
+
+
+def check_reservation(
+    rule: GroupRule,
+    reservation: ReservationWindow,
+    current_reservations: Iterable[ReservationWindow],
+    weekly_hours: float,
+) -> Tuple[bool, List[str]]:
+    """Validate a reservation against the provided rules."""
+
+    reasons: List[str] = []
+    now = datetime.now(reservation.start.tzinfo)
+
+    # Restrict how far in advance a reservation can be made.
+    if rule.reservation_open_days_before is not None:
+        max_start = now + timedelta(days=rule.reservation_open_days_before)
+        if reservation.start > max_start:
+            reasons.append("reservation too far in future")
+
+    # Restrict late reservations close to the start time.
+    if rule.reservation_close_minutes_before is not None:
+        min_start = now + timedelta(minutes=rule.reservation_close_minutes_before)
+        if reservation.start < min_start:
+            reasons.append("reservation too close to start time")
+
+    # Limit number of simultaneous reservations.
+    if rule.max_simultaneous_reservations is not None:
+        current_count = len(list(current_reservations))
+        if current_count >= rule.max_simultaneous_reservations:
+            reasons.append("too many active reservations")
+
+    # Limit total weekly hours.
+    if rule.max_weekly_hours is not None:
+        duration_hours = (reservation.end - reservation.start).total_seconds() / 3600
+        if weekly_hours + duration_hours > rule.max_weekly_hours:
+            reasons.append("weekly hour limit exceeded")
+
+    # Disallow specific weekdays.
+    if rule.restricted_weekdays and reservation.start.weekday() in rule.restricted_weekdays:
+        reasons.append("weekday not allowed")
+
+    # Restrict daily time ranges.
+    if rule.allowed_time_ranges:
+        start_time = reservation.start.time()
+        end_time = reservation.end.time()
+        in_range = any(
+            tr.start <= start_time and end_time <= tr.end for tr in rule.allowed_time_ranges
+        )
+        if not in_range:
+            reasons.append("time outside allowed ranges")
+
+    # Require host approval (informational).
+    if rule.requires_host_approval:
+        reasons.append("host approval required")
+
+    allowed = not reasons
+    return allowed, reasons

--- a/api/app/schemas/__init__.py
+++ b/api/app/schemas/__init__.py
@@ -1,0 +1,9 @@
+from .rules import GroupRule, ReservationWindow, TimeRange
+from .check import ReservationCheckRequest
+
+__all__ = [
+    "GroupRule",
+    "ReservationWindow",
+    "TimeRange",
+    "ReservationCheckRequest",
+]

--- a/api/app/schemas/check.py
+++ b/api/app/schemas/check.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import List
+
+from pydantic import BaseModel
+
+from .rules import GroupRule, ReservationWindow
+
+
+class ReservationCheckRequest(BaseModel):
+    rule: GroupRule
+    reservation: ReservationWindow
+    current_reservations: List[ReservationWindow] = []
+    weekly_hours: float = 0.0

--- a/api/app/schemas/rules.py
+++ b/api/app/schemas/rules.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from datetime import datetime, time
+from typing import Iterable, List, Optional, Tuple
+
+from pydantic import BaseModel, Field
+
+
+class TimeRange(BaseModel):
+    """Represents an allowed time range for reservations."""
+
+    start: time
+    end: time
+
+
+class ReservationWindow(BaseModel):
+    """Simple start/end pair for reservation times."""
+
+    start: datetime
+    end: datetime
+
+
+class GroupRule(BaseModel):
+    """Rules that restrict how reservations can be made for a group."""
+
+    reservation_open_days_before: Optional[int] = Field(
+        None,
+        ge=0,
+        description="Maximum number of days in advance a reservation can be made.",
+    )
+    reservation_close_minutes_before: Optional[int] = Field(
+        None,
+        ge=0,
+        description="Minimum minutes before start time after which reservations are blocked.",
+    )
+    max_simultaneous_reservations: Optional[int] = Field(
+        None,
+        ge=1,
+        description="Maximum number of active reservations a user can hold simultaneously.",
+    )
+    max_weekly_hours: Optional[int] = Field(
+        None,
+        ge=0,
+        description="Maximum total hours a user may reserve per week.",
+    )
+    allowed_time_ranges: Optional[List[TimeRange]] = Field(
+        default=None,
+        description="List of allowed daily time ranges for reservations.",
+    )
+    restricted_weekdays: List[int] = Field(
+        default_factory=list,
+        description="List of disallowed weekdays (0=Monday).",
+    )
+    requires_host_approval: bool = Field(
+        False, description="Whether reservations require host approval."
+    )

--- a/api/tests/test_rules.py
+++ b/api/tests/test_rules.py
@@ -1,0 +1,28 @@
+import unittest
+from datetime import datetime, timedelta
+
+from app.rules import check_reservation
+from app.schemas import GroupRule, ReservationWindow
+
+
+class RuleTests(unittest.TestCase):
+    def test_open_and_close_limits(self) -> None:
+        now = datetime.now()
+        rule = GroupRule(
+            reservation_open_days_before=7, reservation_close_minutes_before=30
+        )
+        far_res = ReservationWindow(
+            start=now + timedelta(days=8), end=now + timedelta(days=8, hours=1)
+        )
+        allowed, _ = check_reservation(rule, far_res, [], 0)
+        self.assertFalse(allowed)
+
+        near_res = ReservationWindow(
+            start=now + timedelta(days=1), end=now + timedelta(days=1, hours=1)
+        )
+        allowed, _ = check_reservation(rule, near_res, [], 0)
+        self.assertTrue(allowed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- define `GroupRule` schema to express reservation policies
- add `check_reservation` helper and `/rules/validate` endpoint
- cover basic timing limits with unit tests

## Testing
- `cd api && python -m unittest tests.test_rules -v`


------
https://chatgpt.com/codex/tasks/task_e_68b902314e20832388a77b405d4b1140