### PR TITLE
feat(db): add prisma models and reservations api

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ Lab equipment reservation system monorepo.
    ```
 
 ### Environment
+Set `DATABASE_URL` in `web/.env.local` to point to your Neon (Postgres) instance.
+Prisma migrations are applied automatically during `pnpm build`.
 
-The web app uses SQLite for user persistence. Configure the database path
-via `DATABASE_PATH` in `web/.env.local` (default: `./data.db`).
+### DB health check
+
+Run the health endpoint to verify connectivity:
+
+```bash
+curl http://localhost:3000/api/health/db
+```
+
+In Neon SQL editor you can run:
+
+```sql
+select table_schema, table_name
+from information_schema.tables
+where table_schema = 'public'
+order by table_name;
+```

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && next build",
+    "build": "prisma generate && prisma migrate deploy && next build",
     "start": "next start",
     "lint": "next lint",
     "postinstall": "echo skip prisma generate on postinstall",

--- a/web/prisma/migrations/init/migration.sql
+++ b/web/prisma/migrations/init/migration.sql
@@ -1,0 +1,129 @@
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "name" TEXT,
+    "email" TEXT,
+    "emailVerified" TIMESTAMP(3),
+    "image" TEXT,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Account" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "providerAccountId" TEXT NOT NULL,
+    "refresh_token" TEXT,
+    "access_token" TEXT,
+    "expires_at" INTEGER,
+    "token_type" TEXT,
+    "scope" TEXT,
+    "id_token" TEXT,
+    "session_state" TEXT,
+
+    CONSTRAINT "Account_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Session" (
+    "id" TEXT NOT NULL,
+    "sessionToken" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "expires" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Session_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "VerificationToken" (
+    "identifier" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expires" TIMESTAMP(3) NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "Group" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "name" TEXT,
+    "hostEmail" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Group_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Device" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "groupId" TEXT NOT NULL,
+
+    CONSTRAINT "Device_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Reservation" (
+    "id" TEXT NOT NULL,
+    "deviceId" TEXT NOT NULL,
+    "userEmail" TEXT NOT NULL,
+    "start" TIMESTAMP(3) NOT NULL,
+    "end" TIMESTAMP(3) NOT NULL,
+    "purpose" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Reservation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "UserProfile" (
+    "email" TEXT NOT NULL,
+    "displayName" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserProfile_pkey" PRIMARY KEY ("email")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Account_provider_providerAccountId_key" ON "Account"("provider", "providerAccountId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Session_sessionToken_key" ON "Session"("sessionToken");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "VerificationToken_token_key" ON "VerificationToken"("token");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "VerificationToken_identifier_token_key" ON "VerificationToken"("identifier", "token");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Group_slug_key" ON "Group"("slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Device_groupId_slug_key" ON "Device"("groupId", "slug");
+
+-- CreateIndex
+CREATE INDEX "Reservation_deviceId_start_idx" ON "Reservation"("deviceId", "start");
+
+-- CreateIndex
+CREATE INDEX "Reservation_start_end_idx" ON "Reservation"("start", "end");
+
+-- AddForeignKey
+ALTER TABLE "Account" ADD CONSTRAINT "Account_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Device" ADD CONSTRAINT "Device_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "Group"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Reservation" ADD CONSTRAINT "Reservation_deviceId_fkey" FOREIGN KEY ("deviceId") REFERENCES "Device"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/web/prisma/migrations/migration_lock.toml
+++ b/web/prisma/migrations/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "postgresql"

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -52,9 +52,42 @@ model VerificationToken {
 }
 
 model Group {
-  id        String   @id
-  name      String
+  id        String   @id @default(cuid())
   slug      String   @unique
-  createdBy String?  @map("created_by")
-  createdAt DateTime @default(now()) @map("created_at")
+  name      String?
+  hostEmail String
+  devices   Device[]
+  createdAt DateTime @default(now())
+}
+
+model Device {
+  id        String   @id @default(cuid())
+  slug      String
+  name      String
+  group     Group    @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  groupId   String
+  reservations Reservation[]
+
+  @@unique([groupId, slug])
+}
+
+model Reservation {
+  id        String   @id @default(cuid())
+  device    Device   @relation(fields: [deviceId], references: [id], onDelete: Cascade)
+  deviceId  String
+  userEmail String
+  start     DateTime
+  end       DateTime
+  purpose   String?
+  createdAt DateTime @default(now())
+
+  @@index([deviceId, start])
+  @@index([start, end])
+}
+
+model UserProfile {
+  email String  @id
+  displayName String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }

--- a/web/src/app/api/health/db/route.ts
+++ b/web/src/app/api/health/db/route.ts
@@ -1,0 +1,12 @@
+export const runtime = 'nodejs'
+
+import { prisma } from '@/src/lib/prisma'
+
+export async function GET() {
+  try {
+    await prisma.$queryRaw`SELECT 1`
+    return Response.json({ ok: true })
+  } catch (e) {
+    return new Response('db NG', { status: 500 })
+  }
+}

--- a/web/src/app/api/reservations/route.ts
+++ b/web/src/app/api/reservations/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/src/lib/prisma'
+import { z } from 'zod'
+
+export const dynamic = 'force-dynamic'
+
+const Body = z.object({
+  groupSlug: z.string().min(1),
+  deviceSlug: z.string().min(1),
+  start: z.string().transform((s) => new Date(s)),
+  end: z.string().transform((s) => new Date(s)),
+  purpose: z.string().optional(),
+})
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const groupSlug = searchParams.get('group') ?? ''
+  const rows = await prisma.reservation.findMany({
+    where: { device: { group: { slug: groupSlug } } },
+    include: { device: { select: { slug: true, group: { select: { slug: true } } } } },
+    orderBy: { createdAt: 'desc' },
+  })
+  return NextResponse.json(rows)
+}
+
+export async function POST(req: Request) {
+  const body = Body.parse(await req.json())
+
+  const device = await prisma.device.findFirst({
+    where: { slug: body.deviceSlug, group: { slug: body.groupSlug } },
+    select: { id: true },
+  })
+  if (!device) {
+    return NextResponse.json({ error: 'device not found' }, { status: 404 })
+  }
+
+  const me = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL ?? ''}/api/auth/me`, { cache: 'no-store' }).then(r => r.json())
+  const userEmail = me?.email ?? 'unknown@example.com'
+
+  if (body.start >= body.end) {
+    return NextResponse.json({ error: 'invalid time range' }, { status: 400 })
+  }
+
+  const created = await prisma.reservation.create({
+    data: {
+      deviceId: device.id,
+      userEmail,
+      start: body.start,
+      end: body.end,
+      purpose: body.purpose,
+    },
+  })
+  return NextResponse.json(created, { status: 201 })
+}


### PR DESCRIPTION
## Summary
- add Prisma models for devices, reservations, and user profile
- implement real `/api/reservations` endpoint using Prisma
- expose database health endpoint and document DATABASE_URL usage

## Testing
- `npx prisma generate`
- `pnpm lint`
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68c7888eeb188323aa861193cbf10778