### PR TITLE
chore(build): allow pnpm built deps

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,7 @@
 allow-scripts=@prisma/client @prisma/engines prisma @tailwindcss/oxide unrs-resolver
 enable-pre-post-scripts=true
+only-built-dependencies[]=@tailwindcss/oxide
+only-built-dependencies[]=unrs-resolver
+only-built-dependencies[]=@prisma/client
+only-built-dependencies[]=@prisma/engines
+only-built-dependencies[]=prisma


### PR DESCRIPTION
## Summary
- allow listed dependencies to run build scripts via pnpm's only-built-dependencies
- ensure prisma client generation happens during build instead of postinstall

## Testing
- `pnpm -C web build` *(fails: You cannot use different slug names for the same dynamic path ('group' !== 'slug'))*

------
https://chatgpt.com/codex/tasks/task_e_68c42242013883238043858cc07c1eef