### PR TITLE
feat: enhance reservation UI with calendar filtering

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -18,8 +18,8 @@ html, body { height: 100%; }
 }
 
 /* 任意: 簡易ユーティリティ */
-.input { @apply border rounded-md px-3 py-2 w-full focus:border-primary focus:ring-1 focus:ring-primary; }
-.btn-primary { @apply inline-flex items-center justify-center rounded-md px-4 py-2 bg-primary text-white hover:bg-primary-dark; }
+.input { @apply border rounded-md px-3 py-2 w-full focus:border-primary focus:ring-1 focus:ring-primary transition shadow-sm; }
+.btn-primary { @apply inline-flex items-center justify-center rounded-md px-4 py-2 bg-primary text-white hover:bg-primary-dark transition; }
 .btn-danger { @apply inline-flex items-center justify-center rounded-md px-4 py-2 bg-red-600 text-white hover:bg-red-700; }
 
 @media print {

--- a/web/src/app/groups/[slug]/CalendarReservationSection.tsx
+++ b/web/src/app/groups/[slug]/CalendarReservationSection.tsx
@@ -1,0 +1,41 @@
+'use client';
+import { useMemo, useState } from 'react';
+import CalendarWithBars, { Span } from '@/components/CalendarWithBars';
+import ReservationList, { ReservationItem } from '@/components/ReservationList';
+
+export default function CalendarReservationSection({
+  weeks,
+  month,
+  spans,
+  listItems,
+}: {
+  weeks: Date[][];
+  month: number;
+  spans: Span[];
+  listItems: ReservationItem[];
+}) {
+  const [selected, setSelected] = useState<Date | null>(null);
+  const items = useMemo(() => {
+    if (!selected) return listItems;
+    return listItems.filter(
+      (i) => i.start.toDateString() === selected.toDateString()
+    );
+  }, [selected, listItems]);
+  return (
+    <>
+      <CalendarWithBars
+        weeks={weeks}
+        month={month}
+        spans={spans}
+        onSelectDate={setSelected}
+        showModal={false}
+      />
+      <div className="mt-4">
+        <h2 className="text-xl font-semibold mb-2">
+          予約一覧{selected && ` (${selected.getMonth() + 1}/${selected.getDate()})`}
+        </h2>
+        <ReservationList items={items} />
+      </div>
+    </>
+  );
+}

--- a/web/src/app/groups/[slug]/ReservationForm.tsx
+++ b/web/src/app/groups/[slug]/ReservationForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
+import Spinner from '@/components/ui/Spinner';
 
 export default function ReservationForm({
   groupSlug,
@@ -82,12 +83,12 @@ export default function ReservationForm({
   return (
     <form
       onSubmit={handleAddReservation}
-      className="grid grid-cols-1 md:grid-cols-5 gap-3 max-w-5xl"
+      className="flex flex-col gap-3 md:flex-row md:items-end max-w-5xl"
     >
       <select
         value={deviceId}
         onChange={(e) => setDeviceId(e.target.value)}
-        className="input"
+        className="input md:w-48"
         required
       >
         <option value="">機器を選択</option>
@@ -97,35 +98,39 @@ export default function ReservationForm({
           </option>
         ))}
       </select>
-      <input
-        type="datetime-local"
-        value={start}
-        onChange={(e) => setStart(e.target.value)}
-        className="input"
-        required
-      />
-      <input
-        type="datetime-local"
-        value={end}
-        onChange={(e) => setEnd(e.target.value)}
-        className="input"
-        required
-      />
+      <div className="flex flex-col sm:flex-row gap-2 flex-1">
+        <input
+          type="datetime-local"
+          value={start}
+          onChange={(e) => setStart(e.target.value)}
+          className="input flex-1"
+          required
+        />
+        <span className="hidden sm:flex items-center">〜</span>
+        <input
+          type="datetime-local"
+          value={end}
+          onChange={(e) => setEnd(e.target.value)}
+          className="input flex-1"
+          required
+        />
+      </div>
       <input
         value={title}
         onChange={(e) => setTitle(e.target.value)}
         placeholder="用途（任意）"
-        className="input md:col-span-2"
+        className="input flex-1"
       />
       <button
         type="submit"
         disabled={addingReservation}
-        className="btn-primary md:col-span-5 md:w-40"
+        className="btn-primary md:w-40 flex items-center justify-center gap-2"
       >
+        {addingReservation && <Spinner size={16} />}
         予約追加
       </button>
       {errorMsg && (
-        <div className="text-sm text-red-600 md:col-span-5 whitespace-pre-wrap">
+        <div className="text-sm text-red-600 whitespace-pre-wrap w-full">
           {errorMsg}
         </div>
       )}

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -3,10 +3,11 @@ import { notFound } from 'next/navigation';
 import GroupScreenClient from './GroupScreenClient';
 import ReservationForm from './ReservationForm';
 import { readUserFromCookie } from '@/lib/auth';
-import CalendarWithBars, { Span } from '@/components/CalendarWithBars';
+import type { Span } from '@/components/CalendarWithBars';
 import { getBaseUrl } from '@/lib/config';
 import PrintButton from '@/components/PrintButton';
-import ReservationList, { ReservationItem } from '@/components/ReservationList';
+import type { ReservationItem } from '@/components/ReservationList';
+import CalendarReservationSection from './CalendarReservationSection';
 import Image from 'next/image';
 function buildMonth(base = new Date()) {
   const y = base.getFullYear(), m = base.getMonth();
@@ -139,11 +140,12 @@ export default async function GroupPage({
             </div>
           </div>
         </div>
-        <CalendarWithBars weeks={weeks} month={month} spans={spans} />
-        <div className="mt-4">
-          <h2 className="text-xl font-semibold mb-2">予約一覧</h2>
-          <ReservationList items={listItems} />
-        </div>
+        <CalendarReservationSection
+          weeks={weeks}
+          month={month}
+          spans={spans}
+          listItems={listItems}
+        />
         <Image
           src={`/api/mock/groups/${group.slug}/qr`}
           alt="QRコード"

--- a/web/src/app/loading.tsx
+++ b/web/src/app/loading.tsx
@@ -1,0 +1,8 @@
+import Spinner from '@/components/ui/Spinner';
+export default function Loading() {
+  return (
+    <div className="flex items-center justify-center h-64">
+      <Spinner size={48} />
+    </div>
+  );
+}

--- a/web/src/components/CalendarWithBars.tsx
+++ b/web/src/components/CalendarWithBars.tsx
@@ -28,13 +28,19 @@ function labelForDay(cell: Date, s: Date, e: Date) {
 }
 
 export default function CalendarWithBars({
-  weeks, month, spans,
+  weeks,
+  month,
+  spans,
+  onSelectDate,
+  showModal = true,
 }:{
   weeks: Date[][];
   month: number;
   spans: Span[];
+  onSelectDate?: (d: Date) => void;
+  showModal?: boolean;
 }) {
-  const [sel, setSel] = useState<Date|null>(null);
+  const [sel, setSel] = useState<Date | null>(null);
 
   const map = useMemo(()=>{
     const m = new Map<string, Span[]>();
@@ -57,14 +63,23 @@ export default function CalendarWithBars({
             <button
               key={i}
               className={clsx(
-                'h-16 rounded-lg border relative text-left px-1',
+                'h-16 rounded-lg border relative text-left px-1 transition-colors',
                 isSun && 'bg-red-50',
                 isSat && 'bg-blue-50',
+                todays.length > 0 && 'bg-primary/5',
                 isToday && 'border-2 border-primary'
               )}
-              onClick={()=>setSel(d)}
+              onClick={() => {
+                setSel(d);
+                onSelectDate?.(d);
+              }}
             >
               <div className="absolute left-1 top-1 text-xs">{d.getDate()}</div>
+              {todays.length > 0 && (
+                <div className="absolute top-1 right-1 text-[10px] bg-primary text-white rounded-full h-4 w-4 flex items-center justify-center">
+                  {todays.length}
+                </div>
+              )}
               <div className="absolute left-1 right-1 bottom-2 space-y-1">
                 {todays.slice(0,2).map((s)=>(
                   <div
@@ -87,7 +102,7 @@ export default function CalendarWithBars({
         })}
       </div>
 
-      {sel && (
+      {showModal && sel && (
         <DayModal
           date={sel}
           items={(map.get(sel.toDateString()) ?? []).sort((a,b)=>a.start.getTime()-b.start.getTime())}

--- a/web/src/components/ui/Spinner.tsx
+++ b/web/src/components/ui/Spinner.tsx
@@ -1,0 +1,9 @@
+"use client";
+export default function Spinner({ size = 24 }: { size?: number }) {
+  return (
+    <div
+      className="animate-spin rounded-full border-4 border-primary border-t-transparent"
+      style={{ width: size, height: size }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- restyle reservation form with horizontal layout and spinner
- show booking counts and filter reservations by selected calendar day
- add global loading spinner and input/button styling

## Testing
- `pnpm --filter web lint`
- `pnpm --filter web typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b91303b3708323803f1989adbbd048