### PR TITLE
Restrict personal reservations and add membership controls

### DIFF
--- a/web/src/app/_parts/UpcomingReservations.tsx
+++ b/web/src/app/_parts/UpcomingReservations.tsx
@@ -51,7 +51,7 @@ export default function UpcomingReservations({
     setLoading(true);
     setErr(null);
     try {
-      const r = await fetch('/api/me/reservations', {
+      const r = await fetch('/api/me/reservations?take=50', {
         cache: 'no-store',
         credentials: 'same-origin',
       });

--- a/web/src/app/account/profile/ProfileClient.tsx
+++ b/web/src/app/account/profile/ProfileClient.tsx
@@ -4,13 +4,13 @@ import { useState } from 'react';
 import { toast } from '@/lib/toast';
 
 export default function ProfileClient({
-  initialDisplayName,
+  initialName,
   email,
 }: {
-  initialDisplayName: string;
+  initialName: string;
   email: string;
 }) {
-  const [displayName, setDisplayName] = useState(initialDisplayName);
+  const [name, setName] = useState(initialName);
   const [saving, setSaving] = useState(false);
   const router = useRouter();
 
@@ -21,7 +21,7 @@ export default function ProfileClient({
       const res = await fetch('/api/me/profile', {
         method: 'PUT',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ displayName }),
+        body: JSON.stringify({ name }),
         credentials: 'same-origin',
       });
       if (!res.ok) throw new Error('failed');
@@ -47,8 +47,8 @@ export default function ProfileClient({
       <label className="block">
         <div className="mb-1">表示名</div>
         <input
-          value={displayName}
-          onChange={(e) => setDisplayName(e.target.value)}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
           className="input w-full"
         />
       </label>

--- a/web/src/app/account/profile/page.tsx
+++ b/web/src/app/account/profile/page.tsx
@@ -21,12 +21,13 @@ export default async function ProfilePage() {
     redirect('/login?next=/account/profile');
   }
   const json = await res.json();
+  const data = json?.data ?? null;
   return (
     <div className="max-w-md space-y-4">
       <h1 className="text-2xl font-bold">プロフィール</h1>
       <ProfileClient
-        initialDisplayName={json?.displayName ?? ''}
-        email={json?.email ?? ''}
+        initialName={data?.name ?? user.name ?? ''}
+        email={data?.email ?? user.email ?? ''}
       />
     </div>
   );

--- a/web/src/app/api/groups/[slug]/join/route.ts
+++ b/web/src/app/api/groups/[slug]/join/route.ts
@@ -1,0 +1,63 @@
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+export const runtime = 'nodejs'
+
+import { NextResponse } from 'next/server'
+import { prisma } from '@/src/lib/prisma'
+import { hashPassword, readUserFromCookie } from '@/lib/auth'
+
+function normalizeSlug(value: string | string[] | undefined) {
+  if (!value) return ''
+  const str = Array.isArray(value) ? value[0] : value
+  return String(str || '').trim().toLowerCase()
+}
+
+export async function POST(req: Request, { params }: { params: { slug: string } }) {
+  try {
+    const me = await readUserFromCookie()
+    console.info('[api.groups.join.POST]', {
+      hasUserId: Boolean(me?.id),
+      hasEmail: Boolean(me?.email),
+    })
+    if (!me?.email) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+    }
+
+    const slug = normalizeSlug(params?.slug)
+    if (!slug) {
+      return NextResponse.json({ error: 'invalid slug' }, { status: 400 })
+    }
+
+    let body: unknown = null
+    try {
+      body = await req.json()
+    } catch {
+      body = null
+    }
+    const passcodeRaw = body && typeof body === 'object' ? (body as any)?.passcode : undefined
+    const passcode = typeof passcodeRaw === 'string' ? passcodeRaw : undefined
+
+    const group = await prisma.group.findUnique({ where: { slug } })
+    if (!group) {
+      return NextResponse.json({ error: 'group not found' }, { status: 404 })
+    }
+
+    if (group.passcode) {
+      const hashed = hashPassword(passcode ?? '')
+      if (hashed !== group.passcode) {
+        return NextResponse.json({ error: 'invalid passcode' }, { status: 403 })
+      }
+    }
+
+    await prisma.groupMember.upsert({
+      where: { groupId_email: { groupId: group.id, email: me.email } },
+      update: {},
+      create: { groupId: group.id, email: me.email },
+    })
+
+    return NextResponse.json({ ok: true, data: { slug: group.slug, name: group.name ?? group.slug } })
+  } catch (error) {
+    console.error('join group failed', error)
+    return NextResponse.json({ error: 'join group failed' }, { status: 500 })
+  }
+}

--- a/web/src/app/api/groups/[slug]/leave/route.ts
+++ b/web/src/app/api/groups/[slug]/leave/route.ts
@@ -1,0 +1,56 @@
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+export const runtime = 'nodejs'
+
+import { NextResponse } from 'next/server'
+import { prisma } from '@/src/lib/prisma'
+import { readUserFromCookie } from '@/lib/auth'
+
+function normalizeSlug(value: string | string[] | undefined) {
+  if (!value) return ''
+  const str = Array.isArray(value) ? value[0] : value
+  return String(str || '').trim().toLowerCase()
+}
+
+export async function POST(_req: Request, { params }: { params: { slug: string } }) {
+  try {
+    const me = await readUserFromCookie()
+    console.info('[api.groups.leave.POST]', {
+      hasUserId: Boolean(me?.id),
+      hasEmail: Boolean(me?.email),
+    })
+    if (!me?.email) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+    }
+
+    const slug = normalizeSlug(params?.slug)
+    if (!slug) {
+      return NextResponse.json({ error: 'invalid slug' }, { status: 400 })
+    }
+
+    const group = await prisma.group.findUnique({ where: { slug } })
+    if (!group) {
+      return NextResponse.json({ error: 'group not found' }, { status: 404 })
+    }
+
+    if (group.hostEmail === me.email) {
+      return NextResponse.json({ error: 'owner cannot leave' }, { status: 403 })
+    }
+
+    const membership = await prisma.groupMember.findUnique({
+      where: { groupId_email: { groupId: group.id, email: me.email } },
+    })
+    if (!membership) {
+      return NextResponse.json({ error: 'not a member' }, { status: 400 })
+    }
+
+    await prisma.groupMember.delete({
+      where: { groupId_email: { groupId: group.id, email: me.email } },
+    })
+
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    console.error('leave group failed', error)
+    return NextResponse.json({ error: 'leave group failed' }, { status: 500 })
+  }
+}

--- a/web/src/app/api/reservations/route.ts
+++ b/web/src/app/api/reservations/route.ts
@@ -49,6 +49,7 @@ export async function GET(req: Request) {
     }
 
     const url = new URL(req.url)
+    const mine = url.searchParams.get('mine') === '1'
     const parsed = QuerySchema.safeParse({
       groupSlug: url.searchParams.get('groupSlug') ?? '',
       deviceSlug: url.searchParams.get('deviceSlug') ?? undefined,
@@ -119,6 +120,13 @@ export async function GET(req: Request) {
     }
     if (rangeEnd) {
       where.start = { lt: rangeEnd }
+    }
+    if (mine) {
+      const orConditions: Prisma.ReservationWhereInput[] = [{ userEmail: me.email }]
+      if (me.id) {
+        orConditions.push({ userId: me.id })
+      }
+      where.OR = orConditions
     }
 
     const reservations = await prisma.reservation.findMany({

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -30,7 +30,7 @@ export default async function DashboardPage() {
   let spans: Span[] = [];
   let myGroups: { slug: string; name: string }[] = [];
 
-  const res = await serverFetch('/api/me/reservations');
+  const res = await serverFetch('/api/me/reservations?take=50');
   if (res.status === 401) redirect('/login?next=/dashboard');
   if (!res.ok) redirect('/login?next=/dashboard');
 

--- a/web/src/app/groups/[slug]/GroupScreenClient.tsx
+++ b/web/src/app/groups/[slug]/GroupScreenClient.tsx
@@ -2,15 +2,18 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
+import LeaveButton from './LeaveButton';
 
 export default function GroupScreenClient({
   initialGroup,
   initialDevices,
   defaultReserver,
+  canLeave,
 }: {
   initialGroup: any;
   initialDevices: any[];
   defaultReserver?: string;
+  canLeave: boolean;
 }) {
   const group = initialGroup;
   const [devices, setDevices] = useState<any[]>(initialDevices);
@@ -60,7 +63,7 @@ export default function GroupScreenClient({
     <div className="space-y-8">
       <header className="space-y-2">
         <a href="/" className="text-sm text-indigo-600 hover:underline">&larr; ホームへ戻る</a>
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between flex-wrap gap-3">
           <h1 className="text-3xl font-bold">{group.name}</h1>
           <div className="flex gap-2 flex-wrap justify-end">
             <Link
@@ -81,6 +84,9 @@ export default function GroupScreenClient({
               >
                 設定を変更
               </a>
+            )}
+            {!isHost && canLeave && (
+              <LeaveButton slug={group.slug} />
             )}
           </div>
         </div>

--- a/web/src/app/groups/[slug]/LeaveButton.tsx
+++ b/web/src/app/groups/[slug]/LeaveButton.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+export default function LeaveButton({ slug }: { slug: string }) {
+  const router = useRouter();
+  const [leaving, setLeaving] = useState(false);
+
+  async function leave() {
+    if (leaving) return;
+    if (!confirm("このグループを退出しますか？")) return;
+    setLeaving(true);
+    try {
+      const res = await fetch(`/api/groups/${encodeURIComponent(slug)}/leave`, {
+        method: 'POST',
+        credentials: 'same-origin',
+        cache: 'no-store',
+      });
+      if (!res.ok) {
+        const { error } = await res.json().catch(() => ({ error: '退出に失敗しました' }));
+        alert(error || '退出に失敗しました');
+        return;
+      }
+      router.push('/groups');
+      router.refresh();
+    } catch (error: any) {
+      alert(error?.message || '退出に失敗しました');
+    } finally {
+      setLeaving(false);
+    }
+  }
+
+  return (
+    <button
+      onClick={leave}
+      disabled={leaving}
+      className="btn btn-danger"
+    >
+      {leaving ? '退出中…' : 'グループを退出'}
+    </button>
+  );
+}

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -96,6 +96,8 @@ export default async function GroupPage({
     redirect(`/groups/join?slug=${encodeURIComponent(paramSlug)}`);
   }
 
+  const canLeave = isMember && groupRecord.hostEmail !== user.email;
+
   const res = await serverFetch(`/api/groups/${encodeURIComponent(paramSlug)}`);
   if (res.status === 401) redirect(`/login?next=/groups/${encodeURIComponent(paramSlug)}`);
   if (res.status === 403 || res.status === 404) {
@@ -197,6 +199,7 @@ export default async function GroupPage({
           initialGroup={group}
           initialDevices={devices}
           defaultReserver={me?.email}
+          canLeave={canLeave}
         />
       </div>
       <div className="rounded-2xl border p-4 md:p-6 bg-white space-y-4 overflow-visible">

--- a/web/src/app/groups/new/actions.ts
+++ b/web/src/app/groups/new/actions.ts
@@ -71,9 +71,9 @@ export async function createGroupAction(
     return { error: 'グループの作成に失敗しました' }
   }
 
-  const joinResponse = await serverFetch('/api/groups/join', {
+  const joinResponse = await serverFetch(`/api/groups/${encodeURIComponent(slug)}/join`, {
     method: 'POST',
-    body: JSON.stringify({ slug, query: slug, password }),
+    body: JSON.stringify({ passcode: password || undefined }),
     headers: { 'content-type': 'application/json' },
   })
 

--- a/web/src/app/profile/page.tsx
+++ b/web/src/app/profile/page.tsx
@@ -1,0 +1,2 @@
+export { default } from '../account/profile/page';
+export { dynamic, revalidate, runtime, fetchCache } from '../account/profile/page';

--- a/web/src/lib/api-core.ts
+++ b/web/src/lib/api-core.ts
@@ -36,10 +36,10 @@ export function createApi(
     createGroup: (body: any) =>
       api('/api/groups', { method: 'POST', body: JSON.stringify(body) }),
     getGroup: (slug: string) => api(`/api/groups/${slug}`),
-    joinGroup: (payload: any) =>
-      api('/api/groups/join', {
+    joinGroup: (slug: string, passcode?: string) =>
+      api(`/api/groups/${encodeURIComponent(slug)}/join`, {
         method: 'POST',
-        body: JSON.stringify(payload),
+        body: JSON.stringify({ passcode }),
       }),
     listDevices: (slug: string) =>
       api(`/api/groups/${encodeURIComponent(slug)}/devices`),

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -40,3 +40,15 @@ export async function saveUser(user: UserRecord): Promise<void> {
     dbData.users.push(user);
   }
 }
+
+export async function updateUserNameByEmail(email: string, name: string): Promise<void> {
+  if (db) {
+    db.prepare('UPDATE users SET name = ? WHERE LOWER(email) = LOWER(?)').run(name, email);
+    return;
+  }
+  const dbData = loadDB();
+  const record = dbData.users.find((user) => user.email.toLowerCase() === email.toLowerCase());
+  if (record) {
+    record.name = name;
+  }
+}


### PR DESCRIPTION
## Summary
- ensure `/api/me/reservations` filters by the signed-in member and request a larger slice for dashboard views
- switch the profile API and UI to update the primary user name and expose the page at `/profile`
- add RESTful group join/leave endpoints with a leave button and allow filtering group reservations via `mine=1`

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d6de41ed54832385e9342b1e1e8a71