### PR TITLE
Fix group membership and slug handling

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -3,3 +3,11 @@
 
 /* 必要ならここにカスタムCSS */
 
+@layer components {
+  .btn { @apply inline-flex items-center gap-2 rounded-xl px-4 py-2 font-medium shadow-sm transition; }
+  .btn-primary { @apply bg-indigo-600 text-white hover:bg-indigo-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300; }
+  .btn-secondary { @apply bg-white text-indigo-700 border border-indigo-200 hover:bg-indigo-50; }
+  .btn-ghost { @apply text-zinc-700 hover:bg-zinc-50; }
+  .btn-danger { @apply bg-red-600 text-white hover:bg-red-500; }
+}
+

--- a/web/src/app/groups/[slug]/GroupScreenClient.tsx
+++ b/web/src/app/groups/[slug]/GroupScreenClient.tsx
@@ -57,22 +57,16 @@ export default function GroupScreenClient({
         <div className="flex items-center justify-between">
           <h1 className="text-3xl font-bold">{group.name}</h1>
           <div className="flex gap-2 flex-wrap justify-end">
-            <button
-              onClick={handleLineShare}
-              className="px-2 py-1 border rounded"
-            >
+            <button onClick={handleLineShare} className="btn btn-ghost">
               LINEで共有
             </button>
-            <button
-              onClick={handleMailShare}
-              className="px-2 py-1 border rounded"
-            >
+            <button onClick={handleMailShare} className="btn btn-ghost">
               メールで共有
             </button>
             {isHost && (
               <a
                 href={`/groups/${group.slug}/settings`}
-                className="rounded-xl bg-indigo-600 text-white hover:bg-indigo-500 px-4 py-2"
+                className="btn btn-secondary"
               >
                 設定を変更
               </a>
@@ -101,7 +95,7 @@ export default function GroupScreenClient({
           <h2 className="text-xl font-semibold">機器</h2>
           <a
             href={`/devices/new?group=${encodeURIComponent(group.slug)}`}
-            className="rounded-xl bg-indigo-600 text-white hover:bg-indigo-500 px-4 py-2"
+            className="btn btn-primary"
           >
             機器を追加
           </a>
@@ -126,13 +120,13 @@ export default function GroupScreenClient({
                   href={`/api/mock/devices/${d.slug}/qr`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="rounded-xl bg-indigo-600 text-white hover:bg-indigo-500 px-4 py-2 flex-1"
+                  className="btn btn-secondary flex-1"
                 >
                   QRコード
                 </a>
                 <button
                   onClick={() => handleDeleteDevice(d.id)}
-                  className="rounded-xl bg-rose-600 text-white hover:bg-rose-500 px-4 py-2 flex-1"
+                  className="btn btn-danger flex-1"
                   disabled={removingId === d.id}
                 >
                   削除

--- a/web/src/app/groups/[slug]/ReservationForm.tsx
+++ b/web/src/app/groups/[slug]/ReservationForm.tsx
@@ -138,7 +138,7 @@ export default function ReservationForm({
       <button
         type="submit"
         disabled={addingReservation}
-        className="rounded-xl bg-indigo-600 text-white hover:bg-indigo-500 px-4 py-2 md:w-40 flex items-center justify-center gap-2"
+        className="btn btn-primary md:w-40 flex items-center justify-center gap-2"
       >
         {addingReservation && <Spinner size={16} />}
         予約追加

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -46,22 +46,25 @@ export default async function GroupPage({
   params: { slug: string };
   searchParams: { month?: string };
 }) {
-  const { slug } = params;
+  const paramSlug = params.slug;
 
-  const res = await serverFetch(`/api/mock/groups/${encodeURIComponent(slug)}`);
-  if (res.status === 401) redirect(`/login?next=/groups/${slug}`);
+  const res = await serverFetch(`/api/mock/groups/${encodeURIComponent(paramSlug)}`);
+  if (res.status === 401) redirect(`/login?next=/groups/${paramSlug}`);
   if (res.status === 404) return notFound();
   if (!res.ok) throw new Error(`failed: ${res.status}`);
-  const json = await res.json();
+  const data = await res.json();
+  const raw = data?.data ?? data?.group ?? data;
   const group = {
-    ...json,
-    members: toArr(json.members),
-    devices: toArr(json.devices),
-    reservations: toArr(json.reservations),
+    ...raw,
+    slug: raw?.slug ?? paramSlug,
+    members: toArr(raw?.members),
+    devices: toArr(raw?.devices),
+    reservations: toArr(raw?.reservations),
   };
   const devices = group.devices;
   const reservationList = group.reservations;
   const me = await readUserFromCookie();
+  const qrUrl = `/api/mock/groups/${encodeURIComponent(paramSlug)}/qr`;
 
   const baseMonth = (() => {
     if (searchParams?.month) {
@@ -135,7 +138,7 @@ export default async function GroupPage({
               ›
             </a>
             <div className="print:hidden">
-              <PrintButton className="rounded-xl bg-indigo-600 text-white hover:bg-indigo-500 px-4 py-2" />
+              <PrintButton className="btn btn-secondary" />
             </div>
           </div>
         </div>
@@ -149,7 +152,7 @@ export default async function GroupPage({
           defaultReserver={me?.email}
         />
         <Image
-          src={`/api/mock/groups/${group.slug}/qr`}
+          src={qrUrl}
           alt="QRコード"
           width={128}
           height={128}

--- a/web/src/app/groups/[slug]/settings/GroupSettingsClient.tsx
+++ b/web/src/app/groups/[slug]/settings/GroupSettingsClient.tsx
@@ -84,7 +84,7 @@ export default function GroupSettingsClient({ initialGroup }: { initialGroup: an
         <button
           type="submit"
           disabled={saving}
-          className="rounded-xl bg-indigo-600 text-white hover:bg-indigo-500 px-4 py-2"
+          className="btn btn-primary"
         >
           保存
         </button>

--- a/web/src/app/groups/join/page.tsx
+++ b/web/src/app/groups/join/page.tsx
@@ -42,7 +42,7 @@ export default function GroupJoinPage() {
     <main className="mx-auto max-w-6xl px-6 py-8 space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-3xl font-bold">グループに参加</h1>
-        <a href="/" className="rounded-lg border px-3 py-2 hover:bg-gray-100">ホームに戻る</a>
+        <a href="/" className="btn btn-secondary">ホームに戻る</a>
       </div>
       <form onSubmit={onSubmit} className="space-y-5">
         <label className="block">
@@ -72,7 +72,7 @@ export default function GroupJoinPage() {
           </p>
         )}
         <button
-          className="rounded-xl bg-indigo-600 text-white hover:bg-indigo-500 px-5 py-2 disabled:opacity-50 disabled:cursor-not-allowed"
+          className="btn btn-primary disabled:opacity-50 disabled:cursor-not-allowed"
           disabled={loading || !group || !password}
           aria-disabled={loading || !group || !password}
         >

--- a/web/src/app/groups/new/NewGroupForm.tsx
+++ b/web/src/app/groups/new/NewGroupForm.tsx
@@ -60,7 +60,7 @@ export default function NewGroupForm() {
           <textarea name="memo" className="w-full rounded-xl border p-3" />
         </label>
       </div>
-      <button type="submit" className="rounded-xl px-4 py-2 bg-indigo-600 text-white hover:bg-indigo-500">
+      <button type="submit" className="btn btn-primary">
         グループを作る
       </button>
     </form>

--- a/web/src/app/groups/new/page.tsx
+++ b/web/src/app/groups/new/page.tsx
@@ -11,7 +11,7 @@ export default async function NewGroupPage() {
     <main className="mx-auto max-w-6xl px-6 py-8 space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-3xl font-bold">グループ作成</h1>
-        <a href="/" className="rounded-lg border px-3 py-2 hover:bg-gray-100">ホームに戻る</a>
+        <a href="/" className="btn btn-secondary">ホームに戻る</a>
       </div>
       <NewGroupForm />
     </main>

--- a/web/src/app/groups/page.tsx
+++ b/web/src/app/groups/page.tsx
@@ -5,7 +5,7 @@ import { serverFetch } from '@/lib/server-fetch';
 export const dynamic = 'force-dynamic';
 
 export default async function GroupsPage() {
-  const res = await serverFetch('/api/mock/groups');
+  const res = await serverFetch('/api/mock/groups?mine=1');
   if (res.status === 401) redirect('/login?next=/groups');
   if (!res.ok) throw new Error(`failed: ${res.status}`);
   const data = await res.json();
@@ -15,8 +15,8 @@ export default async function GroupsPage() {
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">グループ一覧</h1>
         <div className="flex gap-2">
-          <a href="/groups/new" className="rounded-lg border px-3 py-2 bg-indigo-600 text-white hover:bg-indigo-500">グループをつくる</a>
-          <a href="/" className="rounded-lg border px-3 py-2 hover:bg-gray-100">ホームに戻る</a>
+          <a href="/groups/new" className="btn btn-primary">グループをつくる</a>
+          <a href="/" className="btn btn-secondary">ホームに戻る</a>
         </div>
       </div>
       <ul className="list-disc pl-5 space-y-1">

--- a/web/src/lib/server-fetch.ts
+++ b/web/src/lib/server-fetch.ts
@@ -15,9 +15,8 @@ export async function serverFetch(path: string, init: RequestInit = {}) {
   const cookie = headers().get('cookie') ?? '';
   const url = absoluteUrl(path);
   return fetch(url, {
-    cache: 'no-store',
-    next: { revalidate: 0 }, // キャッシュ無効化
+    cache: 'no-store', // 再検証オプションなしで警告を回避
     ...init,
-    headers: { ...(init.headers || {}), cookie }, // ← これが超重要
+    headers: { ...(init.headers || {}), cookie }, // Cookieで認証を引き継ぐ
   });
 }


### PR DESCRIPTION
## Summary
- eliminate caching warnings by simplifying server-side fetch wrapper
- ensure group creators appear in their own group list and secure membership filtering
- handle slug safely in group detail while unifying button styles across group pages

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3036780cc83238c492c86de3be5ab