### PR TITLE
Harden reservation cancellation with ownership checks

### DIFF
--- a/web/prisma/migrations/202409201200_reservation_owner_and_reminder/migration.sql
+++ b/web/prisma/migrations/202409201200_reservation_owner_and_reminder/migration.sql
@@ -1,0 +1,17 @@
+ALTER TABLE "Reservation"
+  ADD COLUMN "userId" TEXT,
+  ADD COLUMN "reminderMinutes" INTEGER;
+
+ALTER TABLE "Reservation"
+  ADD CONSTRAINT "Reservation_userId_fkey"
+  FOREIGN KEY ("userId")
+  REFERENCES "User"("id")
+  ON DELETE SET NULL
+  ON UPDATE CASCADE;
+
+UPDATE "Reservation" AS r
+SET "userId" = u."id"
+FROM "User" AS u
+WHERE r."userEmail" IS NOT NULL
+  AND u."email" IS NOT NULL
+  AND lower(r."userEmail") = lower(u."email");

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -84,12 +84,16 @@ model Reservation {
   id        String   @id @default(cuid())
   device    Device   @relation(fields: [deviceId], references: [id], onDelete: Cascade)
   deviceId  String
+  userId    String?
   userEmail String
   userName  String?
   start     DateTime
   end       DateTime
   purpose   String?
+  reminderMinutes Int?
   createdAt DateTime @default(now())
+
+  user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
 
   @@index([deviceId, start])
   @@index([start, end])

--- a/web/src/app/_parts/UpcomingReservations.tsx
+++ b/web/src/app/_parts/UpcomingReservations.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { updateReservation, deleteReservation } from '@/lib/api';
+import { toast } from '@/lib/toast';
 
 export type Item = {
   id: string;
@@ -170,6 +171,10 @@ function Modal({
         reminderMinutes: minutes,
       });
       onUpdated(res.data);
+      toast.success('リマインダー設定を保存しました');
+    } catch (error) {
+      console.error('update reservation reminder failed', error);
+      toast.error('リマインダー設定に失敗しました');
     } finally {
       setSaving(false);
     }
@@ -181,6 +186,10 @@ function Modal({
     try {
       await deleteReservation({ id: item.id, groupSlug: item.groupSlug });
       onDeleted(item.id);
+      toast.success('予約をキャンセルしました');
+    } catch (error) {
+      console.error('cancel reservation failed', error);
+      toast.error('予約のキャンセルに失敗しました');
     } finally {
       setSaving(false);
     }

--- a/web/src/app/api/groups/[slug]/devices/[device]/route.ts
+++ b/web/src/app/api/groups/[slug]/devices/[device]/route.ts
@@ -63,6 +63,8 @@ export async function GET(
         reservation.userName ||
         displayNameMap.get(reservation.userEmail) ||
         reservation.userEmail.split('@')[0],
+      reminderMinutes: reservation.reminderMinutes ?? null,
+      userId: reservation.userId,
     }))
 
     return NextResponse.json({

--- a/web/src/app/api/groups/[slug]/route.ts
+++ b/web/src/app/api/groups/[slug]/route.ts
@@ -35,6 +35,8 @@ async function buildGroupPayload(slug: string) {
       purpose: reservation.purpose ?? null,
       userEmail: reservation.userEmail,
       userName: reservation.userName ?? null,
+      reminderMinutes: reservation.reminderMinutes ?? null,
+      userId: reservation.userId,
     }))
   )
 
@@ -59,11 +61,13 @@ async function buildGroupPayload(slug: string) {
     start: reservation.start.toISOString(),
     end: reservation.end.toISOString(),
     purpose: reservation.purpose,
+    reminderMinutes: reservation.reminderMinutes,
     userEmail: reservation.userEmail,
     userName:
       reservation.userName ||
       displayNameMap.get(reservation.userEmail) ||
       reservation.userEmail.split('@')[0],
+    userId: reservation.userId,
   }))
 
   reservationsPayload.sort(

--- a/web/src/app/api/me/reservations/route.ts
+++ b/web/src/app/api/me/reservations/route.ts
@@ -74,8 +74,10 @@ export async function GET() {
       start: reservation.start.toISOString(),
       end: reservation.end.toISOString(),
       purpose: reservation.purpose ?? null,
+      reminderMinutes: reservation.reminderMinutes ?? null,
       userEmail: reservation.userEmail,
       userName,
+      userId: reservation.userId,
     }
   })
 

--- a/web/src/app/api/reservations/[id]/route.ts
+++ b/web/src/app/api/reservations/[id]/route.ts
@@ -1,0 +1,147 @@
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+export const runtime = 'nodejs'
+
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { readUserFromCookie } from '@/lib/auth'
+import { prisma } from '@/src/lib/prisma'
+
+const ParamsSchema = z.object({
+  id: z.string().min(1),
+})
+
+const UpdateSchema = z.object({
+  groupSlug: z.string().min(1).optional(),
+  reminderMinutes: z
+    .number()
+    .int()
+    .min(0)
+    .max(24 * 60)
+    .nullable()
+    .optional(),
+})
+
+async function loadReservation(id: string) {
+  return prisma.reservation.findUnique({
+    where: { id },
+    include: {
+      device: { include: { group: true } },
+      user: { select: { id: true } },
+    },
+  })
+}
+
+function isOwner(reservation: Awaited<ReturnType<typeof loadReservation>>, userId: string, email: string) {
+  if (!reservation) return false
+  if (reservation.userId) {
+    return reservation.userId === userId
+  }
+  return reservation.userEmail.toLowerCase() === email.toLowerCase()
+}
+
+function toPayload(reservation: NonNullable<Awaited<ReturnType<typeof loadReservation>>>) {
+  return {
+    id: reservation.id,
+    deviceId: reservation.deviceId,
+    deviceSlug: reservation.device.slug,
+    deviceName: reservation.device.name,
+    groupSlug: reservation.device.group.slug,
+    start: reservation.start.toISOString(),
+    end: reservation.end.toISOString(),
+    purpose: reservation.purpose ?? null,
+    reminderMinutes: reservation.reminderMinutes ?? null,
+    userEmail: reservation.userEmail,
+    userName: reservation.userName ?? null,
+    userId: reservation.user?.id ?? reservation.userId ?? null,
+  }
+}
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  const me = await readUserFromCookie()
+  if (!me?.email || !me?.id) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  const parsedParams = ParamsSchema.safeParse(params)
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: 'invalid reservation id' }, { status: 400 })
+  }
+
+  const bodyRaw = await req.json().catch(() => ({}))
+  const parsedBody = UpdateSchema.safeParse(bodyRaw)
+  if (!parsedBody.success) {
+    return NextResponse.json({ error: parsedBody.error.flatten() }, { status: 400 })
+  }
+
+  const { id } = parsedParams.data
+  const { groupSlug, reminderMinutes } = parsedBody.data
+  const normalizedGroupSlug = groupSlug?.toLowerCase()
+
+  const reservation = await loadReservation(id)
+  if (!reservation) {
+    return NextResponse.json({ error: 'reservation not found' }, { status: 404 })
+  }
+
+  if (normalizedGroupSlug && reservation.device.group.slug !== normalizedGroupSlug) {
+    return NextResponse.json({ error: 'reservation not found' }, { status: 404 })
+  }
+
+  if (!isOwner(reservation, me.id, me.email)) {
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+  }
+
+  const updates: { reminderMinutes?: number | null } = {}
+  if (reminderMinutes !== undefined) {
+    updates.reminderMinutes = reminderMinutes ?? null
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ ok: true, data: toPayload(reservation) })
+  }
+
+  const updated = await prisma.reservation.update({
+    where: { id },
+    data: updates,
+    include: {
+      device: { include: { group: true } },
+      user: { select: { id: true } },
+    },
+  })
+
+  return NextResponse.json({ ok: true, data: toPayload(updated) })
+}
+
+export async function DELETE(req: Request, { params }: { params: { id: string } }) {
+  const me = await readUserFromCookie()
+  if (!me?.email || !me?.id) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  const parsedParams = ParamsSchema.safeParse(params)
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: 'invalid reservation id' }, { status: 400 })
+  }
+
+  const bodyRaw = await req.json().catch(() => ({}))
+  const groupSlug = typeof bodyRaw?.groupSlug === 'string' ? bodyRaw.groupSlug.toLowerCase() : null
+
+  const { id } = parsedParams.data
+
+  const reservation = await loadReservation(id)
+  if (!reservation) {
+    return NextResponse.json({ error: 'reservation not found' }, { status: 404 })
+  }
+
+  if (groupSlug && reservation.device.group.slug !== groupSlug) {
+    return NextResponse.json({ error: 'reservation not found' }, { status: 404 })
+  }
+
+  if (!isOwner(reservation, me.id, me.email)) {
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+  }
+
+  await prisma.reservation.delete({ where: { id } })
+
+  return NextResponse.json({ ok: true })
+}

--- a/web/src/app/api/reservations/route.ts
+++ b/web/src/app/api/reservations/route.ts
@@ -133,6 +133,7 @@ export async function GET(req: Request) {
             group: { select: { slug: true } },
           },
         },
+        user: { select: { id: true } },
       },
       orderBy: { start: 'asc' },
     })
@@ -150,14 +151,17 @@ export async function GET(req: Request) {
       deviceId: reservation.deviceId,
       deviceSlug: reservation.device.slug,
       deviceName: reservation.device.name,
+      groupSlug: reservation.device.group.slug,
       start: reservation.start.toISOString(),
       end: reservation.end.toISOString(),
       purpose: reservation.purpose ?? null,
+      reminderMinutes: reservation.reminderMinutes ?? null,
       userEmail: reservation.userEmail,
       userName:
         reservation.userName ||
         displayNameMap.get(reservation.userEmail) ||
         reservation.userEmail.split('@')[0],
+      userId: reservation.user?.id ?? null,
     }))
 
     return NextResponse.json({ reservations: payload })
@@ -230,6 +234,7 @@ export async function POST(req: Request) {
     const created = await prisma.reservation.create({
       data: {
         deviceId: device.id,
+        userId: me.id,
         userEmail: me.email,
         userName: displayName,
         start: body.start,
@@ -245,6 +250,7 @@ export async function POST(req: Request) {
             group: { select: { slug: true } },
           },
         },
+        user: { select: { id: true } },
       },
     })
 
@@ -255,11 +261,14 @@ export async function POST(req: Request) {
           deviceId: created.deviceId,
           deviceSlug: created.device.slug,
           deviceName: created.device.name,
+          groupSlug: created.device.group.slug,
           start: created.start.toISOString(),
           end: created.end.toISOString(),
           purpose: created.purpose ?? null,
+          reminderMinutes: created.reminderMinutes ?? null,
           userEmail: created.userEmail,
           userName: created.userName,
+          userId: created.user?.id ?? null,
         },
       },
       { status: 201 }

--- a/web/src/lib/api-core.ts
+++ b/web/src/lib/api-core.ts
@@ -69,11 +69,23 @@ export function createApi(
         method: 'POST',
         body: JSON.stringify(body),
       }),
-    updateReservation: async (_body?: any): Promise<any> => {
-      throw new Error('updateReservation is not implemented');
+    updateReservation: (body: { id: string; groupSlug?: string; reminderMinutes?: number | null }) => {
+      if (!body?.id) throw new Error('reservation id is required');
+      const { id, ...rest } = body;
+      return api(`/api/reservations/${encodeURIComponent(id)}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(rest),
+      });
     },
-    deleteReservation: async (_body?: any): Promise<any> => {
-      throw new Error('deleteReservation is not implemented');
+    deleteReservation: (body: { id: string; groupSlug?: string }) => {
+      if (!body?.id) throw new Error('reservation id is required');
+      const { id, ...rest } = body;
+      return api(`/api/reservations/${encodeURIComponent(id)}`, {
+        method: 'DELETE',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(rest),
+      });
     },
     listMyReservations: () => api('/api/me/reservations'),
   };


### PR DESCRIPTION
## Summary
- add nullable userId and reminderMinutes columns to reservations and backfill existing rows
- expose PATCH/DELETE handlers for individual reservations that verify ownership and return reminder data
- wire client helpers and dashboard modal to use the new APIs with success/error toasts

## Testing
- pnpm --dir web lint

------
https://chatgpt.com/codex/tasks/task_e_68d6c7359f448323859b3c80840bd303