### PR TITLE
Use server-side fetch helper for internal API calls

### DIFF
--- a/web/src/app/devices/[slug]/page.tsx
+++ b/web/src/app/devices/[slug]/page.tsx
@@ -1,12 +1,13 @@
 import { loadDB } from '@/lib/mockdb';
 import { notFound } from 'next/navigation';
 import CalendarWithBars, { Span } from '@/components/CalendarWithBars';
-import { getBaseUrl } from '@/lib/base-url';
 import PrintButton from '@/components/PrintButton';
 import Image from 'next/image';
 import BackButton from '@/components/BackButton';
 import ReservationList, { ReservationItem } from '@/components/ReservationList';
-import { headers } from 'next/headers';
+import { serverGet } from '@/lib/server-api';
+
+export const dynamic = 'force-dynamic';
 
 function buildMonth(base = new Date()) {
   const y = base.getFullYear(), m = base.getMonth();
@@ -38,14 +39,10 @@ export default async function DevicePage({
   const device = group?.devices.find((d: any) => d.slug === slug);
   if (!group || !device) return notFound();
 
-  const base = getBaseUrl();
-  const cookie = headers().get('cookie') ?? '';
-  const r = await fetch(
-    `${base}/api/mock/reservations?slug=${group.slug}&deviceId=${device.id}`,
-    { cache: 'no-store', headers: { cookie } }
+  const r = await serverGet<{ data?: any[] }>(
+    `/api/mock/reservations?slug=${group.slug}&deviceId=${device.id}`
   );
-  const json = r.ok ? await r.json() : { data: [] };
-  const reservations = json.data || [];
+  const reservations = r?.data || [];
 
   const baseMonth = (() => {
     if (searchParams?.month) {

--- a/web/src/app/error.tsx
+++ b/web/src/app/error.tsx
@@ -1,20 +1,18 @@
 "use client";
-import { useEffect } from "react";
-
-export default function ErrorPage({ error, reset }: { error: Error; reset: () => void }) {
-  useEffect(() => {
-    console.error(error);
-  }, [error]);
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  console.error("[GlobalError]", error, error.digest);
   return (
-    <main className="p-6 space-y-4">
-      <h1 className="text-2xl font-bold">エラーが発生しました</h1>
-      <p className="text-neutral-600">{error.message}</p>
-      <button
-        onClick={reset}
-        className="rounded border px-4 py-2"
-      >
-        再試行
-      </button>
-    </main>
+    <html>
+      <body>
+        <h2>エラーが発生しました</h2>
+        <button onClick={() => reset()}>再試行</button>
+      </body>
+    </html>
   );
 }

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -1,15 +1,15 @@
-import { listDevices } from '@/lib/server-api';
+import { serverGet } from '@/lib/server-api';
 import { notFound } from 'next/navigation';
 import GroupScreenClient from './GroupScreenClient';
 import ReservationForm from './ReservationForm';
 import { readUserFromCookie } from '@/lib/auth';
 import type { Span } from '@/components/CalendarWithBars';
-import { getBaseUrl } from '@/lib/base-url';
 import PrintButton from '@/components/PrintButton';
 import type { ReservationItem } from '@/components/ReservationList';
 import CalendarReservationSection from './CalendarReservationSection';
 import Image from 'next/image';
-import { headers } from 'next/headers';
+
+export const dynamic = 'force-dynamic';
 function buildMonth(base = new Date()) {
   const y = base.getFullYear(), m = base.getMonth();
   const first = new Date(y, m, 1);
@@ -41,33 +41,19 @@ export default async function GroupPage({
   searchParams: { month?: string };
 }) {
   const { slug } = params;
-  const base = getBaseUrl();
 
-  const cookie = headers().get('cookie') ?? '';
-  const gRes = await fetch(`${base}/api/mock/groups/${slug}`, {
-    cache: 'no-store',
-    headers: { cookie },
-  });
-  if (gRes.status === 404) return notFound();
-  if (!gRes.ok) throw new Error(`API ${gRes.status} /api/mock/groups/${slug}`);
-  const group = (await gRes.json()).data;
+  const gRes = await serverGet<{ data: any }>(`/api/mock/groups/${slug}`);
+  const group = gRes?.data;
+  if (!group) return notFound();
 
   const [devicesRes, reservations, me] = await Promise.all([
-    listDevices(group.slug),
-    (async () => {
-      const r = await fetch(`${base}/api/mock/reservations?slug=${slug}`, {
-        cache: 'no-store',
-        headers: { cookie },
-      });
-      if (r.ok) {
-        const json = await r.json();
-        return json.data ?? [];
-      }
-      if (r.status === 404) return [];
-      throw new Error(`API ${r.status} /api/mock/reservations?slug=${slug}`);
-    })(),
+    serverGet<{ data?: any[] }>(`/api/mock/devices?slug=${group.slug}`),
+    serverGet<any[]>(`/api/mock/reservations?slug=${slug}`),
     readUserFromCookie(),
   ]);
+
+  const devices = devicesRes?.data || [];
+  const reservationList = reservations ?? [];
 
   const baseMonth = (() => {
     if (searchParams?.month) {
@@ -83,9 +69,8 @@ export default async function GroupPage({
   next.setMonth(next.getMonth() + 1);
   const pad2 = (n: number) => n.toString().padStart(2, '0');
   const toParam = (d: Date) => `${d.getFullYear()}-${pad2(d.getMonth() + 1)}`;
-  const devices = devicesRes.data || [];
-  const spans: Span[] = (reservations ?? []).map((r: any) => {
-    const dev = group.devices.find((d: any)=> d.id === r.deviceId);
+  const spans: Span[] = reservationList.map((r: any) => {
+    const dev = group.devices.find((d: any) => d.id === r.deviceId);
     return {
       id: r.id,
       name: dev?.name ?? r.deviceId,
@@ -98,7 +83,7 @@ export default async function GroupPage({
     };
   });
 
-  const listItems: ReservationItem[] = reservations.map((r: any) => {
+  const listItems: ReservationItem[] = reservationList.map((r: any) => {
     const dev = group.devices.find((d: any) => d.id === r.deviceId);
     return {
       id: r.id,

--- a/web/src/app/groups/[slug]/settings/page.tsx
+++ b/web/src/app/groups/[slug]/settings/page.tsx
@@ -1,19 +1,14 @@
-import { getBaseUrl } from '@/lib/base-url';
+import { serverGet } from '@/lib/server-api';
 import { readUserFromCookie } from '@/lib/auth';
 import { notFound } from 'next/navigation';
 import GroupSettingsClient from './GroupSettingsClient';
-import { headers } from 'next/headers';
+
+export const dynamic = 'force-dynamic';
 
 export default async function GroupSettingsPage({ params }: { params: { slug: string } }) {
-  const base = getBaseUrl();
-  const cookie = headers().get('cookie') ?? '';
-  const res = await fetch(`${base}/api/mock/groups/${params.slug}`, {
-    cache: 'no-store',
-    headers: { cookie },
-  });
-  if (res.status === 404) return notFound();
-  if (!res.ok) throw new Error(`API ${res.status} /api/mock/groups/${params.slug}`);
-  const group = (await res.json()).data;
+  const res = await serverGet<{ data: any }>(`/api/mock/groups/${params.slug}`);
+  const group = res?.data;
+  if (!group) return notFound();
   const me = await readUserFromCookie();
   if (!me || group.host !== me.email) return notFound();
   return (

--- a/web/src/app/groups/page.tsx
+++ b/web/src/app/groups/page.tsx
@@ -1,8 +1,10 @@
 import Link from "next/link";
-import { listGroups } from '@/lib/server-api';
+import { serverGet } from '@/lib/server-api';
+
+export const dynamic = 'force-dynamic';
 
 export default async function GroupsPage() {
-  const groups = await listGroups();
+  const groups = (await serverGet<any[]>('/api/me/groups')) ?? [];
   return (
     <main className="mx-auto max-w-6xl px-6 py-8 space-y-4">
       <h1 className="text-2xl font-bold">グループ一覧</h1>


### PR DESCRIPTION
## Summary
- add `serverGet` helper to forward cookies and avoid throwing on API errors
- replace RSC API fetches with `serverGet` and mark auth-sensitive pages as dynamic
- log server component errors with digest via global error component

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c2bee00e408323be5f2a56dd3391f3