### PR TITLE
Refactor Prisma client and simplify DB health check

### DIFF
--- a/web/src/app/api/health/route.ts
+++ b/web/src/app/api/health/route.ts
@@ -1,15 +1,6 @@
 export const runtime = 'nodejs'
 import { prisma } from '@/lib/prisma'
-
 export async function GET() {
-  try {
-    const r = await prisma.$queryRaw`SELECT NOW()`
-    return new Response(JSON.stringify({ ok: true, r }), { status: 200 })
-  } catch (e: any) {
-    console.error('DB health error:', e)
-    return new Response(
-      JSON.stringify({ ok: false, error: e.message }),
-      { status: 500 }
-    )
-  }
+  try { await prisma.$queryRaw`SELECT NOW()`; return new Response('ok',{status:200}) }
+  catch(e:any){ console.error(e); return new Response(e.message,{status:500}) }
 }

--- a/web/src/lib/prisma.ts
+++ b/web/src/lib/prisma.ts
@@ -1,8 +1,4 @@
 import { PrismaClient } from '@prisma/client'
-
-const globalForPrisma = global as unknown as { prisma: PrismaClient | undefined }
-
-export const prisma =
-  globalForPrisma.prisma || new PrismaClient()
-
-if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+const g = global as any
+export const prisma: PrismaClient = g.prisma || new PrismaClient()
+if (process.env.NODE_ENV !== 'production') g.prisma = prisma


### PR DESCRIPTION
## Summary
- streamline Prisma client singleton initialization
- simplify health API route and ensure Node.js runtime

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68c060ccf4c08323b256a6052afd1ebb