### PR TITLE
feat: show reservation form on calendar date

### DIFF
--- a/web/src/app/groups/[slug]/CalendarReservationSection.tsx
+++ b/web/src/app/groups/[slug]/CalendarReservationSection.tsx
@@ -2,19 +2,34 @@
 import { useMemo, useState } from 'react';
 import CalendarWithBars, { Span } from '@/components/CalendarWithBars';
 import ReservationList, { ReservationItem } from '@/components/ReservationList';
+import ReservationForm from './ReservationForm';
 
 export default function CalendarReservationSection({
   weeks,
   month,
   spans,
   listItems,
+  groupSlug,
+  devices,
+  defaultReserver,
 }: {
   weeks: Date[][];
   month: number;
   spans: Span[];
   listItems: ReservationItem[];
+  groupSlug: string;
+  devices: any[];
+  defaultReserver?: string;
 }) {
   const [selected, setSelected] = useState<Date | null>(null);
+  const [formDate, setFormDate] = useState<Date | null>(null);
+  const handleSelect = (d: Date) => {
+    setSelected(d);
+    setFormDate(d);
+  };
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  const buildDateTime = (d: Date, h: number) =>
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(h)}:00`;
   const items = useMemo(() => {
     if (!selected) return listItems;
     return listItems.filter(
@@ -27,7 +42,7 @@ export default function CalendarReservationSection({
         weeks={weeks}
         month={month}
         spans={spans}
-        onSelectDate={setSelected}
+        onSelectDate={handleSelect}
         showModal={false}
       />
       <div className="mt-4">
@@ -36,6 +51,27 @@ export default function CalendarReservationSection({
         </h2>
         <ReservationList items={items} />
       </div>
+      {formDate && (
+        <div className="fixed inset-0 bg-black/30 z-50 flex items-center justify-center">
+          <div className="bg-white rounded-lg p-5 shadow-lg space-y-4 w-full max-w-3xl">
+            <ReservationForm
+              groupSlug={groupSlug}
+              devices={devices}
+              defaultReserver={defaultReserver}
+              defaultStart={buildDateTime(formDate, 9)}
+              defaultEnd={buildDateTime(formDate, 10)}
+            />
+            <div className="text-right">
+              <button
+                onClick={() => setFormDate(null)}
+                className="px-3 py-1 rounded border"
+              >
+                閉じる
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </>
   );
 }

--- a/web/src/app/groups/[slug]/ReservationForm.tsx
+++ b/web/src/app/groups/[slug]/ReservationForm.tsx
@@ -8,15 +8,19 @@ export default function ReservationForm({
   groupSlug,
   devices,
   defaultReserver,
+  defaultStart = '',
+  defaultEnd = '',
 }: {
   groupSlug: string;
   devices: any[];
   defaultReserver?: string;
+  defaultStart?: string;
+  defaultEnd?: string;
 }) {
   const [deviceId, setDeviceId] = useState('');
   const reserver = defaultReserver || '';
-  const [start, setStart] = useState('');
-  const [end, setEnd] = useState('');
+  const [start, setStart] = useState(defaultStart);
+  const [end, setEnd] = useState(defaultEnd);
   const [title, setTitle] = useState('');
   const [errorMsg, setErrorMsg] = useState<string>('');
   const [addingReservation, setAddingReservation] = useState(false);
@@ -28,6 +32,14 @@ export default function ReservationForm({
     const preselect = searchParams.get('device');
     if (preselect) setDeviceId(preselect);
   }, [searchParams]);
+
+  useEffect(() => {
+    setStart(defaultStart);
+  }, [defaultStart]);
+
+  useEffect(() => {
+    setEnd(defaultEnd);
+  }, [defaultEnd]);
 
   async function handleAddReservation(e: React.FormEvent) {
     e.preventDefault();

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -145,6 +145,9 @@ export default async function GroupPage({
           month={month}
           spans={spans}
           listItems={listItems}
+          groupSlug={group.slug}
+          devices={devices}
+          defaultReserver={me?.email}
         />
         <Image
           src={`/api/mock/groups/${group.slug}/qr`}


### PR DESCRIPTION
## Summary
- open reservation form when a date is selected on the calendar
- allow ReservationForm to receive default start/end times for easier entry

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9aa8f7d78832398e88343dcc57c0f