### PR TITLE
chore: unify group slug naming

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@tailwindcss/oxide",
+      "unrs-resolver",
+      "@prisma/client",
+      "@prisma/engines",
+      "prisma"
+    ]
+  }
+}
+

--- a/web/package.json
+++ b/web/package.json
@@ -32,15 +32,6 @@
     "tailwindcss": "^4.0.0",
     "typescript": "^5.5.4"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@tailwindcss/oxide",
-      "unrs-resolver",
-      "@prisma/client",
-      "@prisma/engines",
-      "prisma"
-    ]
-  },
   "engines": {
     "node": ">=18.18 <23"
   }

--- a/web/src/app/api/mock/groups/[group]/devices/[device]/route.ts
+++ b/web/src/app/api/mock/groups/[group]/devices/[device]/route.ts
@@ -1,9 +1,0 @@
-import { NextResponse } from 'next/server';
-import { store, toArr } from '../../../../_store';
-
-export async function GET(_req: Request, { params }: { params: { group: string; device: string } }) {
-  const dev = store.findDevice(params.group, params.device);
-  if (!dev) return NextResponse.json({ error: 'not found' }, { status: 404 });
-  const reservations = toArr(store.findReservationsByDevice(dev.id));
-  return NextResponse.json({ device: dev, group: { slug: params.group }, reservations });
-}

--- a/web/src/app/api/mock/groups/[slug]/devices/[device]/route.ts
+++ b/web/src/app/api/mock/groups/[slug]/devices/[device]/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { store, toArr } from '../../../../_store';
+
+export async function GET(_req: Request, { params }: { params: { slug: string; device: string } }) {
+  const dev = store.findDevice(params.slug, params.device);
+  if (!dev) return NextResponse.json({ error: 'not found' }, { status: 404 });
+  const reservations = toArr(store.findReservationsByDevice(dev.id));
+  return NextResponse.json({ device: dev, group: { slug: params.slug }, reservations });
+}

--- a/web/src/app/api/mock/groups/[slug]/devices/route.ts
+++ b/web/src/app/api/mock/groups/[slug]/devices/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { store } from '../../../_store';
 
-export async function POST(req: Request, { params }: { params: { group: string } }) {
+export async function POST(req: Request, { params }: { params: { slug: string } }) {
   const body = await req.json();
   const name = String(body.name || '').trim();
   const slug = String(body.slug || '').trim();
@@ -9,7 +9,7 @@ export async function POST(req: Request, { params }: { params: { group: string }
   const code = String(body.code || '');
   if (!name || !slug)
     return NextResponse.json({ error: 'invalid request' }, { status: 400 });
-  const device = store.addDevice(params.group, { name, slug, caution, code });
+  const device = store.addDevice(params.slug, { name, slug, caution, code });
   if (!device)
     return NextResponse.json({ error: 'group not found or exists' }, { status: 404 });
   return NextResponse.json({ device }, { status: 201 });


### PR DESCRIPTION
## Summary
- rename mock API routes from `[group]` to `[slug]`
- update handlers to reference `params.slug`
- move pnpm onlyBuiltDependencies config to repo root

## Testing
- `pnpm build` *(fails: command not found: pnpm)*


------
https://chatgpt.com/codex/tasks/task_e_68c428ea9e2c8323ae91c1bafe5d773f