### PR TITLE
Refine server-side auth flow and server fetch usage

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -20,3 +20,7 @@ pnpm -C web dev
 - `src/app/globals.css` で `@import "tailwindcss";` を使用します。
 - `postcss.config.js` は `@tailwindcss/postcss` プラグインのみを読み込みます。
 - v4 から `@tailwind base` などは不要です。
+
+## 検証時の注意
+
+- プレビューと本番ではクッキーがホスト単位で分離されます。同じホスト（例: `https://labyoyaku.vercel.app`）に固定してログイン状態を確認してください。

--- a/web/src/app/account/profile/page.tsx
+++ b/web/src/app/account/profile/page.tsx
@@ -5,7 +5,7 @@ export const fetchCache = 'force-no-store';
 import { unstable_noStore as noStore } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { getUserFromCookies } from '@/lib/auth/server';
-import { serverFetch } from '@/lib/serverFetch';
+import { serverFetch } from '@/lib/http/server-fetch';
 import ProfileClient from './ProfileClient';
 
 export default async function ProfilePage() {

--- a/web/src/app/api/auth/login/route.ts
+++ b/web/src/app/api/auth/login/route.ts
@@ -8,6 +8,14 @@ export const runtime = 'nodejs';
 
 export async function POST(req: Request) {
   const { email, password } = await req.json().catch(() => ({}));
+  const requestUrl = new URL(req.url);
+  const host = requestUrl.host;
+  const domain = process.env.NEXT_PUBLIC_COOKIE_DOMAIN ?? requestUrl.hostname;
+  console.info('[api.auth.login.POST]', {
+    host,
+    domain,
+    setCookiePath: '/',
+  });
 
   // デモショートカット：demo/demo でもログイン可（任意）
   if (email === 'demo' && password === 'demo') {

--- a/web/src/app/api/devices/[slug]/route.ts
+++ b/web/src/app/api/devices/[slug]/route.ts
@@ -1,5 +1,6 @@
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+export const runtime = 'nodejs'
 
 import { NextResponse } from 'next/server'
 import { prisma } from '@/src/lib/prisma'

--- a/web/src/app/api/devices/route.ts
+++ b/web/src/app/api/devices/route.ts
@@ -1,5 +1,6 @@
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+export const runtime = 'nodejs'
 
 import { NextResponse } from 'next/server'
 import { z } from 'zod'

--- a/web/src/app/api/groups/[slug]/devices/[device]/route.ts
+++ b/web/src/app/api/groups/[slug]/devices/[device]/route.ts
@@ -1,5 +1,6 @@
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+export const runtime = 'nodejs'
 
 import { NextResponse } from 'next/server'
 import { prisma } from '@/src/lib/prisma'

--- a/web/src/app/api/groups/[slug]/devices/route.ts
+++ b/web/src/app/api/groups/[slug]/devices/route.ts
@@ -1,5 +1,6 @@
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+export const runtime = 'nodejs'
 
 import { NextResponse } from 'next/server'
 import { prisma } from '@/src/lib/prisma'

--- a/web/src/app/api/groups/[slug]/route.ts
+++ b/web/src/app/api/groups/[slug]/route.ts
@@ -1,5 +1,6 @@
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+export const runtime = 'nodejs'
 
 import { NextResponse } from 'next/server'
 import { prisma } from '@/src/lib/prisma'

--- a/web/src/app/api/groups/join/route.ts
+++ b/web/src/app/api/groups/join/route.ts
@@ -1,5 +1,6 @@
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+export const runtime = 'nodejs'
 
 import { NextResponse } from 'next/server'
 import { prisma } from '@/src/lib/prisma'
@@ -10,6 +11,10 @@ const normalize = (value: string) => value.trim().toLowerCase()
 export async function POST(req: Request) {
   try {
     const me = await readUserFromCookie()
+    console.info('[api.groups.join.POST]', {
+      hasUserId: Boolean(me?.id),
+      hasEmail: Boolean(me?.email),
+    })
     if (!me?.email) {
       return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 })
     }

--- a/web/src/app/api/groups/route.ts
+++ b/web/src/app/api/groups/route.ts
@@ -1,5 +1,6 @@
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+export const runtime = 'nodejs'
 
 import { NextResponse } from 'next/server'
 import { prisma } from '@/src/lib/prisma'
@@ -20,6 +21,11 @@ export async function GET(req: Request) {
 
     if (mine) {
       const me = await readUserFromCookie()
+      console.info('[api.groups.GET]', {
+        mine: true,
+        hasUserId: Boolean(me?.id),
+        hasEmail: Boolean(me?.email),
+      })
       if (!me?.email) {
         return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
       }
@@ -44,6 +50,11 @@ export async function GET(req: Request) {
       orderBy: { createdAt: 'desc' },
       select: { slug: true, name: true },
     })
+    console.info('[api.groups.GET]', {
+      mine: false,
+      hasUserId: false,
+      hasEmail: false,
+    })
     return NextResponse.json({ groups })
   } catch (error) {
     console.error('list groups failed', error)
@@ -54,6 +65,10 @@ export async function GET(req: Request) {
 export async function POST(req: Request) {
   try {
     const me = await readUserFromCookie()
+    console.info('[api.groups.POST]', {
+      hasUserId: Boolean(me?.id),
+      hasEmail: Boolean(me?.email),
+    })
     if (!me?.email) {
       return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
     }

--- a/web/src/app/api/me/groups/route.ts
+++ b/web/src/app/api/me/groups/route.ts
@@ -10,6 +10,10 @@ export const runtime = 'nodejs'
 export async function POST(req: Request) {
   try {
     const me = await readUserFromCookie()
+    console.info('[api.me.groups.POST]', {
+      hasUserId: Boolean(me?.id),
+      hasEmail: Boolean(me?.email),
+    })
     const body = await req.json()
 
     const name: string = body?.name ?? ''
@@ -42,6 +46,11 @@ export async function POST(req: Request) {
 
 export async function GET() {
   try {
+    const me = await readUserFromCookie()
+    console.info('[api.me.groups.GET]', {
+      hasUserId: Boolean(me?.id),
+      hasEmail: Boolean(me?.email),
+    })
     const groups = await prisma.group.findMany({
       orderBy: { createdAt: 'desc' },
       select: { id: true, name: true, slug: true, createdAt: true }

--- a/web/src/app/api/me/profile/route.ts
+++ b/web/src/app/api/me/profile/route.ts
@@ -1,5 +1,6 @@
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+export const runtime = 'nodejs'
 
 import { NextResponse } from 'next/server'
 import { readUserFromCookie } from '@/lib/auth'
@@ -7,6 +8,10 @@ import { prisma } from '@/src/lib/prisma'
 
 export async function GET() {
   const me = await readUserFromCookie()
+  console.info('[api.me.profile.GET]', {
+    hasUserId: Boolean(me?.id),
+    hasEmail: Boolean(me?.email),
+  })
   if (!me?.email) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
   }
@@ -17,6 +22,10 @@ export async function GET() {
 
 export async function PUT(req: Request) {
   const me = await readUserFromCookie()
+  console.info('[api.me.profile.PUT]', {
+    hasUserId: Boolean(me?.id),
+    hasEmail: Boolean(me?.email),
+  })
   if (!me?.email) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
   }

--- a/web/src/app/api/me/reservations/route.ts
+++ b/web/src/app/api/me/reservations/route.ts
@@ -10,6 +10,10 @@ export const runtime = 'nodejs'
 
 export async function GET() {
   const me = await readUserFromCookie()
+  console.info('[api.me.reservations.GET]', {
+    hasUserId: Boolean(me?.id),
+    hasEmail: Boolean(me?.email),
+  })
   if (!me?.email) return NextResponse.json({ ok: false }, { status: 401 })
 
   const memberships = await prisma.groupMember.findMany({

--- a/web/src/app/api/mock/devices/[slug]/route.ts
+++ b/web/src/app/api/mock/devices/[slug]/route.ts
@@ -1,3 +1,5 @@
+export const runtime = 'nodejs';
+
 import { NextResponse } from 'next/server';
 import { store } from '../../_store';
 

--- a/web/src/app/api/mock/groups/[slug]/devices/[device]/route.ts
+++ b/web/src/app/api/mock/groups/[slug]/devices/[device]/route.ts
@@ -1,3 +1,5 @@
+export const runtime = 'nodejs';
+
 import { NextResponse } from 'next/server';
 import { store, toArr } from '../../../../_store';
 

--- a/web/src/app/api/mock/groups/[slug]/devices/route.ts
+++ b/web/src/app/api/mock/groups/[slug]/devices/route.ts
@@ -1,3 +1,5 @@
+export const runtime = 'nodejs';
+
 import { NextResponse } from 'next/server';
 import { store } from '../../../_store';
 

--- a/web/src/app/api/mock/groups/[slug]/reservations/route.ts
+++ b/web/src/app/api/mock/groups/[slug]/reservations/route.ts
@@ -1,5 +1,6 @@
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
+export const runtime = 'nodejs';
 
 import { NextResponse } from 'next/server';
 import { store } from '../../../_store';

--- a/web/src/app/api/reservations/route.ts
+++ b/web/src/app/api/reservations/route.ts
@@ -1,5 +1,6 @@
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
+export const runtime = 'nodejs'
 
 import { NextResponse } from 'next/server'
 import { prisma } from '@/src/lib/prisma'

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -5,7 +5,7 @@ export const fetchCache = 'force-no-store';
 import { readUserFromCookie } from '@/lib/auth';
 import type { Span } from '@/components/CalendarWithBars';
 import DashboardClient from './page.client';
-import { serverFetch } from '@/lib/serverFetch';
+import { serverFetch } from '@/lib/http/server-fetch';
 import { unstable_noStore as noStore } from 'next/cache';
 import { redirect } from 'next/navigation';
 

--- a/web/src/app/devices/[slug]/page.tsx
+++ b/web/src/app/devices/[slug]/page.tsx
@@ -2,7 +2,7 @@ export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 export const fetchCache = 'force-no-store';
 
-import { serverFetch } from '@/lib/serverFetch';
+import { serverFetch } from '@/lib/http/server-fetch';
 import { unstable_noStore as noStore } from 'next/cache';
 import { notFound, redirect } from 'next/navigation';
 

--- a/web/src/app/groups/[slug]/devices/[device]/page.tsx
+++ b/web/src/app/groups/[slug]/devices/[device]/page.tsx
@@ -2,7 +2,7 @@ export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 export const fetchCache = 'force-no-store';
 
-import { serverFetch } from '@/lib/serverFetch';
+import { serverFetch } from '@/lib/http/server-fetch';
 import { unstable_noStore as noStore } from 'next/cache';
 import { notFound, redirect } from 'next/navigation';
 import CalendarWithBars, { Span } from '@/components/CalendarWithBars';

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -4,7 +4,7 @@ export const fetchCache = 'force-no-store';
 
 import { redirect } from 'next/navigation';
 import { cookies } from 'next/headers';
-import { serverFetch } from '@/lib/serverFetch';
+import { serverFetch } from '@/lib/http/server-fetch';
 import GroupScreenClient from './GroupScreenClient';
 import Link from 'next/link';
 import { prisma } from '@/src/lib/prisma';

--- a/web/src/app/groups/[slug]/reservations/new/Client.tsx
+++ b/web/src/app/groups/[slug]/reservations/new/Client.tsx
@@ -75,7 +75,7 @@ export default function NewReservationClient({
       });
       const j = await res.json().catch(() => ({}));
       if (res.status === 401) {
-        location.assign(`/login?next=/groups/${params.slug}/reservations/new`);
+        toast.error('認証が必要です。ページを再読み込みしてください。');
         return;
       }
       if (res.status === 409) {

--- a/web/src/app/groups/[slug]/reservations/new/page.tsx
+++ b/web/src/app/groups/[slug]/reservations/new/page.tsx
@@ -2,7 +2,7 @@ export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 export const fetchCache = 'force-no-store';
 
-import { serverFetch } from '@/lib/serverFetch';
+import { serverFetch } from '@/lib/http/server-fetch';
 import { unstable_noStore as noStore } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { getUserFromCookies } from '@/lib/auth/server';

--- a/web/src/app/groups/[slug]/settings/page.tsx
+++ b/web/src/app/groups/[slug]/settings/page.tsx
@@ -2,7 +2,7 @@ export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 export const fetchCache = 'force-no-store';
 
-import { serverFetch } from '@/lib/serverFetch';
+import { serverFetch } from '@/lib/http/server-fetch';
 import { getUserFromCookies } from '@/lib/auth/server';
 import { unstable_noStore as noStore } from 'next/cache';
 import { redirect, notFound } from 'next/navigation';

--- a/web/src/app/groups/new/NewGroupForm.tsx
+++ b/web/src/app/groups/new/NewGroupForm.tsx
@@ -1,85 +1,36 @@
 'use client';
-import { useRouter } from 'next/navigation';
-import { startTransition, useState } from 'react';
+
+import { useFormState, useFormStatus } from 'react-dom';
+import { createGroupAction, type NewGroupFormState } from './actions';
+
+const initialState: NewGroupFormState = { error: '' };
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <button type="submit" className="btn btn-primary" disabled={pending}>
+      {pending ? '作成中…' : 'グループを作る'}
+    </button>
+  );
+}
 
 export default function NewGroupForm() {
-  const r = useRouter();
-  const [error, setError] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
-
-  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    setError(null);
-    setSubmitting(true);
-    const fd = new FormData(e.currentTarget);
-    const name = String(fd.get('name') || '').trim();
-    const payload = {
-      name,
-      password: String(fd.get('password') || ''),
-      startAt: fd.get('startAt') || null,
-      endAt: fd.get('endAt') || null,
-      memo: String(fd.get('memo') || ''),
-    };
-
-    try {
-      const res = await fetch('/api/groups', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify(payload),
-        credentials: 'same-origin',
-      });
-
-      if (res.status === 401) {
-        location.assign('/login?next=/groups/new');
-        return;
-      }
-
-      if (res.status === 409) {
-        setError('同じ URL のグループが既に存在します');
-        return;
-      }
-
-      const json = await res.json().catch(() => ({} as any));
-      if (!res.ok) throw new Error(json?.error ?? `HTTP ${res.status}`);
-
-      const slug = json?.group?.slug ?? json?.slug ?? (name || '').toLowerCase();
-
-      const joinRes = await fetch('/api/groups/join', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ slug, query: slug, password: payload.password }),
-        credentials: 'same-origin',
-      });
-
-      if (joinRes.status === 401) {
-        location.assign(`/login?next=/groups/${encodeURIComponent(slug)}`);
-        return;
-      }
-
-      if (!joinRes.ok) {
-        const joinJson = await joinRes.json().catch(() => ({} as any));
-        throw new Error(joinJson?.error ?? `HTTP ${joinRes.status}`);
-      }
-
-      r.replace(`/groups/${encodeURIComponent(slug)}`);
-      startTransition(() => r.refresh());
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'グループの作成に失敗しました';
-      setError(message || 'グループの作成に失敗しました');
-    } finally {
-      setSubmitting(false);
-    }
-  }
+  const [state, formAction] = useFormState(createGroupAction, initialState);
 
   return (
-    <form onSubmit={onSubmit} className="space-y-5">
+    <form action={formAction} className="space-y-5">
       <label className="block">
         <div className="mb-1">名称</div>
         <input name="name" className="w-full rounded-xl border p-3" required />
       </label>
       <label className="block">
         <div className="mb-1">パスワード</div>
-        <input type="password" name="password" className="w-full rounded-xl border p-3" required />
+        <input
+          type="password"
+          name="password"
+          className="w-full rounded-xl border p-3"
+          required
+        />
       </label>
       <div className="pt-2 space-y-4">
         <label className="block">
@@ -95,14 +46,12 @@ export default function NewGroupForm() {
           <textarea name="memo" className="w-full rounded-xl border p-3" />
         </label>
       </div>
-      {error && (
+      {state?.error && (
         <p className="text-sm text-red-600" role="alert">
-          {error}
+          {state.error}
         </p>
       )}
-      <button type="submit" className="btn btn-primary" disabled={submitting}>
-        {submitting ? '作成中…' : 'グループを作る'}
-      </button>
+      <SubmitButton />
     </form>
   );
 }

--- a/web/src/app/groups/new/actions.ts
+++ b/web/src/app/groups/new/actions.ts
@@ -1,0 +1,100 @@
+'use server';
+
+import { unstable_noStore as noStore } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { serverFetch } from '@/lib/http/server-fetch';
+
+export type NewGroupFormState = {
+  error?: string;
+};
+
+function asNullableString(value: FormDataEntryValue | null) {
+  if (value === null) return null;
+  const str = String(value);
+  return str ? str : null;
+}
+
+export async function createGroupAction(
+  _prevState: NewGroupFormState,
+  formData: FormData,
+): Promise<NewGroupFormState> {
+  noStore();
+
+  const name = String(formData.get('name') ?? '').trim();
+  const password = String(formData.get('password') ?? '');
+  const startAt = asNullableString(formData.get('startAt'));
+  const endAt = asNullableString(formData.get('endAt'));
+  const memo = String(formData.get('memo') ?? '').trim();
+
+  if (!name) {
+    return { error: '名称を入力してください' };
+  }
+
+  const payload = {
+    name,
+    password,
+    startAt,
+    endAt,
+    memo,
+  };
+
+  const createResponse = await serverFetch('/api/groups', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  if (createResponse.status === 401) {
+    redirect('/login?next=/groups/new');
+  }
+
+  let createdJson: any = {};
+  try {
+    createdJson = await createResponse.json();
+  } catch {
+    createdJson = {};
+  }
+
+  if (createResponse.status === 409) {
+    return { error: '同じ URL のグループが既に存在します' };
+  }
+
+  if (!createResponse.ok) {
+    const message = typeof createdJson?.error === 'string' && createdJson.error
+      ? createdJson.error
+      : 'グループの作成に失敗しました';
+    return { error: message };
+  }
+
+  const slugRaw = createdJson?.group?.slug ?? createdJson?.slug ?? '';
+  const slug = typeof slugRaw === 'string' ? slugRaw.trim().toLowerCase() : '';
+  if (!slug) {
+    return { error: 'グループの作成に失敗しました' };
+  }
+
+  const joinResponse = await serverFetch('/api/groups/join', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ slug, query: slug, password }),
+  });
+
+  if (joinResponse.status === 401) {
+    redirect(`/login?next=/groups/${encodeURIComponent(slug)}`);
+  }
+
+  let joinJson: any = {};
+  try {
+    joinJson = await joinResponse.json();
+  } catch {
+    joinJson = {};
+  }
+
+  if (!joinResponse.ok) {
+    const message = typeof joinJson?.error === 'string' && joinJson.error
+      ? joinJson.error
+      : 'グループへの参加に失敗しました';
+    return { error: message };
+  }
+
+  redirect(`/groups/${encodeURIComponent(slug)}`);
+}

--- a/web/src/app/groups/new/page.tsx
+++ b/web/src/app/groups/new/page.tsx
@@ -5,8 +5,10 @@ export const fetchCache = 'force-no-store';
 import { redirect } from 'next/navigation';
 import { getUserFromCookies } from '@/lib/auth/server';
 import NewGroupForm from './NewGroupForm';
+import { unstable_noStore as noStore } from 'next/cache';
 
 export default async function NewGroupPage() {
+  noStore();
   const user = await getUserFromCookies();
   if (!user) redirect('/login?next=/groups/new');
   return (

--- a/web/src/app/groups/page.tsx
+++ b/web/src/app/groups/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import { unstable_noStore as noStore } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { getUserFromCookies } from '@/lib/auth/server';
-import { serverFetch } from '@/lib/serverFetch';
+import { serverFetch } from '@/lib/http/server-fetch';
 import Empty from '@/components/Empty';
 
 export default async function GroupsPage() {

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,4 +1,8 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 import { redirect } from 'next/navigation';
+
 export default function Home() {
   redirect('/dashboard');
 }

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import { readUserFromCookie } from '@/lib/auth';
 import NavLinks from './NavLinks';
-import { serverFetch } from '@/lib/serverFetch';
+import { serverFetch } from '@/lib/http/server-fetch';
 import { unstable_noStore as noStore } from 'next/cache';
 
 export default async function Header() {

--- a/web/src/lib/http/server-fetch.ts
+++ b/web/src/lib/http/server-fetch.ts
@@ -1,5 +1,5 @@
 import { headers } from 'next/headers';
-import { getBaseUrl } from './http/base-url';
+import { getBaseUrl } from './base-url';
 
 type ServerFetchInit = RequestInit & { next?: Record<string, unknown> };
 
@@ -11,8 +11,12 @@ export async function serverFetch(input: string, init: ServerFetchInit = {}) {
     : `${base}${input.startsWith('/') ? '' : '/'}${input}`;
 
   const h = new Headers(init.headers);
-  const cookie = headers().get('cookie') ?? '';
-  h.set('cookie', cookie);
+  const cookie = headers().get('cookie');
+  if (cookie) {
+    h.set('cookie', cookie);
+  } else {
+    h.delete('cookie');
+  }
 
   const next = { ...(init.next ?? {}), revalidate: 0 };
 

--- a/web/src/lib/server-api.ts
+++ b/web/src/lib/server-api.ts
@@ -2,7 +2,7 @@
 import { headers } from "next/headers";
 import { createApi } from "./api-core";
 import { getBaseUrl } from "@/lib/http/base-url";
-import { serverFetch } from "./serverFetch";
+import { serverFetch } from "@/lib/http/server-fetch";
 
 function getInit() {
   const cookie = headers().get("cookie");

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,14 +1,32 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
+const AUTH_COOKIE_NAME = process.env.NEXT_PUBLIC_AUTH_COOKIE_NAME ?? 'lab_session'
+const STATIC_EXT = /\.(?:css|js|json|ico|png|jpg|jpeg|gif|svg|webp|txt|xml|map|woff2?|ttf)$/i
+
+function isStaticAsset(pathname: string) {
+  return (
+    pathname.startsWith('/_next') ||
+    pathname.startsWith('/favicon') ||
+    pathname.startsWith('/public') ||
+    STATIC_EXT.test(pathname)
+  )
+}
+
 export function middleware(req: NextRequest) {
   const pathname = req.nextUrl.pathname
+  const hasSession = Boolean(req.cookies.get(AUTH_COOKIE_NAME)?.value)
+  const logPayload = {
+    path: pathname,
+    hasSession,
+    nextUrl: req.nextUrl.href,
+  }
+  console.info('[middleware] access', logPayload)
   const mockEnabled = process.env.USE_MOCK === 'true'
   if ((process.env.NODE_ENV === 'production' || !mockEnabled) && pathname.startsWith('/api/mock')) {
     return new NextResponse('Mock APIs are disabled', { status: 410 })
   }
 
-  const { search } = req.nextUrl
   const m = pathname.match(/^\/(groups|devices)\/([^\/]+)/)
   if (m) {
     const lower = m[2].toLowerCase()
@@ -19,20 +37,19 @@ export function middleware(req: NextRequest) {
     }
   }
 
-  if (
+  const isExcluded =
     pathname.startsWith('/login') ||
     pathname.startsWith('/api/auth') ||
-    pathname.startsWith('/_next') ||
-    pathname.startsWith('/favicon') ||
-    pathname.startsWith('/public')
-  ) {
+    pathname.startsWith('/api/health') ||
+    pathname.startsWith('/groups/join')
+
+  if (isExcluded || isStaticAsset(pathname)) {
     return NextResponse.next()
   }
 
-  const token = req.cookies.get('lab_session')?.value
-  if (!token) {
+  if (!hasSession) {
     const url = new URL('/login', req.url)
-    const next = pathname + (search || '')
+    const next = pathname + (req.nextUrl.search || '')
     url.searchParams.set('next', next || '/')
     return NextResponse.redirect(url)
   }
@@ -41,5 +58,5 @@ export function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/api/mock/:path*', '/((?!_next|favicon|public).*)'],
+  matcher: ['/((?!_next/static|_next/image|favicon).*)'],
 }


### PR DESCRIPTION
## Summary
- move the server-side fetch helper under `lib/http`, enforce absolute URLs/cookie forwarding, and update server components to use it
- replace the group creation client logic with a server action that creates and joins groups via `serverFetch` before redirecting
- tighten authentication middleware and API route logging while documenting host-specific cookie handling for preview vs production

## Testing
- pnpm -C web lint

------
https://chatgpt.com/codex/tasks/task_e_68cb8682974c8323bf36309bc27aa146