### PR TITLE
Fix Vercel build configuration for web app

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,0 @@
-{
-  "buildCommand": "pnpm -C web build",
-  "installCommand": "pnpm install --frozen-lockfile"
-}

--- a/web/package.json
+++ b/web/package.json
@@ -31,5 +31,17 @@
     "prisma": "5.22.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.5.4"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@tailwindcss/oxide",
+      "unrs-resolver",
+      "@prisma/client",
+      "@prisma/engines",
+      "prisma"
+    ]
+  },
+  "engines": {
+    "node": ">=18.18 <23"
   }
 }

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "pnpm build",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "framework": "nextjs"
+}


### PR DESCRIPTION
## Summary
- configure build in `web/vercel.json` to run `pnpm build` with frozen installs
- ensure Prisma client generation and onlyBuiltDependencies via package.json
- drop obsolete root `vercel.json`

## Testing
- `pnpm build` *(fails: You cannot use different slug names for the same dynamic path)*

------
https://chatgpt.com/codex/tasks/task_e_68c4275294f8832396e55618e0081cb2