### PR TITLE
chore: run prisma generate in build and add vercel config

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   web:
     dependencies:
       '@prisma/client':
-        specifier: ^5.12.0
+        specifier: 5.22.0
         version: 5.22.0(prisma@5.22.0)
       clsx:
         specifier: ^2.1.0
@@ -55,7 +55,7 @@ importers:
         specifier: ^8.4.31
         version: 8.4.31
       prisma:
-        specifier: ^5.12.0
+        specifier: 5.22.0
         version: 5.22.0
       tailwindcss:
         specifier: ^4.0.0

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "pnpm -C web build",
+  "installCommand": "pnpm install --frozen-lockfile"
+}

--- a/web/package.json
+++ b/web/package.json
@@ -3,15 +3,15 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
-    "postinstall": "prisma generate",
+    "postinstall": "echo skip prisma generate on postinstall",
     "prisma:deploy": "prisma migrate deploy",
     "prisma:push": "prisma db push"
   },
   "dependencies": {
-    "@prisma/client": "^5.12.0",
+    "@prisma/client": "5.22.0",
     "clsx": "^2.1.0",
     "jose": "^5.2.2",
     "next": "14.1.0",
@@ -28,7 +28,7 @@
     "eslint": "^8.56.0",
     "eslint-config-next": "14.1.0",
     "postcss": "^8.4.31",
-    "prisma": "^5.12.0",
+    "prisma": "5.22.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.5.4"
   }


### PR DESCRIPTION
## Summary
- run `prisma generate` at the start of `web` build
- skip prisma generation during `postinstall`
- add `vercel.json` with build command targeting `web`

## Testing
- `pnpm -C web lint` *(fails: pnpm: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c315eeb4c08323836dbbea6d8ea86e