### PR TITLE
fix(web): restore button colors

### DIFF
--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -4,8 +4,10 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        primary: '#4A90E2',
-        'primary-dark': '#3F7ACC',
+        primary: {
+          DEFAULT: '#4A90E2',
+          dark: '#3F7ACC',
+        },
         accent: '#F5A623',
         success: '#7ED321',
         background: '#F8F9FA',


### PR DESCRIPTION
## Summary
- fix Tailwind config to properly expose `primary` and `primary-dark` colors
- ensure buttons and dashboard links use correct color styling

## Testing
- `pnpm -C web lint`
- `pnpm -C web build`


------
https://chatgpt.com/codex/tasks/task_e_68c2e0e773b88323931d61828714a7e5