### PR TITLE
Expand purpose field visibility on focus

### DIFF
--- a/web/src/app/groups/[slug]/ReservationForm.tsx
+++ b/web/src/app/groups/[slug]/ReservationForm.tsx
@@ -127,7 +127,7 @@ export default function ReservationForm({
           required
         />
       </div>
-      <div className="flex-1">
+      <div className="flex-1 min-w-[8rem] focus-within:min-w-[16rem] transition-[min-width] duration-300">
         <input
           value={title}
           onChange={(e) => setTitle(e.target.value)}


### PR DESCRIPTION
## Summary
- widen the optional purpose field on reservation form when focused so typed text remains visible

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9cbfdb85c832391feaa7d128dffb8