### PR TITLE
Refine reservation request validation

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -1,8 +1,19 @@
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
     domains: ['via.placeholder.com'],
   },
-};
+  webpack(config) {
+    config.resolve = config.resolve ?? {}
+    config.resolve.alias = config.resolve.alias ?? {}
+    config.resolve.alias.zod = path.resolve(__dirname, 'src/lib/zod')
+    return config
+  },
+}
 
-export default nextConfig;
+export default nextConfig

--- a/web/src/app/api/reservations/route.ts
+++ b/web/src/app/api/reservations/route.ts
@@ -1,74 +1,16 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/src/lib/prisma'
+import { z } from 'zod'
 
 export const dynamic = 'force-dynamic'
 
-type ReservationRequestBody = {
-  groupSlug: string
-  deviceSlug: string
-  start: Date
-  end: Date
-  purpose?: string
-}
-
-type ValidationResult =
-  | { ok: true; value: ReservationRequestBody }
-  | { ok: false; error: string }
-
-function parseReservationBody(payload: unknown): ValidationResult {
-  if (!payload || typeof payload !== 'object') {
-    return { ok: false, error: 'invalid body' }
-  }
-
-  const record = payload as Record<string, unknown>
-
-  const groupSlug = record.groupSlug
-  if (typeof groupSlug !== 'string' || groupSlug.length === 0) {
-    return { ok: false, error: 'groupSlug must be a non-empty string' }
-  }
-
-  const deviceSlug = record.deviceSlug
-  if (typeof deviceSlug !== 'string' || deviceSlug.length === 0) {
-    return { ok: false, error: 'deviceSlug must be a non-empty string' }
-  }
-
-  const start = record.start
-  if (typeof start !== 'string' || start.length === 0) {
-    return { ok: false, error: 'start must be a non-empty string' }
-  }
-  const startDate = new Date(start)
-  if (Number.isNaN(startDate.getTime())) {
-    return { ok: false, error: 'start must be a valid date string' }
-  }
-
-  const end = record.end
-  if (typeof end !== 'string' || end.length === 0) {
-    return { ok: false, error: 'end must be a non-empty string' }
-  }
-  const endDate = new Date(end)
-  if (Number.isNaN(endDate.getTime())) {
-    return { ok: false, error: 'end must be a valid date string' }
-  }
-
-  let purpose: string | undefined
-  if (record.purpose !== undefined) {
-    if (typeof record.purpose !== 'string') {
-      return { ok: false, error: 'purpose must be a string if provided' }
-    }
-    purpose = record.purpose
-  }
-
-  return {
-    ok: true,
-    value: {
-      groupSlug,
-      deviceSlug,
-      start: startDate,
-      end: endDate,
-      purpose,
-    },
-  }
-}
+const ReservationBodySchema = z.object({
+  groupSlug: z.string().min(1),
+  deviceSlug: z.string().min(1),
+  start: z.coerce.date(),
+  end: z.coerce.date(),
+  purpose: z.string().optional(),
+})
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url)
@@ -89,11 +31,12 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'invalid body' }, { status: 400 })
   }
 
-  const result = parseReservationBody(parsed)
-  if (!result.ok) {
-    return NextResponse.json({ error: result.error }, { status: 400 })
+  const parsedResult = ReservationBodySchema.safeParse(parsed)
+  if (!parsedResult.success) {
+    const flattened = 'error' in parsedResult ? parsedResult.error.flatten() : { formErrors: ['invalid body'], fieldErrors: {} }
+    return NextResponse.json({ error: flattened }, { status: 400 })
   }
-  const body = result.value
+  const body = parsedResult.data
 
   const device = await prisma.device.findFirst({
     where: { slug: body.deviceSlug, group: { slug: body.groupSlug } },

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -25,6 +25,9 @@
       ],
       "@/src/*": [
         "src/*"
+      ],
+      "zod": [
+        "src/lib/zod"
       ]
     },
     "plugins": [


### PR DESCRIPTION
## Summary
- replace the manual reservation request parser with a schema-based safeParse flow
- add a lightweight local zod implementation and wire it up through Next.js and TypeScript aliases
- surface flattened validation errors from the schema before proceeding to reservation creation

## Testing
- pnpm --filter lab_yoyaku-web lint
- DATABASE_URL=postgres://user:pass@localhost:5432/db pnpm exec next build *(fails to connect to the placeholder database during Prisma data fetching)*

------
https://chatgpt.com/codex/tasks/task_e_68c86423a000832397948fbebbe7c7d2