### PR TITLE
Add reservation settings guide and clarify dashboard calendar

### DIFF
--- a/web/src/app/devices/[slug]/page.tsx
+++ b/web/src/app/devices/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import CalendarWithBars, { Span } from '@/components/CalendarWithBars';
 import { getBaseUrl } from '@/lib/config';
 import PrintButton from '@/components/PrintButton';
+import Image from 'next/image';
 import BackButton from '@/components/BackButton';
 import ReservationList, { ReservationItem } from '@/components/ReservationList';
 
@@ -110,7 +111,7 @@ export default async function DevicePage({
           <h2 className="text-xl font-semibold mb-2">予約一覧</h2>
           <ReservationList items={listItems} />
         </div>
-        <img
+        <Image
           src={`/api/mock/devices/${slug}/qr`}
           alt="QRコード"
           width={128}

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { getBaseUrl } from '@/lib/config';
 import PrintButton from '@/components/PrintButton';
 import BackButton from '@/components/BackButton';
 import ReservationList, { ReservationItem } from '@/components/ReservationList';
+import Image from 'next/image';
 function buildMonth(base = new Date()) {
   const y = base.getFullYear(), m = base.getMonth();
   const first = new Date(y, m, 1);
@@ -141,7 +142,7 @@ export default async function GroupPage({
           <h2 className="text-xl font-semibold mb-2">予約一覧</h2>
           <ReservationList items={listItems} />
         </div>
-        <img
+        <Image
           src={`/api/mock/groups/${group.slug}/qr`}
           alt="QRコード"
           width={128}

--- a/web/src/app/groups/new/page.tsx
+++ b/web/src/app/groups/new/page.tsx
@@ -63,32 +63,45 @@ export default function NewGroupPage() {
             required
           />
         </label>
-        <label className="block">
-          <div className="mb-1">予約開始（任意）</div>
-          <input
-            type="datetime-local"
-            value={reserveFrom}
-            onChange={(e) => setReserveFrom(e.target.value)}
-            className="w-full rounded-xl border p-3"
-          />
-        </label>
-        <label className="block">
-          <div className="mb-1">予約終了（任意）</div>
-          <input
-            type="datetime-local"
-            value={reserveTo}
-            onChange={(e) => setReserveTo(e.target.value)}
-            className="w-full rounded-xl border p-3"
-          />
-        </label>
-        <label className="block">
-          <div className="mb-1">メモ（任意）</div>
-          <textarea
-            value={memo}
-            onChange={(e) => setMemo(e.target.value)}
-            className="w-full rounded-xl border p-3"
-          />
-        </label>
+        <div className="pt-2">
+          <div className="text-lg font-semibold mb-2">詳細設定</div>
+          <p className="text-sm text-muted mb-4">
+            予約期間の制限などについては
+            <a
+              href="/usage/reservation-settings"
+              className="text-blue-600 hover:underline ml-1"
+            >
+              こちら
+            </a>
+            を参照してください。
+          </p>
+          <label className="block">
+            <div className="mb-1">予約開始（任意）</div>
+            <input
+              type="datetime-local"
+              value={reserveFrom}
+              onChange={(e) => setReserveFrom(e.target.value)}
+              className="w-full rounded-xl border p-3"
+            />
+          </label>
+          <label className="block">
+            <div className="mb-1">予約終了（任意）</div>
+            <input
+              type="datetime-local"
+              value={reserveTo}
+              onChange={(e) => setReserveTo(e.target.value)}
+              className="w-full rounded-xl border p-3"
+            />
+          </label>
+          <label className="block">
+            <div className="mb-1">メモ（任意）</div>
+            <textarea
+              value={memo}
+              onChange={(e) => setMemo(e.target.value)}
+              className="w-full rounded-xl border p-3"
+            />
+          </label>
+        </div>
         <button
           type="submit"
           disabled={pending}

--- a/web/src/app/page.client.tsx
+++ b/web/src/app/page.client.tsx
@@ -57,6 +57,7 @@ export default function DashboardClient({ initialItems, initialSpans }: { initia
       </section>
 
       <section className={card}>
+        <h2 className="font-medium mb-2">予約カレンダー</h2>
         <div className="flex items-center justify-between mb-2">
           <button className="px-2 py-1 rounded border" onClick={() => setAnchor((a) => addMonths(a, -1))}>
             ‹

--- a/web/src/app/usage/reservation-settings/page.tsx
+++ b/web/src/app/usage/reservation-settings/page.tsx
@@ -1,0 +1,28 @@
+export default function ReservationSettingsPage() {
+  return (
+    <div className="max-w-3xl p-4 space-y-4">
+      <h1 className="text-2xl font-bold">予約設定について</h1>
+      <p>
+        グループ作成時や後から設定できる予約の制限項目について説明します。
+      </p>
+      <ul className="list-disc ml-6 space-y-2">
+        <li>
+          <span className="font-medium">予約開始：</span>
+          予約を受け付け始める日時を指定できます。それ以前の予約はできません。
+        </li>
+        <li>
+          <span className="font-medium">予約終了：</span>
+          予約を受け付ける最終日時を指定できます。それ以降の予約はできません。
+        </li>
+        <li>
+          <span className="font-medium">メモ：</span>
+          グループ全体への注意事項などを記載できます。
+        </li>
+      </ul>
+      <p className="text-sm text-neutral-500">
+        これらの項目はグループ作成時に設定でき、後から変更することも可能です。
+      </p>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reservation settings help page
- link detailed settings from group creation form
- label dashboard calendar and clean lint issues

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9057ec8bc8323a9a2e588412f386c