### PR TITLE
fix server-side fetch wrapper and enforce login on group creation

### DIFF
--- a/web/src/app/groups/new/page.tsx
+++ b/web/src/app/groups/new/page.tsx
@@ -1,12 +1,12 @@
-import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
+import { serverFetch } from '@/lib/server-fetch';
 import NewGroupForm from './NewGroupForm';
 
+export const dynamic = 'force-dynamic';
+
 export default async function NewGroupPage() {
-  const cookie = headers().get('cookie') ?? '';
-  if (!cookie.includes('labyoyaku_token')) {
-    redirect('/login?next=/groups/new');
-  }
+  const me = await serverFetch('/api/auth/me');
+  if (me.status === 401) redirect('/login?next=/groups/new');
   return (
     <main className="mx-auto max-w-6xl px-6 py-8 space-y-6">
       <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- ensure server-side fetch builds absolute URLs and forwards cookies
- check session via API when loading new group page and redirect unauthenticated users

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2fe8364ac8323ba548bd64d969f43