### PR TITLE
Fix pnpm lockfile for bcryptjs dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   web:
     dependencies:
+      bcryptjs:
+        specifier: ^2.4.3
+        version: 2.4.3
       '@prisma/client':
         specifier: 5.22.0
         version: 5.22.0(prisma@5.22.0)
@@ -586,6 +589,9 @@ packages:
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
+
+  bcryptjs@2.4.3:
+    resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -2404,6 +2410,8 @@ snapshots:
   axe-core@4.10.3: {}
 
   axobject-query@4.1.0: {}
+
+  bcryptjs@2.4.3: {}
 
   balanced-match@1.0.2: {}
 

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "prisma:push": "prisma db push"
   },
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "@prisma/client": "5.22.0",
     "clsx": "^2.1.0",
     "jose": "^5.2.2",


### PR DESCRIPTION
## Summary
- reintroduce bcryptjs as a dependency of the web workspace
- restore the bcryptjs entry in pnpm-lock.yaml so frozen installations succeed again

## Testing
- not run (dependency install blocked in CI build step)


------
https://chatgpt.com/codex/tasks/task_e_68d6c0e887ec83238898b06130dddf92