### PR TITLE
Improve mobile usability with purpose suggestions

### DIFF
--- a/web/src/app/groups/[slug]/GroupScreenClient.tsx
+++ b/web/src/app/groups/[slug]/GroupScreenClient.tsx
@@ -52,10 +52,11 @@ export default function GroupScreenClient({
 
   return (
     <div className="max-w-4xl mx-auto space-y-8">
-      <header className="space-y-1">
+      <header className="space-y-2">
+        <a href="/" className="text-sm text-primary hover:underline">&larr; ホームへ戻る</a>
         <div className="flex items-center justify-between">
           <h1 className="text-3xl font-bold">{group.name}</h1>
-          <div className="flex gap-2">
+          <div className="flex gap-2 flex-wrap justify-end">
             <button
               onClick={handleLineShare}
               className="px-2 py-1 border rounded"

--- a/web/src/app/groups/[slug]/ReservationForm.tsx
+++ b/web/src/app/groups/[slug]/ReservationForm.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import Spinner from '@/components/ui/Spinner';
 
+const PURPOSE_SUGGESTIONS = ['PCR', '電気泳動', '解析', '培養', 'その他'];
+
 export default function ReservationForm({
   groupSlug,
   devices,
@@ -115,12 +117,20 @@ export default function ReservationForm({
           required
         />
       </div>
-      <input
-        value={title}
-        onChange={(e) => setTitle(e.target.value)}
-        placeholder="用途（任意）"
-        className="input flex-1"
-      />
+      <div className="flex-1">
+        <input
+          list="purpose-options"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="用途（任意）"
+          className="input"
+        />
+        <datalist id="purpose-options">
+          {PURPOSE_SUGGESTIONS.map((p) => (
+            <option key={p} value={p} />
+          ))}
+        </datalist>
+      </div>
       <button
         type="submit"
         disabled={addingReservation}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import './globals.css';
 import Header from '@/components/Header';
 
+export const viewport = { width: 'device-width', initialScale: 1 };
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja" className="h-full">


### PR DESCRIPTION
## Summary
- add viewport meta for better mobile scaling
- provide datalist suggestions to make "用途" input easier
- add home link and flex-wrap to group header for mobile navigation

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b916d805988323a36def31fcd90937