### PR TITLE
fix: run api tests from correct path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,12 @@ jobs:
       - name: Install dependencies
         run: |
           corepack enable
-          pnpm install --frozen-lockfile || true
+          pnpm install --frozen-lockfile
           pip install fastapi uvicorn pytest
       - name: Lint web
-        run: pnpm --filter web lint || true
+        run: pnpm --filter ./web lint
       - name: Test api
-        run: pytest -q || true
+        working-directory: api
+        env:
+          PYTHONPATH: .
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -42,3 +42,22 @@ from information_schema.tables
 where table_schema = 'public'
 order by table_name;
 ```
+
+## Testing
+
+### Web
+
+Run the linter for the Next.js frontend:
+
+```bash
+pnpm --filter ./web lint
+```
+
+### API
+
+Execute the FastAPI unit tests:
+
+```bash
+cd api
+PYTHONPATH=. pytest -q
+```


### PR DESCRIPTION
## Summary
- run web lints and API tests correctly in CI
- document running lints and tests locally

## Testing
- `pnpm --filter ./web lint`
- `cd api && PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c78e42f0e48323987e96a3555c9257