### PR TITLE
Ensure dynamic SSR auth pages forward cookies

### DIFF
--- a/web/src/app/account/profile/page.tsx
+++ b/web/src/app/account/profile/page.tsx
@@ -1,6 +1,6 @@
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
-export const fetchCache = 'default-no-store';
+export const fetchCache = 'force-no-store';
 
 import { redirect } from 'next/navigation';
 import { getUserFromCookies } from '@/lib/auth/server';

--- a/web/src/app/api/auth/me/route.ts
+++ b/web/src/app/api/auth/me/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 import { NextResponse } from 'next/server';
 import { readUserFromCookie } from '@/lib/auth';
 

--- a/web/src/app/api/devices/[slug]/route.ts
+++ b/web/src/app/api/devices/[slug]/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import { NextResponse } from 'next/server'
 import { prisma } from '@/src/lib/prisma'
 import { readUserFromCookie } from '@/lib/auth'

--- a/web/src/app/api/devices/route.ts
+++ b/web/src/app/api/devices/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { readUserFromCookie } from '@/lib/auth'

--- a/web/src/app/api/groups/[slug]/devices/[device]/route.ts
+++ b/web/src/app/api/groups/[slug]/devices/[device]/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import { NextResponse } from 'next/server'
 import { prisma } from '@/src/lib/prisma'
 import { readUserFromCookie } from '@/lib/auth'

--- a/web/src/app/api/groups/[slug]/devices/route.ts
+++ b/web/src/app/api/groups/[slug]/devices/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import { NextResponse } from 'next/server'
 import { prisma } from '@/src/lib/prisma'
 import { readUserFromCookie } from '@/lib/auth'

--- a/web/src/app/api/groups/[slug]/route.ts
+++ b/web/src/app/api/groups/[slug]/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import { NextResponse } from 'next/server'
 import { prisma } from '@/src/lib/prisma'
 import { readUserFromCookie } from '@/lib/auth'

--- a/web/src/app/api/groups/join/route.ts
+++ b/web/src/app/api/groups/join/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import { NextResponse } from 'next/server'
 import { prisma } from '@/src/lib/prisma'
 import { hashPassword, readUserFromCookie } from '@/lib/auth'

--- a/web/src/app/api/groups/route.ts
+++ b/web/src/app/api/groups/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import { NextResponse } from 'next/server'
 import { prisma } from '@/src/lib/prisma'
 import { readUserFromCookie, hashPassword } from '@/lib/auth'

--- a/web/src/app/api/me/groups/route.ts
+++ b/web/src/app/api/me/groups/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import { NextResponse } from 'next/server'
 import { readUserFromCookie } from '@/lib/auth'
 import { prisma } from '@/src/lib/prisma'

--- a/web/src/app/api/me/profile/route.ts
+++ b/web/src/app/api/me/profile/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import { NextResponse } from 'next/server'
 import { readUserFromCookie } from '@/lib/auth'
 import { prisma } from '@/src/lib/prisma'

--- a/web/src/app/api/me/reservations/route.ts
+++ b/web/src/app/api/me/reservations/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import { NextResponse } from 'next/server'
 import { readUserFromCookie } from '@/lib/auth'
 import { prisma } from '@/src/lib/prisma'

--- a/web/src/app/api/mock/groups/[slug]/reservations/route.ts
+++ b/web/src/app/api/mock/groups/[slug]/reservations/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 import { NextResponse } from 'next/server';
 import { store } from '../../../_store';
 import { readUserFromCookie } from '@/lib/auth';

--- a/web/src/app/api/mock/groups/[slug]/route.ts
+++ b/web/src/app/api/mock/groups/[slug]/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 import { NextResponse } from 'next/server';
 import { loadDB, saveDB } from '@/lib/mockdb';
 import { readUserFromCookie } from '@/lib/auth';

--- a/web/src/app/api/mock/groups/join/route.ts
+++ b/web/src/app/api/mock/groups/join/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 import { NextResponse } from 'next/server';
 import { loadDB, saveDB } from '@/lib/mockdb';
 import { readUserFromCookie } from '@/lib/auth';

--- a/web/src/app/api/mock/groups/route.ts
+++ b/web/src/app/api/mock/groups/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 import { NextResponse } from 'next/server';
 import { loadDB, saveDB } from '@/lib/mockdb';
 import { makeSlug } from '@/lib/slug';

--- a/web/src/app/api/mock/reservations/route.ts
+++ b/web/src/app/api/mock/reservations/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 import { NextResponse } from 'next/server';
 import { readUserFromCookie } from '@/lib/auth';
 import { loadDB, saveDB } from '@/lib/mockdb';

--- a/web/src/app/api/reservations/route.ts
+++ b/web/src/app/api/reservations/route.ts
@@ -1,10 +1,10 @@
+export const dynamic = 'force-dynamic'
+
 import { NextResponse } from 'next/server'
 import { prisma } from '@/src/lib/prisma'
 import { z } from 'zod'
 import { readUserFromCookie } from '@/lib/auth'
 import type { Prisma } from '@prisma/client'
-
-export const dynamic = 'force-dynamic'
 
 const ReservationBodySchema = z.object({
   groupSlug: z.string().min(1),

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -1,13 +1,12 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
+
 import { readUserFromCookie } from '@/lib/auth';
 import type { Span } from '@/components/CalendarWithBars';
 import DashboardClient from './page.client';
 import { serverFetch } from '@/lib/serverFetch';
 import { redirect } from 'next/navigation';
-
-export const revalidate = 0;
-export const fetchCache = 'default-no-store';
-
-export const dynamic = 'force-dynamic';
 
 type Mine = {
   id:string; deviceId:string; deviceName?:string; userEmail:string; userName?:string;

--- a/web/src/app/devices/[slug]/page.tsx
+++ b/web/src/app/devices/[slug]/page.tsx
@@ -1,6 +1,6 @@
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
-export const fetchCache = 'default-no-store';
+export const fetchCache = 'force-no-store';
 
 import { serverFetch } from '@/lib/serverFetch';
 import { notFound, redirect } from 'next/navigation';

--- a/web/src/app/groups/[slug]/devices/[device]/page.tsx
+++ b/web/src/app/groups/[slug]/devices/[device]/page.tsx
@@ -1,6 +1,6 @@
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
-export const fetchCache = 'default-no-store';
+export const fetchCache = 'force-no-store';
 
 import { serverFetch } from '@/lib/serverFetch';
 import { notFound, redirect } from 'next/navigation';

--- a/web/src/app/groups/[slug]/devices/new/page.tsx
+++ b/web/src/app/groups/[slug]/devices/new/page.tsx
@@ -1,6 +1,6 @@
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
-export const fetchCache = 'default-no-store';
+export const fetchCache = 'force-no-store';
 
 import { redirect } from 'next/navigation';
 import { getUserFromCookies } from '@/lib/auth/server';

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -1,6 +1,6 @@
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
-export const fetchCache = 'default-no-store';
+export const fetchCache = 'force-no-store';
 
 import { redirect } from 'next/navigation';
 import { serverFetch } from '@/lib/serverFetch';

--- a/web/src/app/groups/[slug]/reservations/new/page.tsx
+++ b/web/src/app/groups/[slug]/reservations/new/page.tsx
@@ -1,6 +1,6 @@
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
-export const fetchCache = 'default-no-store';
+export const fetchCache = 'force-no-store';
 
 import { serverFetch } from '@/lib/serverFetch';
 import { redirect } from 'next/navigation';

--- a/web/src/app/groups/[slug]/settings/page.tsx
+++ b/web/src/app/groups/[slug]/settings/page.tsx
@@ -1,6 +1,6 @@
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
-export const fetchCache = 'default-no-store';
+export const fetchCache = 'force-no-store';
 
 import { serverFetch } from '@/lib/serverFetch';
 import { getUserFromCookies } from '@/lib/auth/server';

--- a/web/src/app/groups/new/page.tsx
+++ b/web/src/app/groups/new/page.tsx
@@ -1,6 +1,6 @@
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
-export const fetchCache = 'default-no-store';
+export const fetchCache = 'force-no-store';
 
 import { redirect } from 'next/navigation';
 import { getUserFromCookies } from '@/lib/auth/server';

--- a/web/src/app/groups/page.tsx
+++ b/web/src/app/groups/page.tsx
@@ -1,6 +1,6 @@
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
-export const fetchCache = 'default-no-store';
+export const fetchCache = 'force-no-store';
 
 import Link from 'next/link';
 import { redirect } from 'next/navigation';

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,3 +1,6 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 import './globals.css';
 import Header from '@/components/Header';
 import { Toaster } from '@/lib/toast';

--- a/web/src/lib/serverFetch.ts
+++ b/web/src/lib/serverFetch.ts
@@ -1,33 +1,24 @@
 import { headers } from 'next/headers';
-import { getBaseUrl } from './base-url';
 
 function resolveBaseURL() {
-  const base = getBaseUrl();
-  if (!base) {
-    return 'http://localhost:3000';
-  }
-  return base;
+  const envUrl =
+    process.env.NEXT_PUBLIC_SITE_URL ??
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined);
+  return envUrl ?? 'http://localhost:3000';
 }
 
-/**
- * RSC/SSR から内部 API を叩くための安全な fetch
- * - 絶対URLに変換
- * - Cookie を前方転送
- * - キャッシュをしない（認証系なので）
- */
+/** SSR/RSC から内部APIを叩くための安全な fetch */
 export async function serverFetch(input: string, init: RequestInit = {}) {
   const base = resolveBaseURL();
   const url = input.startsWith('http') ? input : new URL(input, base).toString();
 
-  const headerInit = new Headers(init.headers);
+  const h = new Headers(init.headers);
   const cookie = headers().get('cookie');
-  if (cookie) {
-    headerInit.set('cookie', cookie);
-  }
+  if (cookie) h.set('cookie', cookie);
 
   return fetch(url, {
     ...init,
-    headers: headerInit,
+    headers: h,
     cache: 'no-store',
     credentials: 'include',
   });


### PR DESCRIPTION
## Summary
- update the server-side fetch helper to always forward cookies and disable caching when hitting internal APIs
- force dynamic rendering with no-store caching for the authenticated dashboard and group pages plus the root layout
- mark all cookie-reading API routes as dynamic so they consistently opt out of static rendering

## Testing
- pnpm --filter lab_yoyaku-web lint

------
https://chatgpt.com/codex/tasks/task_e_68cb08823790832387af03f7271d5258