### PR TITLE
Ensure SSR fetches forward cookies with base URL

### DIFF
--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -1,8 +1,10 @@
 import { readUserFromCookie } from '@/lib/auth';
 import NavLinks from './NavLinks';
 import { serverFetch } from '@/lib/serverFetch';
+import { unstable_noStore as noStore } from 'next/cache';
 
 export default async function Header() {
+  noStore();
   const me = await readUserFromCookie();
   let displayName: string | null = null;
   if (me?.email) {

--- a/web/src/lib/http/base-url.ts
+++ b/web/src/lib/http/base-url.ts
@@ -1,11 +1,10 @@
 import { headers } from 'next/headers';
 
 export function getBaseUrl() {
-  const envUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.APP_URL;
-  if (envUrl) return envUrl.replace(/\/$/, '');
-
+  const env = process.env.NEXT_PUBLIC_APP_URL || process.env.APP_URL;
+  if (env) return env.replace(/\/$/, '');
   const h = headers();
   const host = h.get('x-forwarded-host') ?? h.get('host');
   const proto = h.get('x-forwarded-proto') ?? 'https';
-  return host ? `${proto}://${host}` : 'http://localhost:3000';
+  return `${proto}://${host}`;
 }


### PR DESCRIPTION
## Summary
- align the base URL helper with the new SSR requirements
- prevent caching of the header server component before it fetches profile data

## Testing
- pnpm --filter lab_yoyaku-web lint

------
https://chatgpt.com/codex/tasks/task_e_68cb8237af40832388d64ef2a854a63f