### PR TITLE
Finalize Tailwind v4 and improve dashboard auth handling

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,20 @@
+# Web frontend
+
+## ローカル起動
+
+```bash
+pnpm -C web dev
+```
+
+ブラウザで <http://localhost:3000> を開きます。
+
+## 環境変数
+
+- `NEXT_PUBLIC_API_BASE` : クライアント側 fetch が別オリジンの API を叩く場合のベース URL。通常は空で相対パスを使用します。
+- `NEXT_PUBLIC_SITE_URL` : サーバー側 fetch のベース URL。指定がなければ Vercel 環境では `https://$VERCEL_URL`、ローカルでは `http://localhost:3000` を用います。
+
+## Tailwind v4 メモ
+
+- `src/app/globals.css` で `@import "tailwindcss";` を使用します。
+- `postcss.config.js` は `@tailwindcss/postcss` プラグインのみを読み込みます。
+- v4 から `@tailwind base` などは不要です。

--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -2,6 +2,5 @@
 module.exports = {
   plugins: {
     '@tailwindcss/postcss': {},
-    autoprefixer: {},
   },
 };

--- a/web/public/favicon.ico
+++ b/web/public/favicon.ico
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" rx="2" fill="#3b82f6"/>
+  <text x="8" y="12" font-size="10" text-anchor="middle" fill="#fff">Y</text>
+</svg>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1,3 +1,5 @@
+/* Tailwind v4 */
 @import "tailwindcss";
+
 /* 必要ならここにカスタムCSS */
 

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -3,7 +3,7 @@ import Header from '@/components/Header';
 
 export const metadata = {
   icons: {
-    icon: '/favicon.svg',
+    icon: '/favicon.ico',
   },
 };
 

--- a/web/src/app/page.client.tsx
+++ b/web/src/app/page.client.tsx
@@ -12,7 +12,7 @@ function colorFromString(s: string) {
   return palette[h % palette.length];
 }
 
-export default function DashboardClient({ initialItems, initialSpans }: { initialItems: Item[]; initialSpans: Span[] }) {
+export default function DashboardClient({ initialItems, initialSpans, isLoggedIn }: { initialItems: Item[]; initialSpans: Span[]; isLoggedIn: boolean }) {
   const [spans, setSpans] = useState<Span[]>(initialSpans);
   const today = new Date();
   const [anchor, setAnchor] = useState(firstOfMonth(today.getFullYear(), today.getMonth()));
@@ -53,7 +53,11 @@ export default function DashboardClient({ initialItems, initialSpans }: { initia
   return (
     <div className="grid gap-6 md:grid-cols-3">
       <section className={`md:col-span-2 ${card}`}>
-        <UpcomingReservations initialItems={initialItems} onLoaded={handleLoaded} />
+        <UpcomingReservations
+          initialItems={initialItems}
+          onLoaded={handleLoaded}
+          isLoggedIn={isLoggedIn}
+        />
       </section>
 
       <section className={card}>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,5 +1,4 @@
 import { readUserFromCookie } from '@/lib/auth';
-import { redirect } from 'next/navigation';
 import type { Span } from '@/components/CalendarWithBars';
 import DashboardClient from './page.client';
 import { serverGet } from '@/lib/server-api';
@@ -19,34 +18,39 @@ function colorFromString(s:string){
 }
 export default async function Home() {
   const me = await readUserFromCookie();
-  if (!me) redirect('/login?next=/');
 
-  const json = await serverGet<{ data: Mine[]; all: any[] }>(
-    '/api/me/reservations'
-  );
+  let upcoming: Mine[] = [];
+  let spans: Span[] = [];
+  let myGroups: { slug: string; name: string }[] = [];
 
-  const upcomingRaw: Mine[] = json?.data ?? [];
-  upcomingRaw.sort(
-    (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime()
-  );
-  const upcoming = upcomingRaw.slice(0, 10);
+  if (me) {
+    const json = await serverGet<{ data: Mine[]; all: any[] }>(
+      '/api/me/reservations'
+    );
 
-  const mineAll = json?.all ?? [];
-  const spans: Span[] = mineAll.map((r: any) => ({
-    id: r.id,
-    name: r.deviceName ?? r.deviceId,
-    start: new Date(r.start),
-    end: new Date(r.end),
-    color: colorFromString(r.deviceId),
-    groupSlug: r.groupSlug,
-    by: r.userName || r.user,
-    participants: r.participants ?? [],
-  }));
+    const upcomingRaw: Mine[] = json?.data ?? [];
+    upcomingRaw.sort(
+      (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime()
+    );
+    upcoming = upcomingRaw.slice(0, 10);
 
-  const myGroups =
-    (await serverGet<{ slug: string; name: string }[]>(
-      '/api/me/groups'
-    )) ?? [];
+    const mineAll = json?.all ?? [];
+    spans = mineAll.map((r: any) => ({
+      id: r.id,
+      name: r.deviceName ?? r.deviceId,
+      start: new Date(r.start),
+      end: new Date(r.end),
+      color: colorFromString(r.deviceId),
+      groupSlug: r.groupSlug,
+      by: r.userName || r.user,
+      participants: r.participants ?? [],
+    }));
+
+    myGroups =
+      (await serverGet<{ slug: string; name: string }[]>(
+        '/api/me/groups'
+      )) ?? [];
+  }
 
   return (
     <div className="mx-auto max-w-6xl px-6 py-8 space-y-6">
@@ -58,7 +62,7 @@ export default async function Home() {
         </div>
       </div>
 
-      {myGroups.length > 0 && (
+      {me && myGroups.length > 0 && (
         <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
           <h2 className="text-xl font-semibold mb-2">参加グループ</h2>
           <ul className="list-disc pl-5 space-y-1">
@@ -73,7 +77,11 @@ export default async function Home() {
         </section>
       )}
 
-      <DashboardClient initialItems={upcoming} initialSpans={spans} />
+      <DashboardClient
+        initialItems={upcoming}
+        initialSpans={spans}
+        isLoggedIn={!!me}
+      />
     </div>
   );
 }

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -9,11 +9,9 @@ export default async function Header() {
         <nav className="flex items-center gap-4 text-sm">
           <a className="hover:underline" href="/usage">使い方</a>
           <a className="hover:underline" href="/groups/join">グループ参加</a>
-          {me && (
-            <a className="hover:underline" href="/groups/new">グループ作成</a>
-          )}
           {me ? (
             <>
+              <a className="hover:underline" href="/groups/new">グループ作成</a>
               <a className="hover:underline" href="/">ダッシュボード</a>
               <a className="hover:underline" href="/groups">グループ</a>
               <span className="hidden sm:inline text-white/80">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5,6 +5,14 @@ function getBaseURL() {
   return process.env.NEXT_PUBLIC_API_BASE || '';
 }
 
+export async function apiGet(path: string, init?: RequestInit) {
+  const base = getBaseURL();
+  const url = path.startsWith('http') ? path : `${base}${path}`;
+  const res = await fetch(url, { cache: 'no-store', ...init });
+  if (!res.ok) throw new Error(`${res.status} ${path}`);
+  return res.json();
+}
+
 export const {
   listGroups,
   createGroup,


### PR DESCRIPTION
## Summary
- finalize Tailwind v4 setup and simplify PostCSS
- expose "グループ作成" link and serve `favicon.ico`
- add API helper and handle unauthenticated dashboard refresh
- document local run, env vars and Tailwind v4 notes

## Testing
- `pnpm -C web lint`
- `DATABASE_URL=postgres://user:pass@localhost:5432/db pnpm -C web build` *(fails to reach DB but build output generated)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d9499c648323b3bc3a187268d31f