### PR TITLE
fix(ssr): forward cookies when server-fetching internal API

### DIFF
--- a/web/src/app/devices/[slug]/page.tsx
+++ b/web/src/app/devices/[slug]/page.tsx
@@ -6,6 +6,7 @@ import PrintButton from '@/components/PrintButton';
 import Image from 'next/image';
 import BackButton from '@/components/BackButton';
 import ReservationList, { ReservationItem } from '@/components/ReservationList';
+import { headers } from 'next/headers';
 
 function buildMonth(base = new Date()) {
   const y = base.getFullYear(), m = base.getMonth();
@@ -38,9 +39,10 @@ export default async function DevicePage({
   if (!group || !device) return notFound();
 
   const base = getBaseUrl();
+  const cookie = headers().get('cookie') ?? '';
   const r = await fetch(
     `${base}/api/mock/reservations?slug=${group.slug}&deviceId=${device.id}`,
-    { cache: 'no-store' }
+    { cache: 'no-store', headers: { cookie } }
   );
   const json = r.ok ? await r.json() : { data: [] };
   const reservations = json.data || [];

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -9,6 +9,7 @@ import PrintButton from '@/components/PrintButton';
 import type { ReservationItem } from '@/components/ReservationList';
 import CalendarReservationSection from './CalendarReservationSection';
 import Image from 'next/image';
+import { headers } from 'next/headers';
 function buildMonth(base = new Date()) {
   const y = base.getFullYear(), m = base.getMonth();
   const first = new Date(y, m, 1);
@@ -42,7 +43,11 @@ export default async function GroupPage({
   const { slug } = params;
   const base = getBaseUrl();
 
-  const gRes = await fetch(`${base}/api/mock/groups/${slug}`, { cache: 'no-store' });
+  const cookie = headers().get('cookie') ?? '';
+  const gRes = await fetch(`${base}/api/mock/groups/${slug}`, {
+    cache: 'no-store',
+    headers: { cookie },
+  });
   if (gRes.status === 404) return notFound();
   if (!gRes.ok) throw new Error(`API ${gRes.status} /api/mock/groups/${slug}`);
   const group = (await gRes.json()).data;
@@ -52,6 +57,7 @@ export default async function GroupPage({
     (async () => {
       const r = await fetch(`${base}/api/mock/reservations?slug=${slug}`, {
         cache: 'no-store',
+        headers: { cookie },
       });
       if (r.ok) {
         const json = await r.json();

--- a/web/src/app/groups/[slug]/settings/page.tsx
+++ b/web/src/app/groups/[slug]/settings/page.tsx
@@ -2,10 +2,15 @@ import { getBaseUrl } from '@/lib/base-url';
 import { readUserFromCookie } from '@/lib/auth';
 import { notFound } from 'next/navigation';
 import GroupSettingsClient from './GroupSettingsClient';
+import { headers } from 'next/headers';
 
 export default async function GroupSettingsPage({ params }: { params: { slug: string } }) {
   const base = getBaseUrl();
-  const res = await fetch(`${base}/api/mock/groups/${params.slug}`, { cache: 'no-store' });
+  const cookie = headers().get('cookie') ?? '';
+  const res = await fetch(`${base}/api/mock/groups/${params.slug}`, {
+    cache: 'no-store',
+    headers: { cookie },
+  });
   if (res.status === 404) return notFound();
   if (!res.ok) throw new Error(`API ${res.status} /api/mock/groups/${params.slug}`);
   const group = (await res.json()).data;

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation';
 import type { Span } from '@/components/CalendarWithBars';
 import { getBaseUrl } from '@/lib/base-url';
 import DashboardClient from './page.client';
+import { headers } from 'next/headers';
 
 type Mine = {
   id:string; deviceId:string; deviceName?:string; user:string; userName?:string;
@@ -22,12 +23,19 @@ export default async function Home() {
   if (!me) redirect('/login?next=/');
 
   const base = getBaseUrl();
-  const res = await fetch(`${base}/api/me/reservations`, { cache:'no-store' });
+  const cookie = headers().get('cookie') ?? '';
+  const res = await fetch(`${base}/api/me/reservations`, {
+    cache:'no-store',
+    headers: { cookie },
+  });
   const json = await res.json();
 
   let myGroups: { slug: string; name: string }[] = [];
   try {
-    const gRes = await fetch(`${base}/api/me/groups`, { cache: 'no-store' });
+    const gRes = await fetch(`${base}/api/me/groups`, {
+      cache: 'no-store',
+      headers: { cookie },
+    });
     if (gRes.ok) {
       myGroups = await gRes.json();
     }

--- a/web/src/lib/api-core.ts
+++ b/web/src/lib/api-core.ts
@@ -1,8 +1,21 @@
-export function createApi(getBaseURL: () => string) {
+export function createApi(
+  getBaseURL: () => string,
+  getInit?: () => RequestInit
+) {
   async function api(path: string, init?: RequestInit) {
     const base = getBaseURL();
     const url = `${base}${path}`;
-    const res = await fetch(url, { ...init, cache: 'no-store' });
+    const extra = getInit?.() ?? {};
+    const headers = {
+      ...(extra.headers || {}),
+      ...(init?.headers || {}),
+    } as HeadersInit;
+    const res = await fetch(url, {
+      cache: 'no-store',
+      ...extra,
+      ...init,
+      headers,
+    });
     if (!res.ok) {
       const text = await res.text().catch(() => '');
       throw new Error(`API ${res.status} ${path} :: ${text || res.statusText}`);

--- a/web/src/lib/server-api.ts
+++ b/web/src/lib/server-api.ts
@@ -11,6 +11,11 @@ function getBaseURL() {
   return `${proto}://${host}`;
 }
 
+function getInit() {
+  const cookie = headers().get('cookie') ?? '';
+  return { headers: { cookie } };
+}
+
 export const {
   listGroups,
   createGroup,
@@ -21,4 +26,4 @@ export const {
   listReservations,
   createReservation,
   listMyReservations,
-} = createApi(getBaseURL);
+} = createApi(getBaseURL, getInit);


### PR DESCRIPTION
## Summary
- forward incoming cookies when server components fetch internal API endpoints
- pipe cookies through server-side API helper

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68c25f2193bc832384f9039ac87411f9