### PR TITLE
Fix auth middleware and server cookie handling

### DIFF
--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -1,21 +1,51 @@
-import { NextResponse, type NextRequest } from 'next/server'
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+const PUBLIC_PREFIXES = [
+  '/login',
+  '/api/health',
+  '/api/health/db',
+  '/_next',
+  '/favicon',
+  '/robots',
+  '/sitemap',
+  '/',
+];
+
+function isPublic(pathname: string) {
+  return PUBLIC_PREFIXES.some((prefix) => {
+    if (prefix === '/') {
+      return pathname === '/';
+    }
+    return pathname === prefix || pathname.startsWith(prefix);
+  });
+}
+
+export function middleware(req: NextRequest) {
+  const { pathname, search } = req.nextUrl;
+  if (isPublic(pathname)) {
+    return NextResponse.next();
+  }
+
+  const hasSession = !!req.cookies.get('lab_session')?.value;
+
+  const needAuth =
+    pathname.startsWith('/dashboard') ||
+    pathname.startsWith('/groups') ||
+    pathname.startsWith('/devices') ||
+    pathname.startsWith('/account');
+
+  if (!hasSession && needAuth) {
+    const url = req.nextUrl.clone();
+    url.pathname = '/login';
+    url.search = '';
+    url.searchParams.set('next', pathname + search);
+    return NextResponse.redirect(url);
+  }
+
+  return NextResponse.next();
+}
 
 export const config = {
-  matcher: [
-    '/dashboard',
-    '/groups/:path*',
-    '/devices/:path*',
-    '/account/:path*',
-    '/api/(me|groups|devices|reservations)(.*)',
-  ],
-}
-
-export default function middleware(req: NextRequest) {
-  const hasSession = !!req.cookies.get('lab_session')?.value
-  if (!hasSession) {
-    const url = new URL('/login', req.url)
-    url.searchParams.set('next', req.nextUrl.pathname + req.nextUrl.search)
-    return NextResponse.redirect(url)
-  }
-  return NextResponse.next()
-}
+  matcher: ['/((?!api/health).*)'],
+};

--- a/web/src/app/api/auth/login/route.ts
+++ b/web/src/app/api/auth/login/route.ts
@@ -20,8 +20,9 @@ export async function POST(req: Request) {
   // デモショートカット：demo/demo でもログイン可（任意）
   if (email === 'demo' && password === 'demo') {
     const token = await signToken({ id: 'u-demo', name: 'demo', email: 'demo@example.com' });
-    setSessionCookie(token);
-    return NextResponse.json({ ok: true });
+    const res = NextResponse.json({ ok: true });
+    setSessionCookie(res, token);
+    return res;
   }
 
   const user = email ? await findUserByEmail(String(email)) : null;
@@ -29,7 +30,8 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok:false, error:'invalid credentials' }, { status:401 });
   }
   const token = await signToken({ id: user.id, name: user.name || '', email: user.email });
-  setSessionCookie(token);
-  return NextResponse.json({ ok:true });
+  const res = NextResponse.json({ ok:true });
+  setSessionCookie(res, token);
+  return res;
 }
 

--- a/web/src/app/api/auth/logout/route.ts
+++ b/web/src/app/api/auth/logout/route.ts
@@ -16,8 +16,9 @@ function resolveLoginUrl(request: Request) {
 }
 
 async function doLogout(request: Request) {
-  clearSessionCookie();
-  return NextResponse.redirect(resolveLoginUrl(request));
+  const res = NextResponse.redirect(resolveLoginUrl(request));
+  clearSessionCookie(res);
+  return res;
 }
 
 export async function GET(request: Request)  { return doLogout(request); }

--- a/web/src/app/api/auth/register/route.ts
+++ b/web/src/app/api/auth/register/route.ts
@@ -35,6 +35,7 @@ export async function POST(req: Request) {
 
   // 自動ログイン
   const token = await signToken({ id: user.id, name: user.name || '', email: user.email });
-  setSessionCookie(token);
-  return NextResponse.json({ ok:true });
+  const res = NextResponse.json({ ok:true });
+  setSessionCookie(res, token);
+  return res;
 }

--- a/web/src/lib/auth/cookies.ts
+++ b/web/src/lib/auth/cookies.ts
@@ -1,24 +1,32 @@
-import { cookies } from 'next/headers'
+import type { NextResponse } from 'next/server';
 
-const COOKIE_NAME = 'lab_session'
-export const AUTH_COOKIE = COOKIE_NAME
+const COOKIE_NAME = 'lab_session';
+export const AUTH_COOKIE = COOKIE_NAME;
 
-export function setSessionCookie(token: string, maxAgeSec = 60 * 60 * 24 * 30) {
-  cookies().set(COOKIE_NAME, token, {
+export function setSessionCookie(
+  res: NextResponse,
+  token: string,
+  maxAgeSec = 60 * 60 * 24 * 30,
+) {
+  res.cookies.set({
+    name: COOKIE_NAME,
+    value: token,
     httpOnly: true,
     secure: true,
     sameSite: 'lax',
     path: '/',
     maxAge: maxAgeSec,
-  })
+  });
 }
 
-export function clearSessionCookie() {
-  cookies().set(COOKIE_NAME, '', {
+export function clearSessionCookie(res: NextResponse) {
+  res.cookies.set({
+    name: COOKIE_NAME,
+    value: '',
     httpOnly: true,
     secure: true,
     sameSite: 'lax',
     path: '/',
     maxAge: 0,
-  })
+  });
 }

--- a/web/src/lib/http/serverFetch.ts
+++ b/web/src/lib/http/serverFetch.ts
@@ -1,22 +1,39 @@
-import { headers } from 'next/headers'
+import { headers } from 'next/headers';
+
+function resolveTargetUrl(path: string, proto: string, host: string) {
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+  if (!path.startsWith('/')) {
+    return `${proto}://${host}/${path}`;
+  }
+  return `${proto}://${host}${path}`;
+}
 
 export async function serverFetch(path: string, init: RequestInit = {}) {
-  const incomingHeaders = headers()
-  const proto = incomingHeaders.get('x-forwarded-proto') ?? 'https'
+  const incomingHeaders = headers();
+  const proto = incomingHeaders.get('x-forwarded-proto') ?? 'https';
   const host =
     incomingHeaders.get('x-forwarded-host') ??
+    incomingHeaders.get('host') ??
     process.env.NEXT_PUBLIC_BASE_HOST ??
-    'labyoyaku.vercel.app'
-  const base = `${proto}://${host}`
-  const url = new URL(path, base).toString()
-  const cookie = incomingHeaders.get('cookie') ?? ''
+    'labyoyaku.vercel.app';
+  const target = resolveTargetUrl(path, proto, host);
+  const cookie = incomingHeaders.get('cookie') ?? '';
 
-  const headerBag = new Headers(init.headers)
-  headerBag.set('cookie', cookie)
+  const headerBag = new Headers(init.headers ?? undefined);
+  if (cookie) {
+    headerBag.set('cookie', cookie);
+  }
+  headerBag.set('accept', 'application/json');
 
-  return fetch(url, {
+  const nextInit = (init as any)?.next ?? {};
+
+  return fetch(target, {
     ...init,
     cache: 'no-store',
+    credentials: 'include',
     headers: headerBag,
-  })
+    next: { ...nextInit, revalidate: 0 },
+  });
 }


### PR DESCRIPTION
## Summary
- ensure the login and registration routes attach the `lab_session` cookie via `NextResponse`
- clear the session cookie on logout responses and tighten middleware public route handling
- forward cookies and disable caching for internal server-side fetches

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cb9333bb1083238827ea97b09cf5b9