### PR TITLE
Add Prisma health check API and Prisma configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__/
 .env
 .env.*
 !web/.env.local
+!web/.env.example
 
 # Misc
 .DS_Store

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,14 @@
+# NextAuth configuration
+NEXTAUTH_URL=
+NEXTAUTH_SECRET=
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# Database connection
+DATABASE_URL=
+
+# Legacy settings
+AUTH_SECRET=dev-secret-change-me
+INTERNAL_API_BASE=http://localhost:3000
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
+NEXT_PUBLIC_API_MODE=mock

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint --max-warnings=0",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "next": "14.1.0",
@@ -19,7 +20,8 @@
     "bcryptjs": "^2.4.3",
     "jose": "^5.2.2",
     "better-sqlite3": "^9.4.0",
-    "@vercel/postgres": "^0.5.0"
+    "@vercel/postgres": "^0.5.0",
+    "@prisma/client": "^5.12.0"
   },
   "devDependencies": {
     "@types/react": "18.2.21",
@@ -30,6 +32,7 @@
     "prettier": "3.1.0",
     "tailwindcss": "^3.4.1",
     "postcss": "^8.4.31",
-    "autoprefixer": "^10.4.16"
+    "autoprefixer": "^10.4.16",
+    "prisma": "^5.12.0"
   }
 }

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -1,0 +1,52 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id            String   @id @default(cuid())
+  name          String?
+  email         String?  @unique
+  emailVerified DateTime?
+  image         String?
+  accounts      Account[]
+  sessions      Session[]
+}
+
+model Account {
+  id                String  @id @default(cuid())
+  userId            String
+  type              String
+  provider          String
+  providerAccountId String
+  refresh_token     String?  @db.Text
+  access_token      String?  @db.Text
+  expires_at        Int?
+  token_type        String?
+  scope             String?
+  id_token          String?  @db.Text
+  session_state     String?
+  user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
+}
+
+model Session {
+  id           String   @id @default(cuid())
+  sessionToken String   @unique
+  userId       String
+  expires      DateTime
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model VerificationToken {
+  identifier String
+  token      String   @unique
+  expires    DateTime
+
+  @@unique([identifier, token])
+}

--- a/web/src/app/api/auth/login/route.ts
+++ b/web/src/app/api/auth/login/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { findUserByEmail, hashPassword, signToken, setAuthCookie } from '@/lib/auth';
 
+export const runtime = 'nodejs';
+
 export async function POST(req: Request) {
   const { email, password } = await req.json().catch(() => ({}));
 

--- a/web/src/app/api/auth/logout/route.ts
+++ b/web/src/app/api/auth/logout/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { clearAuthCookie } from '@/lib/auth';
 
+export const runtime = 'nodejs';
+
 async function doLogout(request: Request) {
   await clearAuthCookie();
   // ブラウザ遷移ならログインへ

--- a/web/src/app/api/auth/me/route.ts
+++ b/web/src/app/api/auth/me/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { readUserFromCookie } from '@/lib/auth';
 
+export const runtime = 'nodejs';
+
 export async function GET() {
   const me = await readUserFromCookie();
   return NextResponse.json({ ok: !!me, user: me });

--- a/web/src/app/api/auth/register/route.ts
+++ b/web/src/app/api/auth/register/route.ts
@@ -3,6 +3,8 @@ import { hashPassword, signToken, setAuthCookie } from '@/lib/auth';
 import { loadUsers, saveUser } from '@/lib/db';
 import { isEmail, uid, UserRecord } from '@/lib/mockdb';
 
+export const runtime = 'nodejs';
+
 export async function POST(req: Request) {
   const { email, password, name } = await req.json().catch(() => ({}));
   if (!email || !password) {

--- a/web/src/app/api/health/route.ts
+++ b/web/src/app/api/health/route.ts
@@ -1,0 +1,15 @@
+export const runtime = 'nodejs'
+import { prisma } from '@/lib/prisma'
+
+export async function GET() {
+  try {
+    const r = await prisma.$queryRaw`SELECT NOW()`
+    return new Response(JSON.stringify({ ok: true, r }), { status: 200 })
+  } catch (e: any) {
+    console.error('DB health error:', e)
+    return new Response(
+      JSON.stringify({ ok: false, error: e.message }),
+      { status: 500 }
+    )
+  }
+}

--- a/web/src/app/api/me/reservations/route.ts
+++ b/web/src/app/api/me/reservations/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server';
 import { readUserFromCookie } from '@/lib/auth';
 import { loadDB } from '@/lib/mockdb';
 
+export const runtime = 'nodejs';
+
 const norm = (v?: string) => (v ?? '').trim().toLowerCase();
 
 export async function GET() {

--- a/web/src/app/api/mock/devices/route.ts
+++ b/web/src/app/api/mock/devices/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server';
 import { loadDB, saveDB, uid } from '@/lib/mockdb';
 import { makeSlug } from '@/lib/slug';
 
+export const runtime = 'nodejs';
+
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const slug = searchParams.get('slug');

--- a/web/src/app/api/mock/groups/[slug]/route.ts
+++ b/web/src/app/api/mock/groups/[slug]/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server';
 import { loadDB, saveDB } from '@/lib/mockdb';
 import { readUserFromCookie } from '@/lib/auth';
 
+export const runtime = 'nodejs';
+
 export async function GET(_req: Request, { params }: { params: { slug: string } }) {
   const db = loadDB();
   const g = db.groups.find((x: any) => x.slug === params.slug);

--- a/web/src/app/api/mock/groups/join/route.ts
+++ b/web/src/app/api/mock/groups/join/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server';
 import { loadDB, saveDB } from '@/lib/mockdb';
 import { readUserFromCookie } from '@/lib/auth';
 
+export const runtime = 'nodejs';
+
 export async function POST(req: Request) {
   const me = await readUserFromCookie();
   if (!me) return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });

--- a/web/src/app/api/mock/groups/route.ts
+++ b/web/src/app/api/mock/groups/route.ts
@@ -3,6 +3,8 @@ import { loadDB, saveDB } from '@/lib/mockdb';
 import { makeSlug } from '@/lib/slug';
 import { readUserFromCookie } from '@/lib/auth';
 
+export const runtime = 'nodejs';
+
 export async function GET() {
   const db = loadDB();
   return NextResponse.json({ ok: true, data: db.groups });

--- a/web/src/app/api/mock/reservations/route.ts
+++ b/web/src/app/api/mock/reservations/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server';
 import { readUserFromCookie } from '@/lib/auth';
 import { loadDB, saveDB } from '@/lib/mockdb';
 
+export const runtime = 'nodejs';
+
 /* 共通: 時間重複判定 ([s1,e1) と [s2,e2)) */
 const overlap = (s1: Date, e1: Date, s2: Date, e2: Date) => !(e1 <= s2 || e2 <= s1);
 

--- a/web/src/lib/prisma.ts
+++ b/web/src/lib/prisma.ts
@@ -1,0 +1,8 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient | undefined }
+
+export const prisma =
+  globalForPrisma.prisma || new PrismaClient()
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma


### PR DESCRIPTION
## Summary
- add `/api/health` endpoint to verify Prisma connectivity
- introduce Prisma client singleton and schema for NextAuth tables
- enforce Node.js runtime on API routes and update package/env config

## Testing
- `pnpm lint` *(fails: sh: 1: next: not found)*
- `npx prisma db push` *(fails: 403 Forbidden fetching prisma)*

------
https://chatgpt.com/codex/tasks/task_e_68bf975b9db4832382bd398d31358a7b