### PR TITLE
Refactor group page layout with dedicated reservation form

### DIFF
--- a/web/src/app/groups/[slug]/GroupScreenClient.tsx
+++ b/web/src/app/groups/[slug]/GroupScreenClient.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { useSearchParams, useRouter } from 'next/navigation';
+import { useState } from 'react';
 
 export default function GroupScreenClient({
   initialGroup,
@@ -15,84 +14,7 @@ export default function GroupScreenClient({
   const group = initialGroup;
   const [devices, setDevices] = useState<any[]>(initialDevices);
   const [removingId, setRemovingId] = useState<string | null>(null);
-
-  const [deviceId, setDeviceId] = useState('');
-  const reserver = defaultReserver || '';
-  const [start, setStart] = useState('');
-  const [end, setEnd] = useState('');
-  const [title, setTitle] = useState('');
-  const [errorMsg, setErrorMsg] = useState<string>('');
-  const [addingReservation, setAddingReservation] = useState(false);
   const isHost = defaultReserver && group.host === defaultReserver;
-
-  const searchParams = useSearchParams();
-  const router = useRouter();
-
-  useEffect(() => {
-    const preselect = searchParams.get('device');
-    if (preselect) setDeviceId(preselect);
-  }, [searchParams]);
-
-
-  async function handleAddReservation(e: React.FormEvent) {
-    e.preventDefault();
-    if (!deviceId || !start || !end || !reserver) return;
-    setAddingReservation(true);
-    setErrorMsg('');
-    try {
-      const me = await fetch('/api/auth/me', { cache: 'no-store' }).then((r) =>
-        r.json()
-      );
-
-      const record = {
-        groupSlug: group.slug,
-        deviceId,
-        start,
-        end,
-        title: title || undefined,
-        user: me.email,
-        userName: me.name || me.email,
-        participants: Array.from(
-          new Set([me.email, me.name || me.email])
-        ),
-      };
-
-      const r = await fetch('/api/mock/reservations', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify(record),
-      });
-
-      if (r.status === 409) {
-        const { conflicts } = await r.json();
-        const lines = conflicts
-          .map((c: any) => {
-            const s = new Date(c.start), e = new Date(c.end);
-            const pad = (n: number) => n.toString().padStart(2, '0');
-            const hhmm = (d: Date) => `${pad(d.getHours())}:${pad(d.getMinutes())}`;
-            return `・${c.deviceName}（${hhmm(s)}–${hhmm(e)}）`;
-          })
-          .join('\n');
-        setErrorMsg(`この時間は他の予約があります。\n${lines}`);
-        return;
-      }
-
-      if (!r.ok) {
-        setErrorMsg('保存に失敗しました');
-        return;
-      }
-
-      router.refresh();
-      setDeviceId('');
-      setStart('');
-      setEnd('');
-      setTitle('');
-    } catch (err: any) {
-      setErrorMsg(err?.message || '保存に失敗しました');
-    } finally {
-      setAddingReservation(false);
-    }
-  }
 
   function handleLineShare() {
     const url = window.location.href;
@@ -146,6 +68,14 @@ export default function GroupScreenClient({
             >
               メールで共有
             </button>
+            {isHost && (
+              <a
+                href={`/groups/${group.slug}/settings`}
+                className="btn-primary"
+              >
+                設定を変更
+              </a>
+            )}
           </div>
         </div>
         <p className="text-sm text-neutral-500">slug: {group.slug}</p>
@@ -164,43 +94,44 @@ export default function GroupScreenClient({
           )}
         </section>
       )}
-      {isHost && (
-        <div>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold">機器</h2>
           <a
-            href={`/groups/${group.slug}/settings`}
-            className="btn-primary inline-block"
+            href={`/devices/new?group=${encodeURIComponent(group.slug)}`}
+            className="btn-primary"
           >
-            設定を変更
+            機器を追加
           </a>
         </div>
-      )}
-
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold">機器</h2>
-        <ul className="space-y-2">
+        <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {devices.map((d) => (
             <li
               key={d.id}
-              className="border rounded p-3 flex items-center justify-between"
+              className="border rounded-md p-4 shadow-card flex flex-col justify-between"
             >
               <div>
-                <a href={`/devices/${d.slug}`} className="font-medium hover:underline">
+                <a
+                  href={`/devices/${d.slug}`}
+                  className="font-medium hover:underline"
+                >
                   {d.name}
                 </a>
                 <div className="text-xs text-neutral-500">ID: {d.id}</div>
               </div>
-              <div className="flex gap-2">
+              <div className="mt-3 flex gap-2">
                 <a
                   href={`/api/mock/devices/${d.slug}/qr`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="btn-primary"
+                  className="btn-primary flex-1"
                 >
                   QRコード
                 </a>
                 <button
                   onClick={() => handleDeleteDevice(d.id)}
-                  className="btn-danger"
+                  className="btn-danger flex-1"
                   disabled={removingId === d.id}
                 >
                   削除
@@ -209,64 +140,6 @@ export default function GroupScreenClient({
             </li>
           ))}
         </ul>
-        <a
-          href={`/devices/new?group=${encodeURIComponent(group.slug)}`}
-          className="btn-primary inline-block"
-        >
-          機器を追加
-        </a>
-      </section>
-
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold">予約</h2>
-        <form
-          onSubmit={handleAddReservation}
-          className="grid grid-cols-1 sm:grid-cols-2 gap-2 max-w-3xl"
-        >
-          <select
-            value={deviceId}
-            onChange={(e) => setDeviceId(e.target.value)}
-            className="input"
-            required
-          >
-            <option value="">機器を選択</option>
-            {devices.map((d) => (
-              <option key={d.id} value={d.id}>
-                {d.name}
-              </option>
-            ))}
-          </select>
-          <input
-            type="datetime-local"
-            value={start}
-            onChange={(e) => setStart(e.target.value)}
-            className="input"
-            required
-          />
-          <input
-            type="datetime-local"
-            value={end}
-            onChange={(e) => setEnd(e.target.value)}
-            className="input"
-            required
-          />
-          <input
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            placeholder="用途（任意）"
-            className="input sm:col-span-2"
-          />
-          <button
-            type="submit"
-            disabled={addingReservation}
-            className="btn-primary w-28 sm:col-span-2"
-          >
-            予約追加
-          </button>
-          {errorMsg && (
-            <div className="text-sm text-red-600 sm:col-span-2 whitespace-pre-wrap">{errorMsg}</div>
-          )}
-        </form>
       </section>
     </div>
   );

--- a/web/src/app/groups/[slug]/ReservationForm.tsx
+++ b/web/src/app/groups/[slug]/ReservationForm.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+
+export default function ReservationForm({
+  groupSlug,
+  devices,
+  defaultReserver,
+}: {
+  groupSlug: string;
+  devices: any[];
+  defaultReserver?: string;
+}) {
+  const [deviceId, setDeviceId] = useState('');
+  const reserver = defaultReserver || '';
+  const [start, setStart] = useState('');
+  const [end, setEnd] = useState('');
+  const [title, setTitle] = useState('');
+  const [errorMsg, setErrorMsg] = useState<string>('');
+  const [addingReservation, setAddingReservation] = useState(false);
+
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  useEffect(() => {
+    const preselect = searchParams.get('device');
+    if (preselect) setDeviceId(preselect);
+  }, [searchParams]);
+
+  async function handleAddReservation(e: React.FormEvent) {
+    e.preventDefault();
+    if (!deviceId || !start || !end || !reserver) return;
+    setAddingReservation(true);
+    setErrorMsg('');
+    try {
+      const me = await fetch('/api/auth/me', { cache: 'no-store' }).then((r) => r.json());
+      const record = {
+        groupSlug,
+        deviceId,
+        start,
+        end,
+        title: title || undefined,
+        user: me.email,
+        userName: me.name || me.email,
+        participants: Array.from(new Set([me.email, me.name || me.email])),
+      };
+      const r = await fetch('/api/mock/reservations', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(record),
+      });
+      if (r.status === 409) {
+        const { conflicts } = await r.json();
+        const lines = conflicts
+          .map((c: any) => {
+            const s = new Date(c.start), e = new Date(c.end);
+            const pad = (n: number) => n.toString().padStart(2, '0');
+            const hhmm = (d: Date) => `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+            return `・${c.deviceName}（${hhmm(s)}–${hhmm(e)}）`;
+          })
+          .join('\n');
+        setErrorMsg(`この時間は他の予約があります。\n${lines}`);
+        return;
+      }
+      if (!r.ok) {
+        setErrorMsg('保存に失敗しました');
+        return;
+      }
+      router.refresh();
+      setDeviceId('');
+      setStart('');
+      setEnd('');
+      setTitle('');
+    } catch (err: any) {
+      setErrorMsg(err?.message || '保存に失敗しました');
+    } finally {
+      setAddingReservation(false);
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleAddReservation}
+      className="grid grid-cols-1 md:grid-cols-5 gap-3 max-w-5xl"
+    >
+      <select
+        value={deviceId}
+        onChange={(e) => setDeviceId(e.target.value)}
+        className="input"
+        required
+      >
+        <option value="">機器を選択</option>
+        {devices.map((d) => (
+          <option key={d.id} value={d.id}>
+            {d.name}
+          </option>
+        ))}
+      </select>
+      <input
+        type="datetime-local"
+        value={start}
+        onChange={(e) => setStart(e.target.value)}
+        className="input"
+        required
+      />
+      <input
+        type="datetime-local"
+        value={end}
+        onChange={(e) => setEnd(e.target.value)}
+        className="input"
+        required
+      />
+      <input
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="用途（任意）"
+        className="input md:col-span-2"
+      />
+      <button
+        type="submit"
+        disabled={addingReservation}
+        className="btn-primary md:col-span-5 md:w-40"
+      >
+        予約追加
+      </button>
+      {errorMsg && (
+        <div className="text-sm text-red-600 md:col-span-5 whitespace-pre-wrap">
+          {errorMsg}
+        </div>
+      )}
+    </form>
+  );
+}
+

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -1,11 +1,11 @@
 import { listDevices } from '@/lib/server-api';
 import { notFound } from 'next/navigation';
 import GroupScreenClient from './GroupScreenClient';
+import ReservationForm from './ReservationForm';
 import { readUserFromCookie } from '@/lib/auth';
 import CalendarWithBars, { Span } from '@/components/CalendarWithBars';
 import { getBaseUrl } from '@/lib/config';
 import PrintButton from '@/components/PrintButton';
-import BackButton from '@/components/BackButton';
 import ReservationList, { ReservationItem } from '@/components/ReservationList';
 import Image from 'next/image';
 function buildMonth(base = new Date()) {
@@ -103,21 +103,23 @@ export default async function GroupPage({
   });
 
   return (
-    <div className="mx-auto max-w-6xl px-6 py-8">
-      <div className="print:hidden space-y-4">
-        <div className="flex gap-4">
-          <BackButton className="text-blue-600 hover:underline" />
-          <a href="/" className="text-blue-600 hover:underline">ホーム</a>
-          <a href="/groups" className="text-blue-600 hover:underline">グループ一覧</a>
-        </div>
+    <div className="mx-auto max-w-6xl px-6 py-8 space-y-8">
+      <div className="print:hidden">
         <GroupScreenClient
           initialGroup={group}
           initialDevices={devices}
           defaultReserver={me?.email}
         />
       </div>
-      <div className="mt-6 rounded-xl border border-gray-200 bg-white p-5 shadow-sm relative">
-        <div className="flex justify-between items-center mb-2">
+      <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm relative space-y-4">
+        <div className="print:hidden">
+          <ReservationForm
+            groupSlug={group.slug}
+            devices={devices}
+            defaultReserver={me?.email}
+          />
+        </div>
+        <div className="flex justify-between items-center">
           <a
             href={`?month=${toParam(prev)}`}
             className="px-2 py-1 rounded border print:hidden"


### PR DESCRIPTION
## Summary
- streamline group header with settings button
- display devices in card grid with add control
- move reservation form above calendar as separate component

## Testing
- ⚠️ `pnpm lint` *(pnpm: command not found)*
- ⚠️ `apt-get update` *(403 Forbidden while attempting to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b90f73f3448323bbc96175142da9f2