### PR TITLE
fix(ssr): avoid localhost fetch; use getBaseUrl() for server fetch

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -9,6 +9,5 @@ DATABASE_URL=
 
 # Legacy settings
 AUTH_SECRET=dev-secret-change-me
-INTERNAL_API_BASE=http://localhost:3000
-NEXT_PUBLIC_BASE_URL=http://localhost:3000
+NEXT_PUBLIC_SITE_URL=
 NEXT_PUBLIC_API_MODE=mock

--- a/web/src/lib/base-url.ts
+++ b/web/src/lib/base-url.ts
@@ -1,5 +1,13 @@
 export function getBaseUrl() {
+  // ブラウザ側は相対パスで OK
   if (typeof window !== 'undefined') return '';
+
+  // 本番（Vercel）は VERCEL_URL が入る（例: labyoyaku.vercel.app）
   if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
-  return `http://localhost:${process.env.PORT ?? 3000}`;
+
+  // 環境変数で明示している場合はそれを使う
+  if (process.env.NEXT_PUBLIC_SITE_URL) return process.env.NEXT_PUBLIC_SITE_URL;
+
+  // ローカル開発
+  return 'http://localhost:3000';
 }


### PR DESCRIPTION
## Summary
- avoid `localhost` SSR fetch by checking `VERCEL_URL` or `NEXT_PUBLIC_SITE_URL`
- document `NEXT_PUBLIC_SITE_URL` in env example

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68c25c555cdc8323842400e4b5ca33d3