### PR TITLE
Ensure dynamic server data fetching

### DIFF
--- a/web/src/app/account/profile/page.tsx
+++ b/web/src/app/account/profile/page.tsx
@@ -2,12 +2,14 @@ export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 export const fetchCache = 'force-no-store';
 
+import { unstable_noStore as noStore } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { getUserFromCookies } from '@/lib/auth/server';
 import { serverFetch } from '@/lib/serverFetch';
 import ProfileClient from './ProfileClient';
 
 export default async function ProfilePage() {
+  noStore();
   const user = await getUserFromCookies();
   if (!user) redirect('/login?next=/account/profile');
   const res = await serverFetch('/api/me/profile');

--- a/web/src/app/api/devices/[slug]/qr/route.ts
+++ b/web/src/app/api/devices/[slug]/qr/route.ts
@@ -1,3 +1,6 @@
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
 import QRCode from 'qrcode'
 import { prisma } from '@/src/lib/prisma'
 import { getBaseUrl } from '@/lib/http/base-url'

--- a/web/src/app/api/groups/[slug]/qr/route.ts
+++ b/web/src/app/api/groups/[slug]/qr/route.ts
@@ -1,3 +1,6 @@
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
 import QRCode from 'qrcode'
 import { prisma } from '@/src/lib/prisma'
 import { getBaseUrl } from '@/lib/http/base-url'

--- a/web/src/app/api/mock/devices/[slug]/qr/route.ts
+++ b/web/src/app/api/mock/devices/[slug]/qr/route.ts
@@ -1,3 +1,6 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 import { loadDB } from '@/lib/mockdb';
 import QRCode from 'qrcode';
 import { getBaseUrl } from '@/lib/http/base-url';

--- a/web/src/app/api/mock/groups/[slug]/qr/route.ts
+++ b/web/src/app/api/mock/groups/[slug]/qr/route.ts
@@ -1,3 +1,6 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 import { loadDB } from '@/lib/mockdb';
 import QRCode from 'qrcode';
 import { getBaseUrl } from '@/lib/http/base-url';

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { readUserFromCookie } from '@/lib/auth';
 import type { Span } from '@/components/CalendarWithBars';
 import DashboardClient from './page.client';
 import { serverFetch } from '@/lib/serverFetch';
+import { unstable_noStore as noStore } from 'next/cache';
 import { redirect } from 'next/navigation';
 
 type Mine = {
@@ -20,6 +21,7 @@ function colorFromString(s:string){
   return palette[h%palette.length];
 }
 export default async function DashboardPage() {
+  noStore();
   const me = await readUserFromCookie();
   if (!me) redirect('/login?next=/dashboard');
 

--- a/web/src/app/devices/[slug]/page.tsx
+++ b/web/src/app/devices/[slug]/page.tsx
@@ -3,9 +3,11 @@ export const revalidate = 0;
 export const fetchCache = 'force-no-store';
 
 import { serverFetch } from '@/lib/serverFetch';
+import { unstable_noStore as noStore } from 'next/cache';
 import { notFound, redirect } from 'next/navigation';
 
 export default async function DeviceGlobal({ params }: { params: { slug: string } }) {
+  noStore();
   const res = await serverFetch(`/api/devices/${encodeURIComponent(params.slug)}`);
   if (res.status === 401) {
     redirect(`/login?next=/devices/${params.slug}`);

--- a/web/src/app/groups/[slug]/devices/[device]/page.tsx
+++ b/web/src/app/groups/[slug]/devices/[device]/page.tsx
@@ -3,6 +3,7 @@ export const revalidate = 0;
 export const fetchCache = 'force-no-store';
 
 import { serverFetch } from '@/lib/serverFetch';
+import { unstable_noStore as noStore } from 'next/cache';
 import { notFound, redirect } from 'next/navigation';
 import CalendarWithBars, { Span } from '@/components/CalendarWithBars';
 import PrintButton from '@/components/PrintButton';
@@ -47,6 +48,7 @@ export default async function DeviceDetail({
   params: { slug: string; device: string };
   searchParams: { month?: string };
 }) {
+  noStore();
   const { slug, device } = params;
   const group = slug;
   const user = await getUserFromCookies();

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -15,6 +15,7 @@ import CalendarReservationSection from './CalendarReservationSection';
 import Image from 'next/image';
 import { AUTH_COOKIE } from '@/lib/auth/cookies';
 import { decodeSession } from '@/lib/auth';
+import { unstable_noStore as noStore } from 'next/cache';
 
 function buildMonth(base = new Date()) {
   const y = base.getFullYear(), m = base.getMonth();
@@ -58,6 +59,7 @@ export default async function GroupPage({
   params: { slug: string };
   searchParams: { month?: string };
 }) {
+  noStore();
   const paramSlug = params.slug.toLowerCase();
   const token = cookies().get(AUTH_COOKIE)?.value;
   let user: Awaited<ReturnType<typeof decodeSession>> | null = null;

--- a/web/src/app/groups/[slug]/reservations/new/page.tsx
+++ b/web/src/app/groups/[slug]/reservations/new/page.tsx
@@ -3,11 +3,13 @@ export const revalidate = 0;
 export const fetchCache = 'force-no-store';
 
 import { serverFetch } from '@/lib/serverFetch';
+import { unstable_noStore as noStore } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { getUserFromCookies } from '@/lib/auth/server';
 import NewReservationClient from './Client';
 
 export default async function NewReservationPage({ params }: { params: { slug: string } }) {
+  noStore();
   const user = await getUserFromCookies();
   if (!user) redirect(`/login?next=/groups/${params.slug}/reservations/new`);
   const res = await serverFetch(

--- a/web/src/app/groups/[slug]/settings/page.tsx
+++ b/web/src/app/groups/[slug]/settings/page.tsx
@@ -4,10 +4,12 @@ export const fetchCache = 'force-no-store';
 
 import { serverFetch } from '@/lib/serverFetch';
 import { getUserFromCookies } from '@/lib/auth/server';
+import { unstable_noStore as noStore } from 'next/cache';
 import { redirect, notFound } from 'next/navigation';
 import GroupSettingsClient from './GroupSettingsClient';
 
 export default async function GroupSettingsPage({ params }: { params: { slug: string } }) {
+  noStore();
   const slug = params.slug.toLowerCase();
   const user = await getUserFromCookies();
   if (!user) redirect(`/login?next=/groups/${slug}/settings`);

--- a/web/src/app/groups/page.tsx
+++ b/web/src/app/groups/page.tsx
@@ -3,12 +3,14 @@ export const revalidate = 0;
 export const fetchCache = 'force-no-store';
 
 import Link from 'next/link';
+import { unstable_noStore as noStore } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { getUserFromCookies } from '@/lib/auth/server';
 import { serverFetch } from '@/lib/serverFetch';
 import Empty from '@/components/Empty';
 
 export default async function GroupsPage() {
+  noStore();
   const user = await getUserFromCookies();
   if (!user) redirect('/login?next=/groups');
   const res = await serverFetch('/api/groups?mine=1');

--- a/web/src/lib/serverFetch.ts
+++ b/web/src/lib/serverFetch.ts
@@ -1,21 +1,26 @@
 import { headers } from 'next/headers';
 import { getBaseUrl } from './http/base-url';
 
+type ServerFetchInit = RequestInit & { next?: Record<string, unknown> };
+
 /** SSR/RSC から内部APIを叩くための安全な fetch */
-export async function serverFetch(input: string, init: RequestInit = {}) {
+export async function serverFetch(input: string, init: ServerFetchInit = {}) {
   const base = getBaseUrl();
   const url = input.startsWith('http')
     ? input
     : `${base}${input.startsWith('/') ? '' : '/'}${input}`;
 
   const h = new Headers(init.headers);
-  const cookie = headers().get('cookie');
-  if (cookie) h.set('cookie', cookie);
+  const cookie = headers().get('cookie') ?? '';
+  h.set('cookie', cookie);
+
+  const next = { ...(init.next ?? {}), revalidate: 0 };
 
   return fetch(url, {
     ...init,
     headers: h,
     cache: 'no-store',
+    next,
     credentials: 'include',
   });
 }


### PR DESCRIPTION
## Summary
- mark QR code API handlers that read request headers as force-dynamic
- call `noStore()` in server-rendered pages that rely on authenticated API fetches
- extend `serverFetch` to always forward cookies and disable caching for internal API calls

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cb7f1b38bc832390cbefea64f76f4a