### PR TITLE
Self-join group creators and refine group access redirects

### DIFF
--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -61,6 +61,7 @@ export default async function GroupPage({
 
   const res = await serverFetch(`/api/groups/${encodeURIComponent(paramSlug)}`);
   if (res.status === 401) redirect(`/login?next=/groups/${paramSlug}`);
+  if (res.status === 403) redirect(`/groups/join?slug=${encodeURIComponent(paramSlug)}`);
   if (res.status === 404) return notFound();
   if (!res.ok) throw new Error(`failed: ${res.status}`);
   const data = await res.json();
@@ -109,6 +110,9 @@ export default async function GroupPage({
   const reservationsRes = await serverFetch(`/api/reservations?${reservationParams.toString()}`);
   if (reservationsRes.status === 401) {
     redirect(`/login?next=/groups/${paramSlug}`);
+  }
+  if (reservationsRes.status === 403) {
+    redirect(`/groups/join?slug=${encodeURIComponent(paramSlug)}`);
   }
   if (reservationsRes.status === 404) {
     return notFound();

--- a/web/src/app/groups/join/page.tsx
+++ b/web/src/app/groups/join/page.tsx
@@ -1,14 +1,21 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 
 export default function GroupJoinPage() {
-  const [group, setGroup] = useState(""); // name or slug
+  const searchParams = useSearchParams();
+  const [group, setGroup] = useState(() => searchParams.get("slug") || ""); // name or slug
   const [password, setPassword] = useState("");
   const [err, setErr] = useState('');
   const [loading, setLoading] = useState(false);
   const router = useRouter();
+
+  const slugParam = searchParams.get("slug") || "";
+
+  useEffect(() => {
+    setGroup(slugParam);
+  }, [slugParam]);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();

--- a/web/src/app/groups/new/NewGroupForm.tsx
+++ b/web/src/app/groups/new/NewGroupForm.tsx
@@ -32,7 +32,19 @@ export default function NewGroupForm() {
     if (!res.ok) throw new Error(json?.error ?? `HTTP ${res.status}`);
 
     const slug = json?.group?.slug ?? json?.slug ?? (name || '').toLowerCase();
-    r.push(`/groups/${encodeURIComponent(slug)}`);
+
+    const joinRes = await fetch('/api/groups/join', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ query: slug, password: payload.password }),
+    });
+
+    if (!joinRes.ok) {
+      const joinJson = await joinRes.json().catch(() => ({} as any));
+      throw new Error(joinJson?.error ?? `HTTP ${joinRes.status}`);
+    }
+
+    r.replace(`/groups/${encodeURIComponent(slug)}`);
   }
 
   return (


### PR DESCRIPTION
## Summary
- join the newly created group via the join API before navigating to the group detail screen
- redirect authenticated non-members from the group page to the join flow instead of the login page
- pre-fill the join form with the slug passed in query parameters to streamline redirects

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68caabd7cd948323a4f3307fd94bdebb