### PR TITLE
Add mock reservation API and navigation fixes

### DIFF
--- a/web/src/app/api/mock/_store.ts
+++ b/web/src/app/api/mock/_store.ts
@@ -1,6 +1,10 @@
 import { loadDB, saveDB, uid } from '@/lib/mockdb';
 
 export const store = {
+  findGroupBySlug(slug: string) {
+    const db = loadDB();
+    return db.groups.find((g: any) => g.slug === slug) || null;
+  },
   findDeviceBySlug(slug: string) {
     const db = loadDB();
     for (const g of db.groups || []) {
@@ -41,6 +45,32 @@ export const store = {
     g.devices.push(device);
     saveDB(db);
     return device;
+  },
+  createReservation(payload: { groupSlug: string; deviceId: string; start: string; end: string; purpose?: string; userId: string }) {
+    const db = loadDB();
+    const g = db.groups.find((x: any) => x.slug === payload.groupSlug);
+    if (!g) return null;
+    const reservation: any = {
+      id: uid(),
+      deviceId: payload.deviceId,
+      start: payload.start,
+      end: payload.end,
+      purpose: payload.purpose,
+      user: payload.userId,
+    };
+    g.reservations = g.reservations || [];
+    g.reservations.push(reservation);
+    saveDB(db);
+    return reservation;
+  },
+  listReservationsByGroup(slug: string) {
+    const db = loadDB();
+    const g = db.groups.find((x: any) => x.slug === slug);
+    return g?.reservations || [];
+  },
+  currentUserId() {
+    const db = loadDB();
+    return db.users?.[0]?.id || 'user1';
   },
 };
 

--- a/web/src/app/api/mock/groups/[slug]/reservations/route.ts
+++ b/web/src/app/api/mock/groups/[slug]/reservations/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { store } from '../../../_store';
+
+export async function POST(req: Request, { params }: { params: { slug: string } }) {
+  const body = await req.json().catch(() => ({}));
+  const groupSlug = params.slug?.toLowerCase();
+  const deviceSlug = String(body.device || '').toLowerCase();
+  const start = String(body.start || '');
+  const end = String(body.end || '');
+  const purpose = String(body.purpose || '');
+
+  const group = store.findGroupBySlug(groupSlug);
+  if (!group) return NextResponse.json({ error: 'group not found' }, { status: 404 });
+
+  const device = store.findDevice(groupSlug, deviceSlug);
+  if (!device) return NextResponse.json({ error: 'device not found' }, { status: 404 });
+
+  const reservation = store.createReservation({
+    groupSlug,
+    deviceId: device.id,
+    start,
+    end,
+    purpose,
+    userId: store.currentUserId(),
+  });
+
+  return NextResponse.json({ ok: true, reservation }, { status: 201 });
+}
+
+export async function GET(_req: Request, { params }: { params: { slug: string } }) {
+  const group = store.findGroupBySlug(params.slug?.toLowerCase());
+  if (!group) return NextResponse.json({ error: 'group not found' }, { status: 404 });
+  const list = store.listReservationsByGroup(params.slug);
+  return NextResponse.json({ reservations: list }, { status: 200 });
+}

--- a/web/src/app/groups/[slug]/GroupScreenClient.tsx
+++ b/web/src/app/groups/[slug]/GroupScreenClient.tsx
@@ -102,12 +102,12 @@ export default function GroupScreenClient({
       <section className="space-y-4">
         <div className="flex items-center justify-between">
           <h2 className="text-xl font-semibold">機器</h2>
-          <a
-            href={`/groups/${encodeURIComponent(group.slug.toLowerCase())}/devices/new`}
+          <Link
+            href={`/groups/${encodeURIComponent(group.slug.toLowerCase())}/devices/new?next=${encodeURIComponent(`/groups/${group.slug.toLowerCase()}`)}`}
             className="btn btn-primary"
           >
             機器を追加
-          </a>
+          </Link>
         </div>
         <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {devices.map((d) => (

--- a/web/src/app/groups/[slug]/devices/new/page.tsx
+++ b/web/src/app/groups/[slug]/devices/new/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 function slugify(name: string) {
   return name
@@ -11,6 +11,8 @@ function slugify(name: string) {
 
 export default function DeviceNew({ params }: { params: { slug: string } }) {
   const r = useRouter();
+  const sp = useSearchParams();
+  const next = sp.get('next');
   async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const fd = new FormData(e.currentTarget);
@@ -19,7 +21,7 @@ export default function DeviceNew({ params }: { params: { slug: string } }) {
       alert('機器名は必須です');
       return;
     }
-      const slug = slugify(name);
+    const slug = slugify(name);
     const res = await fetch(`/api/mock/groups/${params.slug}/devices`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -36,7 +38,8 @@ export default function DeviceNew({ params }: { params: { slug: string } }) {
       alert(json?.error ?? `HTTP ${res.status}`);
       return;
     }
-    r.push(`/groups/${params.slug}/devices/${json?.device?.slug ?? slug}`);
+    const createdSlug = json?.device?.slug ?? slug;
+    r.push(next || `/groups/${params.slug}/devices/${createdSlug}`);
   }
   return (
     <div className="max-w-2xl">

--- a/web/src/app/groups/[slug]/reservations/new/ClientPage.tsx
+++ b/web/src/app/groups/[slug]/reservations/new/ClientPage.tsx
@@ -17,7 +17,7 @@ export default function ClientPage({ params }: { params: { slug: string } }) {
       end: String(fd.get('end') || ''),
       purpose: String(fd.get('purpose') || ''),
     };
-    const res = await fetch('/api/mock/reservations', {
+    const res = await fetch(`/api/mock/groups/${encodeURIComponent(params.slug)}/reservations`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary
- add mock reservations API scoped by group with POST/GET endpoints
- support reservation creation from client via new endpoint
- redirect back after creating devices using `next` query param

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68c5922824948323ad5bf408f74b7889