### PR TITLE
Handle empty group data and guard new group creation

### DIFF
--- a/web/src/app/api/mock/groups/[slug]/route.ts
+++ b/web/src/app/api/mock/groups/[slug]/route.ts
@@ -8,7 +8,16 @@ export async function GET(_req: Request, { params }: { params: { slug: string } 
   const db = loadDB();
   const g = db.groups.find((x: any) => x.slug === params.slug);
   if (!g) return NextResponse.json({ ok: false, error: 'group not found' }, { status: 404 });
-  return NextResponse.json({ ok: true, data: g });
+  const ensureArray = (v: any) => (Array.isArray(v) ? v : v ? Object.values(v) : []);
+  return NextResponse.json({
+    ok: true,
+    data: {
+      ...g,
+      members: ensureArray(g.members),
+      devices: ensureArray(g.devices),
+      reservations: ensureArray(g.reservations),
+    },
+  });
 }
 
 export async function PATCH(

--- a/web/src/app/api/mock/groups/route.ts
+++ b/web/src/app/api/mock/groups/route.ts
@@ -53,7 +53,7 @@ export async function POST(req: Request) {
     db.groups.push(g);
     saveDB(db);
     return NextResponse.json(
-      { ok: true, data: { slug: g.slug, name: g.name } },
+      { ok: true, group: { slug: g.slug, name: g.name } },
       { status: 201 }
     );
   } catch (e: any) {

--- a/web/src/app/groups/[slug]/error.tsx
+++ b/web/src/app/groups/[slug]/error.tsx
@@ -1,0 +1,12 @@
+'use client';
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <div className="space-y-3">
+      <h2 className="text-xl font-semibold">エラーが発生しました</h2>
+      <p className="text-sm text-zinc-600">{error.message}</p>
+      <button onClick={() => reset()} className="rounded-xl px-3 py-1 border">
+        再試行
+      </button>
+    </div>
+  );
+}

--- a/web/src/app/groups/new/NewGroupForm.tsx
+++ b/web/src/app/groups/new/NewGroupForm.tsx
@@ -1,0 +1,77 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+export default function NewGroupForm() {
+  const r = useRouter();
+  const [auth, setAuth] = useState<'checking' | 'ok' | 'unauth'>('checking');
+
+  useEffect(() => {
+    fetch('/api/auth/me', { cache: 'no-store' })
+      .then((res) => res.json())
+      .then((d) => setAuth(d.ok ? 'ok' : 'unauth'))
+      .catch(() => setAuth('unauth'));
+  }, []);
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const payload = {
+      name: String(fd.get('name') || '').trim(),
+      password: String(fd.get('password') || ''),
+      reserveFrom: fd.get('startAt') || null,
+      reserveTo: fd.get('endAt') || null,
+      memo: String(fd.get('memo') || ''),
+    };
+    const res = await fetch('/api/mock/groups', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+      cache: 'no-store',
+    });
+    const json = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(json?.error ?? `HTTP ${res.status}`);
+    const slug = json?.group?.slug ?? json?.slug ?? payload.name.toLowerCase();
+    r.push(`/groups/${encodeURIComponent(slug)}`);
+  }
+
+  if (auth === 'checking') return <p>確認中…</p>;
+  if (auth === 'unauth') {
+    return (
+      <div className="space-y-3">
+        <p>グループ作成にはログインが必要です。</p>
+        <a className="underline" href="/login?next=/groups/new">ログインへ</a>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-5">
+      <label className="block">
+        <div className="mb-1">名称</div>
+        <input name="name" className="w-full rounded-xl border p-3" required />
+      </label>
+      <label className="block">
+        <div className="mb-1">パスワード</div>
+        <input type="password" name="password" className="w-full rounded-xl border p-3" required />
+      </label>
+      <div className="pt-2 space-y-4">
+        <label className="block">
+          <div className="mb-1">予約開始（任意）</div>
+          <input type="datetime-local" name="startAt" className="w-full rounded-xl border p-3" />
+        </label>
+        <label className="block">
+          <div className="mb-1">予約終了（任意）</div>
+          <input type="datetime-local" name="endAt" className="w-full rounded-xl border p-3" />
+        </label>
+        <label className="block">
+          <div className="mb-1">メモ（任意）</div>
+          <textarea name="memo" className="w-full rounded-xl border p-3" />
+        </label>
+      </div>
+      <button type="submit" className="rounded-xl px-4 py-2 bg-indigo-600 text-white hover:bg-indigo-500">
+        グループを作る
+      </button>
+    </form>
+  );
+}

--- a/web/src/app/groups/new/page.tsx
+++ b/web/src/app/groups/new/page.tsx
@@ -1,122 +1,13 @@
-'use client';
-
-import { useState } from 'react';
-import { makeSlug } from '@/lib/slug';
-import { useRouter } from 'next/navigation';
+import NewGroupForm from './NewGroupForm';
 
 export default function NewGroupPage() {
-  const [name, setName] = useState('');
-  const [password, setPassword] = useState('');
-  const [reserveFrom, setReserveFrom] = useState('');
-  const [reserveTo, setReserveTo] = useState('');
-  const [memo, setMemo] = useState('');
-  const [pending, setPending] = useState(false);
-  const router = useRouter();
-
-  async function onSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    setPending(true);
-    try {
-      const auth = await fetch('/api/auth/me', { cache: 'no-store' });
-      if (!auth.ok) {
-        alert('ログインしてください');
-        router.push('/login');
-        return;
-      }
-
-      const res = await fetch('/api/mock/groups', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          name: name.trim(),
-          slug: makeSlug(name),
-        }),
-        cache: 'no-store',
-      });
-      const data = await res.json().catch(() => ({}));
-      if (!res.ok) throw new Error(data?.error ?? `HTTP ${res.status}`);
-      router.push(`/groups/${data.data.slug}`);
-      router.refresh();
-    } catch (e: any) {
-      alert(e.message || '作成に失敗しました');
-    } finally {
-      setPending(false);
-    }
-  }
-
   return (
     <main className="mx-auto max-w-6xl px-6 py-8 space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-3xl font-bold">グループ作成</h1>
         <a href="/" className="rounded-lg border px-3 py-2 hover:bg-gray-100">ホームに戻る</a>
       </div>
-      <form onSubmit={onSubmit} className="space-y-5">
-        <label className="block">
-          <div className="mb-1">名称</div>
-          <input
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            className="w-full rounded-xl border p-3"
-            required
-          />
-        </label>
-        <label className="block">
-          <div className="mb-1">パスワード</div>
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            className="w-full rounded-xl border p-3"
-            required
-          />
-        </label>
-        <div className="pt-2">
-          <div className="text-lg font-semibold mb-2">詳細設定</div>
-          <p className="text-sm text-muted mb-4">
-            予約期間の制限などについては
-            <a
-              href="/usage/reservation-settings"
-              className="text-blue-600 hover:underline ml-1"
-            >
-              こちら
-            </a>
-            を参照してください。
-          </p>
-          <label className="block">
-            <div className="mb-1">予約開始（任意）</div>
-            <input
-              type="datetime-local"
-              value={reserveFrom}
-              onChange={(e) => setReserveFrom(e.target.value)}
-              className="w-full rounded-xl border p-3"
-            />
-          </label>
-          <label className="block">
-            <div className="mb-1">予約終了（任意）</div>
-            <input
-              type="datetime-local"
-              value={reserveTo}
-              onChange={(e) => setReserveTo(e.target.value)}
-              className="w-full rounded-xl border p-3"
-            />
-          </label>
-          <label className="block">
-            <div className="mb-1">メモ（任意）</div>
-            <textarea
-              value={memo}
-              onChange={(e) => setMemo(e.target.value)}
-              className="w-full rounded-xl border p-3"
-            />
-          </label>
-        </div>
-        <button
-          type="submit"
-          disabled={pending}
-          className="rounded-xl bg-indigo-600 text-white hover:bg-indigo-500 px-5 py-2"
-        >
-          作成する
-        </button>
-      </form>
+      <NewGroupForm />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Prevent group page crashes by normalizing API responses and safely mapping lists
- Redirect to new group after creation and hide form when not authenticated
- Return group slug on creation and add group page error boundary

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2f12436808323add7a4faaf3c3b0b