### PR TITLE
feat: make group actions more visible

### DIFF
--- a/web/src/app/groups/join/page.tsx
+++ b/web/src/app/groups/join/page.tsx
@@ -40,7 +40,10 @@ export default function GroupJoinPage() {
 
   return (
     <main className="mx-auto max-w-6xl px-6 py-8 space-y-6">
-      <h1 className="text-3xl font-bold">グループに参加</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold">グループに参加</h1>
+        <a href="/" className="rounded-lg border px-3 py-2 hover:bg-gray-100">ホームに戻る</a>
+      </div>
       <form onSubmit={onSubmit} className="space-y-5">
         <label className="block">
           <div className="mb-1">グループ名 または slug</div>

--- a/web/src/app/groups/new/page.tsx
+++ b/web/src/app/groups/new/page.tsx
@@ -40,7 +40,10 @@ export default function NewGroupPage() {
 
   return (
     <main className="mx-auto max-w-6xl px-6 py-8 space-y-6">
-      <h1 className="text-3xl font-bold">グループ作成</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold">グループ作成</h1>
+        <a href="/" className="rounded-lg border px-3 py-2 hover:bg-gray-100">ホームに戻る</a>
+      </div>
       <form onSubmit={onSubmit} className="space-y-5">
         <label className="block">
           <div className="mb-1">名称</div>
@@ -105,7 +108,7 @@ export default function NewGroupPage() {
           disabled={pending}
           className="rounded-xl bg-primary hover:bg-primary-dark text-white px-5 py-2"
         >
-          作成
+          作成する
         </button>
       </form>
     </main>

--- a/web/src/app/groups/page.tsx
+++ b/web/src/app/groups/page.tsx
@@ -7,7 +7,13 @@ export default async function GroupsPage() {
   const groups = (await serverGet<any[]>('/api/me/groups')) ?? [];
   return (
     <main className="mx-auto max-w-6xl px-6 py-8 space-y-4">
-      <h1 className="text-2xl font-bold">グループ一覧</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">グループ一覧</h1>
+        <div className="flex gap-2">
+          <a href="/groups/new" className="rounded-lg border px-3 py-2 bg-primary text-white hover:bg-primary-dark">グループをつくる</a>
+          <a href="/" className="rounded-lg border px-3 py-2 hover:bg-gray-100">ホームに戻る</a>
+        </div>
+      </div>
       <ul className="list-disc pl-5 space-y-1">
         {groups.map((g:any)=>(
           <li key={g.slug}><Link href={`/groups/${g.slug}`} className="text-blue-600 hover:underline">{g.name}</Link></li>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -57,7 +57,7 @@ export default async function Home() {
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">ダッシュボード</h1>
         <div className="flex gap-2">
-          <a href="/groups/new" className="rounded-lg border px-3 py-2 bg-primary text-white hover:bg-primary-dark">グループ作成</a>
+          <a href="/groups/new" className="rounded-lg border px-3 py-2 bg-primary text-white hover:bg-primary-dark">グループをつくる</a>
           <a href="/groups/join" className="rounded-lg border border-primary text-primary px-3 py-2 hover:bg-primary/10">グループ参加</a>
         </div>
       </div>

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -7,13 +7,13 @@ export default async function Header() {
       <div className="mx-auto max-w-6xl px-6 h-12 flex items-center justify-between">
         <a href="/" className="font-semibold tracking-tight">Lab Yoyaku</a>
         <nav className="flex items-center gap-4 text-sm">
-          <a className="hover:underline" href="/usage">使い方</a>
-          <a className="hover:underline" href="/groups/join">グループ参加</a>
+          <a className="rounded-md px-3 py-1 hover:bg-white/20" href="/usage">使い方</a>
+          <a className="rounded-md px-3 py-1 hover:bg-white/20" href="/groups/join">グループ参加</a>
           {me ? (
             <>
-              <a className="hover:underline" href="/groups/new">グループ作成</a>
-              <a className="hover:underline" href="/">ダッシュボード</a>
-              <a className="hover:underline" href="/groups">グループ</a>
+              <a className="rounded-md px-3 py-1 hover:bg-white/20" href="/groups/new">グループをつくる</a>
+              <a className="rounded-md px-3 py-1 hover:bg-white/20" href="/">ダッシュボード</a>
+              <a className="rounded-md px-3 py-1 hover:bg-white/20" href="/groups">グループ</a>
               <span className="hidden sm:inline text-white/80">
                 {me.name || me.email}
               </span>


### PR DESCRIPTION
## Summary
- style header navigation as buttons and rename group creation link
- add explicit "ホームに戻る" buttons on group pages
- use clearer labels like "グループをつくる" and "作成する"

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68c2e5dfc2b083238690137bcc0a2a15