### PR TITLE
fix(auth): guard protected pages via SSR

### DIFF
--- a/web/src/app/account/profile/page.tsx
+++ b/web/src/app/account/profile/page.tsx
@@ -1,12 +1,16 @@
-import { serverFetch } from '@/lib/server-fetch';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const fetchCache = 'default-no-store';
+
 import { redirect } from 'next/navigation';
+import { getUserFromCookies } from '@/lib/auth/server';
+import { serverFetch } from '@/lib/server-fetch';
 import ProfileClient from './ProfileClient';
 
-export const dynamic = 'force-dynamic';
-
 export default async function ProfilePage() {
+  const user = await getUserFromCookies();
+  if (!user) redirect('/login?next=/account/profile');
   const res = await serverFetch('/api/me/profile');
-  if (res.status === 401) redirect('/login?next=/account/profile');
   const json = await res.json();
   return (
     <div className="max-w-md space-y-4">

--- a/web/src/app/groups/[slug]/devices/[device]/page.tsx
+++ b/web/src/app/groups/[slug]/devices/[device]/page.tsx
@@ -1,3 +1,7 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const fetchCache = 'default-no-store';
+
 import { serverFetch } from '@/lib/server-fetch';
 import { notFound, redirect } from 'next/navigation';
 import CalendarWithBars, { Span } from '@/components/CalendarWithBars';
@@ -5,9 +9,7 @@ import PrintButton from '@/components/PrintButton';
 import Image from 'next/image';
 import BackButton from '@/components/BackButton';
 import ReservationList, { ReservationItem } from '@/components/ReservationList';
-import { readUserFromCookie } from '@/lib/auth';
-
-export const dynamic = 'force-dynamic';
+import { getUserFromCookies } from '@/lib/auth/server';
 
 function buildMonth(base = new Date()) {
   const y = base.getFullYear(), m = base.getMonth();
@@ -47,6 +49,8 @@ export default async function DeviceDetail({
 }) {
   const { slug, device } = params;
   const group = slug;
+  const user = await getUserFromCookies();
+  if (!user) redirect(`/login?next=/groups/${group}/devices/${device}`);
   const res = await serverFetch(
     `/api/groups/${encodeURIComponent(group)}/devices/${encodeURIComponent(device)}`
   );
@@ -55,7 +59,7 @@ export default async function DeviceDetail({
   if (!res.ok) throw new Error(`failed: ${res.status}`);
   const json = await res.json();
   const dev = json?.device;
-  const me = await readUserFromCookie();
+  const me = user;
 
   const baseMonth = (() => {
     if (searchParams?.month) {

--- a/web/src/app/groups/[slug]/devices/new/DeviceNewClient.tsx
+++ b/web/src/app/groups/[slug]/devices/new/DeviceNewClient.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+
+function slugify(name: string) {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export default function DeviceNewClient({ slug }: { slug: string }) {
+  const r = useRouter();
+  useSearchParams();
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const name = String(fd.get('name') || '').trim();
+    if (!name) {
+      alert('機器名は必須です');
+      return;
+    }
+    const deviceSlug = slugify(name);
+    const res = await fetch(`/api/groups/${encodeURIComponent(slug)}/devices`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name,
+        slug: deviceSlug,
+        caution: String(fd.get('caution') || ''),
+        code: String(fd.get('code') || ''),
+      }),
+    });
+    const json = await res.json().catch(() => ({} as any));
+    if (!res.ok) {
+      alert(json?.error ?? `HTTP ${res.status}`);
+      return;
+    }
+    r.push(`/groups/${slug}`);
+  }
+  return (
+    <div className="max-w-2xl">
+      <h1 className="text-2xl font-semibold mb-4">機器登録</h1>
+      <form onSubmit={onSubmit} className="rounded-2xl border p-6 space-y-5 bg-white">
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            機器名 <span className="text-red-600">*</span>
+          </label>
+          <input
+            name="name"
+            className="w-full rounded-xl border px-3 py-2"
+            placeholder="例: PCR"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">使用上の注意（任意）</label>
+          <textarea
+            name="caution"
+            rows={3}
+            className="w-full rounded-xl border px-3 py-2"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">既存コード（任意）</label>
+          <input name="code" className="w-full rounded-xl border px-3 py-2" />
+        </div>
+        <div className="flex gap-2">
+          <button className="btn btn-primary" type="submit">
+            登録
+          </button>
+          <a className="btn btn-secondary" href={`/groups/${slug}`}>
+            キャンセル
+          </a>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/web/src/app/groups/[slug]/devices/new/page.tsx
+++ b/web/src/app/groups/[slug]/devices/new/page.tsx
@@ -1,79 +1,13 @@
-'use client';
-import { useRouter, useSearchParams } from 'next/navigation';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const fetchCache = 'default-no-store';
 
-function slugify(name: string) {
-  return name
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-}
+import { redirect } from 'next/navigation';
+import { getUserFromCookies } from '@/lib/auth/server';
+import DeviceNewClient from './DeviceNewClient';
 
-export default function DeviceNew({ params }: { params: { slug: string } }) {
-  const r = useRouter();
-  useSearchParams();
-  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    const fd = new FormData(e.currentTarget);
-    const name = String(fd.get('name') || '').trim();
-    if (!name) {
-      alert('機器名は必須です');
-      return;
-    }
-    const slug = slugify(name);
-    const res = await fetch(`/api/groups/${encodeURIComponent(params.slug)}/devices`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        name,
-        slug,
-        caution: String(fd.get('caution') || ''),
-        code: String(fd.get('code') || ''),
-      }),
-    });
-    const json = await res.json().catch(() => ({} as any));
-    if (!res.ok) {
-      alert(json?.error ?? `HTTP ${res.status}`);
-      return;
-    }
-    r.push(`/groups/${params.slug}`);
-  }
-  return (
-    <div className="max-w-2xl">
-      <h1 className="text-2xl font-semibold mb-4">機器登録</h1>
-      <form onSubmit={onSubmit} className="rounded-2xl border p-6 space-y-5 bg-white">
-        <div>
-          <label className="block text-sm font-medium mb-1">
-            機器名 <span className="text-red-600">*</span>
-          </label>
-          <input
-            name="name"
-            className="w-full rounded-xl border px-3 py-2"
-            placeholder="例: PCR"
-            required
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium mb-1">使用上の注意（任意）</label>
-          <textarea
-            name="caution"
-            rows={3}
-            className="w-full rounded-xl border px-3 py-2"
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium mb-1">既存コード（任意）</label>
-          <input name="code" className="w-full rounded-xl border px-3 py-2" />
-        </div>
-        <div className="flex gap-2">
-          <button className="btn btn-primary" type="submit">
-            登録
-          </button>
-          <a className="btn btn-secondary" href={`/groups/${params.slug}`}>
-            キャンセル
-          </a>
-        </div>
-      </form>
-    </div>
-  );
+export default async function DeviceNewPage({ params }: { params: { slug: string } }) {
+  const user = await getUserFromCookies();
+  if (!user) redirect(`/login?next=/groups/${params.slug}/devices/new`);
+  return <DeviceNewClient slug={params.slug} />;
 }

--- a/web/src/app/groups/[slug]/reservations/new/page.tsx
+++ b/web/src/app/groups/[slug]/reservations/new/page.tsx
@@ -1,12 +1,15 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const fetchCache = 'default-no-store';
+
 import { serverFetch } from '@/lib/server-fetch';
 import { notFound, redirect } from 'next/navigation';
+import { getUserFromCookies } from '@/lib/auth/server';
 import NewReservationClient from './Client';
 
-export const dynamic = 'force-dynamic';
-
 export default async function NewReservationPage({ params }: { params: { slug: string } }) {
-  const me = await serverFetch('/api/auth/me');
-  if (me.status === 401) redirect(`/login?next=/groups/${params.slug}/reservations/new`);
+  const user = await getUserFromCookies();
+  if (!user) redirect(`/login?next=/groups/${params.slug}/reservations/new`);
   const res = await serverFetch(
     `/api/devices?groupSlug=${encodeURIComponent(params.slug)}`
   );

--- a/web/src/app/groups/[slug]/settings/page.tsx
+++ b/web/src/app/groups/[slug]/settings/page.tsx
@@ -1,20 +1,22 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const fetchCache = 'default-no-store';
+
 import { serverFetch } from '@/lib/server-fetch';
-import { readUserFromCookie } from '@/lib/auth';
+import { getUserFromCookies } from '@/lib/auth/server';
 import { redirect, notFound } from 'next/navigation';
 import GroupSettingsClient from './GroupSettingsClient';
 
-export const dynamic = 'force-dynamic';
-
 export default async function GroupSettingsPage({ params }: { params: { slug: string } }) {
   const slug = params.slug.toLowerCase();
+  const user = await getUserFromCookies();
+  if (!user) redirect(`/login?next=/groups/${slug}/settings`);
   const res = await serverFetch(`/api/groups/${encodeURIComponent(slug)}`);
-  if (res.status === 401) redirect(`/login?next=/groups/${slug}/settings`);
   if (res.status === 404) return notFound();
   if (!res.ok) throw new Error(`failed: ${res.status}`);
   const data = await res.json();
   const group = data?.group ?? data;
-  const me = await readUserFromCookie();
-  if (!me || group.host !== me.email) return notFound();
+  if (!group || group.host !== user.email) return notFound();
   return (
     <div className="mx-auto max-w-4xl">
       <GroupSettingsClient initialGroup={group} />

--- a/web/src/app/groups/new/page.tsx
+++ b/web/src/app/groups/new/page.tsx
@@ -1,12 +1,14 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const fetchCache = 'default-no-store';
+
 import { redirect } from 'next/navigation';
-import { serverFetch } from '@/lib/server-fetch';
+import { getUserFromCookies } from '@/lib/auth/server';
 import NewGroupForm from './NewGroupForm';
 
-export const dynamic = 'force-dynamic';
-
 export default async function NewGroupPage() {
-  const me = await serverFetch('/api/auth/me');
-  if (me.status === 401) redirect('/login?next=/groups/new');
+  const user = await getUserFromCookies();
+  if (!user) redirect('/login?next=/groups/new');
   return (
     <div className="max-w-6xl mx-auto space-y-6">
       <div className="flex items-center justify-between">

--- a/web/src/app/groups/page.tsx
+++ b/web/src/app/groups/page.tsx
@@ -1,13 +1,17 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const fetchCache = 'default-no-store';
+
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
+import { getUserFromCookies } from '@/lib/auth/server';
 import { serverFetch } from '@/lib/server-fetch';
 import Empty from '@/components/Empty';
 
-export const dynamic = 'force-dynamic';
-
 export default async function GroupsPage() {
+  const user = await getUserFromCookies();
+  if (!user) redirect('/login?next=/groups');
   const res = await serverFetch('/api/groups?mine=1');
-  if (res.status === 401) redirect('/login?next=/groups');
   if (!res.ok) throw new Error(`failed: ${res.status}`);
   const data = await res.json();
   const groups: any[] = Array.isArray(data) ? data : data?.groups ?? [];

--- a/web/src/lib/auth/server.ts
+++ b/web/src/lib/auth/server.ts
@@ -1,0 +1,6 @@
+import 'server-only';
+import { readUserFromCookie } from '../auth';
+
+export async function getUserFromCookies() {
+  return readUserFromCookie();
+}


### PR DESCRIPTION
## Summary
- add a server-only helper to read authenticated users from cookies
- force SSR guards on /groups/new and other login-required pages while preserving existing UI
- wrap the device creation form in a client component so the page can enforce the server redirect

## Testing
- pnpm -C web lint
- USE_MOCK=true pnpm -C web build

------
https://chatgpt.com/codex/tasks/task_e_68ca38b6d1f08323a35789900cb1a490