### PR TITLE
Fix auth session cookie path and settings

### DIFF
--- a/web/src/app/api/auth/login/route.ts
+++ b/web/src/app/api/auth/login/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { findUserByEmail, hashPassword, signToken, setAuthCookie } from '@/lib/auth';
+import { createSessionCookie, findUserByEmail, hashPassword, signToken } from '@/lib/auth';
 
 export const runtime = 'nodejs';
 
@@ -9,8 +9,9 @@ export async function POST(req: Request) {
   // デモショートカット：demo/demo でもログイン可（任意）
   if (email === 'demo' && password === 'demo') {
     const token = await signToken({ id: 'u-demo', name: 'demo', email: 'demo@example.com' });
-    await setAuthCookie(token);
-    return NextResponse.json({ ok: true });
+    const res = NextResponse.json({ ok: true });
+    res.cookies.set(createSessionCookie(token));
+    return res;
   }
 
   const user = email ? await findUserByEmail(String(email)) : null;
@@ -18,7 +19,8 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok:false, error:'invalid credentials' }, { status:401 });
   }
   const token = await signToken({ id: user.id, name: user.name || '', email: user.email });
-  await setAuthCookie(token);
-  return NextResponse.json({ ok:true });
+  const res = NextResponse.json({ ok:true });
+  res.cookies.set(createSessionCookie(token));
+  return res;
 }
 

--- a/web/src/app/api/auth/logout/route.ts
+++ b/web/src/app/api/auth/logout/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from 'next/server';
-import { clearAuthCookie } from '@/lib/auth';
+import { clearSessionCookie } from '@/lib/auth';
 
 export const runtime = 'nodejs';
 
 async function doLogout(request: Request) {
-  await clearAuthCookie();
-  // ブラウザ遷移ならログインへ
-  return NextResponse.redirect(new URL('/login', request.url));
+  const res = NextResponse.redirect(new URL('/login', request.url));
+  res.cookies.set(clearSessionCookie());
+  return res;
 }
 
 export async function GET(request: Request)  { return doLogout(request); }

--- a/web/src/app/api/auth/register/route.ts
+++ b/web/src/app/api/auth/register/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { hashPassword, signToken, setAuthCookie } from '@/lib/auth';
+import { createSessionCookie, hashPassword, signToken } from '@/lib/auth';
 import { loadUsers, saveUser } from '@/lib/db';
 import { isEmail, uid, UserRecord } from '@/lib/mockdb';
 
@@ -32,6 +32,7 @@ export async function POST(req: Request) {
 
   // 自動ログイン
   const token = await signToken({ id: user.id, name: user.name || '', email: user.email });
-  await setAuthCookie(token);
-  return NextResponse.json({ ok:true });
+  const res = NextResponse.json({ ok:true });
+  res.cookies.set(createSessionCookie(token));
+  return res;
 }

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -29,7 +29,7 @@ export function middleware(req: NextRequest) {
     return NextResponse.next()
   }
 
-  const token = req.cookies.get('labyoyaku_token')?.value
+  const token = req.cookies.get('session')?.value
   if (!token) {
     const url = new URL('/login', req.url)
     const next = pathname + (search || '')


### PR DESCRIPTION
## Summary
- configure a shared session cookie helper that sets the cookie on the root path with production-safe attributes
- update the login and registration routes to attach the session cookie through their NextResponse objects
- clear the new session cookie on logout and have the middleware read the renamed cookie

## Testing
- pnpm --filter lab_yoyaku-web lint

------
https://chatgpt.com/codex/tasks/task_e_68ca2d9226d88323a05dbff521d673f0