### PR TITLE
Ensure reservation payload includes group members

### DIFF
--- a/web/src/app/api/reservations/[id]/route.ts
+++ b/web/src/app/api/reservations/[id]/route.ts
@@ -25,7 +25,17 @@ async function loadReservation(id: string) {
   return prisma.reservation.findUnique({
     where: { id },
     include: {
-      device: { include: { group: { include: { members: true } } } },
+      device: {
+        include: {
+          group: {
+            include: {
+              members: {
+                select: { id: true, email: true, createdAt: true, groupId: true },
+              },
+            },
+          },
+        },
+      },
       user: { select: { id: true } },
     },
   })
@@ -122,7 +132,17 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
     where: { id },
     data: updates,
     include: {
-      device: { include: { group: true } },
+      device: {
+        include: {
+          group: {
+            include: {
+              members: {
+                select: { id: true, email: true, createdAt: true, groupId: true },
+              },
+            },
+          },
+        },
+      },
       user: { select: { id: true } },
     },
   })


### PR DESCRIPTION
## Summary
- include group members when loading reservations in the single-reservation API
- ensure PATCH responses include the same relation shape expected by toPayload

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6dacea04883238dd02c64720b9a64