### PR TITLE
Fix SSR session handling on group pages

### DIFF
--- a/web/src/lib/auth/cookies.ts
+++ b/web/src/lib/auth/cookies.ts
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers';
 
-export const AUTH_COOKIE = 'lab_session';
+export const AUTH_COOKIE = process.env.NEXT_PUBLIC_AUTH_COOKIE_NAME ?? 'lab_session';
 
 export function setSessionCookie(token: string, maxAgeSec = 60 * 60 * 24 * 30) {
   cookies().set({


### PR DESCRIPTION
## Summary
- honor NEXT_PUBLIC_AUTH_COOKIE_NAME when issuing the session cookie
- add a reusable decodeSession helper and reuse it when reading cookies
- harden the groups/[slug] SSR guard by decoding the cookie before fetching data

## Testing
- pnpm -C web lint

------
https://chatgpt.com/codex/tasks/task_e_68cb7a579270832383322c408534d829