### PR TITLE
feat: host-only group settings page

### DIFF
--- a/web/src/app/api/mock/groups/[slug]/route.ts
+++ b/web/src/app/api/mock/groups/[slug]/route.ts
@@ -13,7 +13,7 @@ export async function PATCH(
   req: Request,
   { params }: { params: { slug: string } }
 ) {
-  const { reserveFrom, reserveTo, memo } = await req.json();
+  const { reserveFrom, reserveTo, memo, host } = await req.json();
   const db = loadDB();
   const g = db.groups.find((x: any) => x.slug === params.slug);
   if (!g) return NextResponse.json({ ok: false, error: 'group not found' }, { status: 404 });
@@ -26,6 +26,12 @@ export async function PATCH(
   if (reserveFrom !== undefined) g.reserveFrom = reserveFrom || undefined;
   if (reserveTo !== undefined) g.reserveTo = reserveTo || undefined;
   if (memo !== undefined) g.memo = memo || undefined;
+  if (host !== undefined) {
+    if (host && !g.members.includes(host)) {
+      return NextResponse.json({ ok: false, error: 'host not member' }, { status: 400 });
+    }
+    g.host = host || undefined;
+  }
 
   saveDB(db);
   return NextResponse.json({ ok: true, data: g });

--- a/web/src/app/api/mock/groups/route.ts
+++ b/web/src/app/api/mock/groups/route.ts
@@ -25,7 +25,7 @@ export async function POST(req: Request) {
     slug: s,
     name,
     password: password || undefined,
-    members: [],
+    members: me?.email ? [me.email] : [],
     devices: [],
     reservations: [],
     reserveFrom: reserveFrom || undefined,

--- a/web/src/app/groups/[slug]/GroupScreenClient.tsx
+++ b/web/src/app/groups/[slug]/GroupScreenClient.tsx
@@ -23,11 +23,6 @@ export default function GroupScreenClient({
   const [title, setTitle] = useState('');
   const [errorMsg, setErrorMsg] = useState<string>('');
   const [addingReservation, setAddingReservation] = useState(false);
-
-  const [reserveFrom, setReserveFrom] = useState(group.reserveFrom || '');
-  const [reserveTo, setReserveTo] = useState(group.reserveTo || '');
-  const [memo, setMemo] = useState(group.memo || '');
-  const [savingSettings, setSavingSettings] = useState(false);
   const isHost = defaultReserver && group.host === defaultReserver;
 
   const searchParams = useSearchParams();
@@ -99,28 +94,6 @@ export default function GroupScreenClient({
     }
   }
 
-  async function handleSaveSettings(e: React.FormEvent) {
-    e.preventDefault();
-    setSavingSettings(true);
-    try {
-      const r = await fetch(`/api/mock/groups/${group.slug}`, {
-        method: 'PATCH',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          reserveFrom: reserveFrom || undefined,
-          reserveTo: reserveTo || undefined,
-          memo: memo || undefined,
-        }),
-      });
-      if (!r.ok) throw new Error('failed');
-      router.refresh();
-    } catch {
-      alert('保存に失敗しました');
-    } finally {
-      setSavingSettings(false);
-    }
-  }
-
   function handleLineShare() {
     const url = window.location.href;
     window.open(
@@ -181,52 +154,25 @@ export default function GroupScreenClient({
         )}
       </header>
 
-      {isHost ? (
-        <section className="space-y-3">
-          <h2 className="text-xl font-semibold">グループ設定</h2>
-          <form onSubmit={handleSaveSettings} className="space-y-2 max-w-md">
-            <label className="block">
-              <div className="mb-1">予約開始（任意）</div>
-              <input
-                type="datetime-local"
-                value={reserveFrom}
-                onChange={(e) => setReserveFrom(e.target.value)}
-                className="input"
-              />
-            </label>
-            <label className="block">
-              <div className="mb-1">予約終了（任意）</div>
-              <input
-                type="datetime-local"
-                value={reserveTo}
-                onChange={(e) => setReserveTo(e.target.value)}
-                className="input"
-              />
-            </label>
-            <label className="block">
-              <div className="mb-1">メモ（任意）</div>
-              <textarea
-                value={memo}
-                onChange={(e) => setMemo(e.target.value)}
-                className="input"
-              />
-            </label>
-            <button type="submit" disabled={savingSettings} className="btn-primary">
-              保存
-            </button>
-          </form>
+      {(group.reserveFrom || group.reserveTo || group.memo) && (
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold">グループ情報</h2>
+          {group.reserveFrom && <div>予約開始: {group.reserveFrom}</div>}
+          {group.reserveTo && <div>予約終了: {group.reserveTo}</div>}
+          {group.memo && (
+            <div className="whitespace-pre-wrap">{group.memo}</div>
+          )}
         </section>
-      ) : (
-        (group.reserveFrom || group.reserveTo || group.memo) && (
-          <section className="space-y-2">
-            <h2 className="text-xl font-semibold">グループ情報</h2>
-            {group.reserveFrom && <div>予約開始: {group.reserveFrom}</div>}
-            {group.reserveTo && <div>予約終了: {group.reserveTo}</div>}
-            {group.memo && (
-              <div className="whitespace-pre-wrap">{group.memo}</div>
-            )}
-          </section>
-        )
+      )}
+      {isHost && (
+        <div>
+          <a
+            href={`/groups/${group.slug}/settings`}
+            className="btn-primary inline-block"
+          >
+            設定を変更
+          </a>
+        </div>
       )}
 
       <section className="space-y-3">

--- a/web/src/app/groups/[slug]/settings/GroupSettingsClient.tsx
+++ b/web/src/app/groups/[slug]/settings/GroupSettingsClient.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function GroupSettingsClient({ initialGroup }: { initialGroup: any }) {
+  const [reserveFrom, setReserveFrom] = useState(initialGroup.reserveFrom || '');
+  const [reserveTo, setReserveTo] = useState(initialGroup.reserveTo || '');
+  const [memo, setMemo] = useState(initialGroup.memo || '');
+  const [host, setHost] = useState(initialGroup.host || '');
+  const [saving, setSaving] = useState(false);
+  const router = useRouter();
+  const members: string[] = initialGroup.members || [];
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      const r = await fetch(`/api/mock/groups/${initialGroup.slug}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          reserveFrom: reserveFrom || undefined,
+          reserveTo: reserveTo || undefined,
+          memo: memo || undefined,
+          host: host || undefined,
+        }),
+      });
+      if (!r.ok) throw new Error('failed');
+      router.push(`/groups/${initialGroup.slug}`);
+      router.refresh();
+    } catch (e) {
+      alert('保存に失敗しました');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">{initialGroup.name} の設定</h1>
+      <form onSubmit={onSubmit} className="space-y-4 max-w-md">
+        <label className="block">
+          <div className="mb-1">ホスト</div>
+          <select
+            value={host}
+            onChange={(e) => setHost(e.target.value)}
+            className="input"
+          >
+            <option value="">未設定</option>
+            {members.map((m) => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block">
+          <div className="mb-1">予約開始（任意）</div>
+          <input
+            type="datetime-local"
+            value={reserveFrom}
+            onChange={(e) => setReserveFrom(e.target.value)}
+            className="input"
+          />
+        </label>
+        <label className="block">
+          <div className="mb-1">予約終了（任意）</div>
+          <input
+            type="datetime-local"
+            value={reserveTo}
+            onChange={(e) => setReserveTo(e.target.value)}
+            className="input"
+          />
+        </label>
+        <label className="block">
+          <div className="mb-1">メモ（任意）</div>
+          <textarea
+            value={memo}
+            onChange={(e) => setMemo(e.target.value)}
+            className="input"
+          />
+        </label>
+        <button type="submit" disabled={saving} className="btn-primary">
+          保存
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/web/src/app/groups/[slug]/settings/page.tsx
+++ b/web/src/app/groups/[slug]/settings/page.tsx
@@ -1,0 +1,19 @@
+import { getBaseUrl } from '@/lib/config';
+import { readUserFromCookie } from '@/lib/auth';
+import { notFound } from 'next/navigation';
+import GroupSettingsClient from './GroupSettingsClient';
+
+export default async function GroupSettingsPage({ params }: { params: { slug: string } }) {
+  const base = getBaseUrl();
+  const res = await fetch(`${base}/api/mock/groups/${params.slug}`, { cache: 'no-store' });
+  if (res.status === 404) return notFound();
+  if (!res.ok) throw new Error(`API ${res.status} /api/mock/groups/${params.slug}`);
+  const group = (await res.json()).data;
+  const me = await readUserFromCookie();
+  if (!me || group.host !== me.email) return notFound();
+  return (
+    <div className="mx-auto max-w-4xl px-6 py-8">
+      <GroupSettingsClient initialGroup={group} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- move group settings to dedicated host-only page
- allow group host to be reassigned
- show edit button on group page instead of inline settings

## Testing
- `pnpm -F web lint`
- `pnpm -F web typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b908c70aa083238c739640bae853d1