### PR TITLE
Add profile access menu and day-specific reservation flow

### DIFF
--- a/web/src/app/groups/[slug]/CalendarReservationSection.tsx
+++ b/web/src/app/groups/[slug]/CalendarReservationSection.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import CalendarWithBars, { Span } from '@/components/CalendarWithBars';
 import ReservationList, { ReservationItem } from '@/components/ReservationList';
 
@@ -9,28 +9,21 @@ export default function CalendarReservationSection({
   spans,
   listItems,
   groupSlug,
-  devices,
-  defaultReserver,
 }: {
   weeks: Date[][];
   month: number;
   spans: Span[];
   listItems: ReservationItem[];
   groupSlug: string;
-  devices: any[];
-  defaultReserver?: string;
 }) {
-  const [selected, setSelected] = useState<Date | null>(null);
-  const handleSelect = (d: Date) => {
-    setSelected(d);
-  };
+  const router = useRouter();
   const pad = (n: number) => n.toString().padStart(2, '0');
-  const items = useMemo(() => {
-    if (!selected) return listItems;
-    return listItems.filter(
-      (i) => i.start.toDateString() === selected.toDateString()
-    );
-  }, [selected, listItems]);
+  const handleSelect = (date: Date) => {
+    const yyyy = date.getFullYear();
+    const mm = pad(date.getMonth() + 1);
+    const dd = pad(date.getDate());
+    router.push(`/groups/${encodeURIComponent(groupSlug.toLowerCase())}/day/${yyyy}-${mm}-${dd}`);
+  };
   return (
     <>
       <CalendarWithBars
@@ -41,11 +34,9 @@ export default function CalendarReservationSection({
         showModal={false}
       />
       <div className="mt-4">
-        <h2 className="text-xl font-semibold mb-2">
-          予約一覧{selected && ` (${selected.getMonth() + 1}/${selected.getDate()})`}
-        </h2>
-        <ReservationList items={items} />
+        <h2 className="text-xl font-semibold mb-2">予約一覧</h2>
+        <ReservationList items={listItems} />
       </div>
-      </>
-    );
-  }
+    </>
+  );
+}

--- a/web/src/app/groups/[slug]/GroupScreenClient.tsx
+++ b/web/src/app/groups/[slug]/GroupScreenClient.tsx
@@ -2,7 +2,9 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import LeaveButton from './LeaveButton';
+import { DeviceCard } from './_components/DeviceCard';
 
 export default function GroupScreenClient({
   initialGroup,
@@ -15,6 +17,7 @@ export default function GroupScreenClient({
   defaultReserver?: string;
   canLeave: boolean;
 }) {
+  const router = useRouter();
   const group = initialGroup;
   const [devices, setDevices] = useState<any[]>(initialDevices);
   const [removingSlug, setRemovingSlug] = useState<string | null>(null);
@@ -40,7 +43,7 @@ export default function GroupScreenClient({
   }
 
   async function handleDeleteDevice(device: { id: string; slug: string }) {
-    if (!confirm('この機器を削除しますか？')) return;
+    if (removingSlug) return;
     setRemovingSlug(device.slug);
     try {
       const r = await fetch(
@@ -119,44 +122,29 @@ export default function GroupScreenClient({
         </div>
         <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {devices.map((d) => (
-            <li
-              key={d.id}
-              className="border rounded-md p-4 shadow-card flex flex-col justify-between"
-            >
-              <div>
-                <a
-                  href={`/groups/${encodeURIComponent(group.slug.toLowerCase())}/devices/${d.slug}`}
-                  className="font-medium hover:underline"
-                >
-                  {d.name}
-                </a>
-                <div className="text-xs text-neutral-500">ID: {d.id}</div>
-              </div>
-              <div className="mt-3 flex gap-2">
-                <Link
-                  href={`/groups/${encodeURIComponent(group.slug)}/reservations/new?device=${encodeURIComponent(
+            <li key={d.id} className="shadow-card">
+              <DeviceCard
+                device={{
+                  id: d.id,
+                  name: d.name,
+                  slug: d.slug,
+                  href: `/groups/${encodeURIComponent(group.slug.toLowerCase())}/devices/${d.slug}`,
+                }}
+                onReserve={() => {
+                  const target = `/groups/${encodeURIComponent(group.slug)}/reservations/new?device=${encodeURIComponent(
                     d.slug
-                  )}`}
-                  className="btn btn-secondary flex-1"
-                >
-                  予約
-                </Link>
-                <a
-                  href={`/api/devices/${d.slug}/qr`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="btn btn-secondary flex-1"
-                >
-                  QRコード
-                </a>
-                <button
-                  onClick={() => handleDeleteDevice(d)}
-                  className="btn btn-danger flex-1"
-                  disabled={removingSlug === d.slug}
-                >
-                  削除
-                </button>
-              </div>
+                  )}`;
+                  router.push(target);
+                }}
+                onShowQR={() => {
+                  window.open(
+                    `/api/devices/${encodeURIComponent(d.slug)}/qr`,
+                    '_blank',
+                    'noopener,noreferrer'
+                  );
+                }}
+                onDelete={() => handleDeleteDevice(d)}
+              />
             </li>
           ))}
         </ul>

--- a/web/src/app/groups/[slug]/_components/DeviceCard.tsx
+++ b/web/src/app/groups/[slug]/_components/DeviceCard.tsx
@@ -1,0 +1,101 @@
+"use client";
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+
+type DeviceInfo = {
+  id: string;
+  name: string;
+  slug?: string;
+  href?: string;
+};
+
+type Props = {
+  device: DeviceInfo;
+  onReserve: () => void;
+  onDelete: () => void;
+  onShowQR: () => void;
+};
+
+export function DeviceCard({ device, onReserve, onDelete, onShowQR }: Props) {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handlePointer = (event: MouseEvent) => {
+      if (!menuRef.current) return;
+      if (!menuRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handlePointer);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handlePointer);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
+
+  return (
+    <div className="rounded-xl border p-4 flex items-center justify-between">
+      <div>
+        {device.href ? (
+          <Link href={device.href} className="font-semibold hover:underline">
+            {device.name}
+          </Link>
+        ) : (
+          <div className="font-semibold">{device.name}</div>
+        )}
+        <div className="text-xs text-gray-500">ID: {device.id}</div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          onClick={onReserve}
+          className="px-3 py-2 rounded bg-blue-600 text-white"
+        >
+          予約
+        </button>
+
+        <div className="relative" ref={menuRef}>
+          <button
+            onClick={() => setOpen((value) => !value)}
+            className="w-9 h-9 rounded-full border flex items-center justify-center"
+            aria-label="メニュー"
+            aria-haspopup="menu"
+            aria-expanded={open}
+          >
+            ︙
+          </button>
+          {open && (
+            <div className="absolute right-0 mt-2 w-40 rounded-xl bg-white shadow ring-1 ring-black/10 overflow-hidden z-10">
+              <button
+                onClick={() => {
+                  setOpen(false);
+                  onShowQR();
+                }}
+                className="w-full text-left px-3 py-2 hover:bg-gray-50"
+              >
+                QRコード
+              </button>
+              <button
+                onClick={() => {
+                  setOpen(false);
+                  if (window.confirm("この機器を削除しますか？")) onDelete();
+                }}
+                className="w-full text-left px-3 py-2 hover:bg-red-50 text-red-600"
+              >
+                削除
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/groups/[slug]/day/[date]/page.tsx
+++ b/web/src/app/groups/[slug]/day/[date]/page.tsx
@@ -1,0 +1,112 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const runtime = 'nodejs';
+export const fetchCache = 'force-no-store';
+
+import Link from 'next/link';
+import { notFound, redirect } from 'next/navigation';
+import { unstable_noStore as noStore } from 'next/cache';
+import { serverFetch } from '@/lib/http/serverFetch';
+
+type Reservation = {
+  id: string;
+  startsAt: string;
+  endsAt: string;
+  device: { name: string };
+};
+
+function isValidDateFormat(value: string) {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+function toRange(date: string) {
+  const from = new Date(`${date}T00:00:00Z`).toISOString();
+  const to = new Date(`${date}T23:59:59Z`).toISOString();
+  return { from, to };
+}
+
+function formatTime(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+export default async function DayPage({
+  params,
+}: {
+  params: { slug: string; date: string };
+}) {
+  noStore();
+  const { slug, date } = params;
+  const normalizedSlug = slug.toLowerCase();
+  if (!isValidDateFormat(date)) {
+    notFound();
+  }
+
+  const { from, to } = toRange(date);
+  const searchParams = new URLSearchParams({
+    groupSlug: normalizedSlug,
+    from,
+    to,
+  });
+
+  const res = await serverFetch(`/api/reservations?${searchParams.toString()}`);
+  if (res.status === 401) {
+    redirect(`/login?next=/groups/${encodeURIComponent(normalizedSlug)}/day/${date}`);
+  }
+  if (res.status === 403 || res.status === 404) {
+    redirect(`/groups/join?slug=${encodeURIComponent(normalizedSlug)}`);
+  }
+  if (!res.ok) {
+    throw new Error('予約情報の取得に失敗しました');
+  }
+
+  const payload = await res.json();
+  const source = payload?.data ?? payload?.reservations ?? [];
+  const listRaw = Array.isArray(source) ? (source as Reservation[]) : [];
+  const list = listRaw
+    .map((item) => ({
+      ...item,
+      startsAt: item.startsAt ?? (item as any).start ?? '',
+      endsAt: item.endsAt ?? (item as any).end ?? '',
+    }))
+    .filter((item) => item.startsAt && item.endsAt && item.device?.name)
+    .sort((a, b) => new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime());
+
+  return (
+    <div className="mx-auto max-w-5xl p-6 space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <Link
+            href={`/groups/${encodeURIComponent(normalizedSlug)}`}
+            className="text-sm text-indigo-600 hover:underline"
+          >
+            &larr; グループへ戻る
+          </Link>
+          <h1 className="text-xl font-bold mt-1">{date} の予約</h1>
+        </div>
+        <Link
+          href={`/groups/${encodeURIComponent(normalizedSlug)}/reservations/new?date=${date}`}
+          className="px-4 py-2 rounded bg-blue-600 text-white"
+        >
+          予約を追加
+        </Link>
+      </div>
+
+      {list.length === 0 ? (
+        <p className="text-gray-500">予約がありません。</p>
+      ) : (
+        <ul className="space-y-2">
+          {list.map((r) => (
+            <li key={r.id} className="rounded-lg border p-3">
+              <div className="font-medium">{r.device.name}</div>
+              <div className="text-sm text-gray-600">
+                {formatTime(r.startsAt)} 〜 {formatTime(r.endsAt)}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -239,8 +239,6 @@ export default async function GroupPage({
           spans={spans}
           listItems={listItems}
           groupSlug={group.slug}
-          devices={devices}
-          defaultReserver={me?.email}
         />
         <Image
           src={qrUrl}

--- a/web/src/app/profile/page.tsx
+++ b/web/src/app/profile/page.tsx
@@ -1,2 +1,219 @@
-export { default } from '../account/profile/page';
-export { dynamic, revalidate, runtime, fetchCache } from '../account/profile/page';
+"use client";
+import { useEffect, useState } from "react";
+
+type Group = {
+  id: string;
+  name: string;
+  slug: string;
+  role?: "OWNER" | "ADMIN" | "MEMBER";
+};
+
+type ProfileResponse = {
+  data?: { name?: string | null } | null;
+};
+
+type GroupsResponse =
+  | { data?: Group[] | null }
+  | { groups?: Group[] | null }
+  | Group[]
+  | null;
+
+function extractGroups(payload: GroupsResponse): Group[] {
+  if (!payload) return [];
+  if (Array.isArray(payload)) return payload;
+  if (Array.isArray(payload.data)) return payload.data;
+  if (Array.isArray(payload.groups)) return payload.groups;
+  return [];
+}
+
+export default function ProfilePage() {
+  const [name, setName] = useState("");
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [slug, setSlug] = useState("");
+  const [passcode, setPasscode] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const profileRes = await fetch("/api/me/profile", { cache: "no-store" });
+        if (profileRes.status === 401) {
+          window.location.href = "/login?next=/profile";
+          return;
+        }
+        if (profileRes.ok) {
+          const me = (await profileRes.json()) as ProfileResponse;
+          if (!cancelled) {
+            setName(me?.data?.name ?? "");
+          }
+        }
+      } catch {
+        /* noop */
+      }
+      try {
+        const groupsRes = await fetch("/api/groups?mine=1", { cache: "no-store" });
+        if (groupsRes.status === 401) {
+          window.location.href = "/login?next=/profile";
+          return;
+        }
+        if (groupsRes.ok) {
+          const payload = (await groupsRes.json()) as GroupsResponse;
+          if (!cancelled) {
+            setGroups(extractGroups(payload));
+          }
+        }
+      } catch {
+        /* noop */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function saveName() {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/me/profile", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      });
+      if (!res.ok) {
+        alert("保存に失敗しました");
+      }
+    } catch {
+      alert("保存に失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function join() {
+    if (!slug) return;
+    try {
+      const res = await fetch(`/api/groups/${encodeURIComponent(slug)}/join`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ passcode: passcode || undefined }),
+      });
+      if (!res.ok) {
+        const { error } = (await res.json().catch(() => ({}))) as { error?: string };
+        alert(`参加失敗: ${error ?? res.statusText}`);
+        return;
+      }
+      window.location.reload();
+    } catch {
+      alert("参加失敗: 通信エラー");
+    }
+  }
+
+  async function leave(s: string, role?: string) {
+    if (role === "OWNER") {
+      alert("オーナーは移譲しないと退出できません");
+      return;
+    }
+    if (!window.confirm("このグループを退出しますか？")) return;
+    try {
+      const res = await fetch(`/api/groups/${encodeURIComponent(s)}/leave`, {
+        method: "POST",
+      });
+      if (!res.ok) {
+        const { error } = (await res.json().catch(() => ({}))) as { error?: string };
+        alert(`退出失敗: ${error ?? res.statusText}`);
+        return;
+      }
+      window.location.reload();
+    } catch {
+      alert("退出失敗: 通信エラー");
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl p-6 space-y-8">
+      <h1 className="text-2xl font-bold">プロフィール</h1>
+
+      <section className="space-y-3">
+        <h2 className="font-semibold">表示名</h2>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <input
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            className="flex-1 border rounded p-2"
+          />
+          <button
+            onClick={saveName}
+            disabled={loading}
+            className="px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-50"
+          >
+            {loading ? "保存中..." : "保存"}
+          </button>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="font-semibold">所属グループ</h2>
+        <ul className="space-y-2">
+          {groups.map((g) => (
+            <li
+              key={g.id}
+              className="flex flex-col gap-3 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div>
+                <div className="font-medium">{g.name}</div>
+                <div className="text-sm text-gray-500">
+                  slug: {g.slug}
+                  {g.role ? ` / role: ${g.role}` : ""}
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <a
+                  href={`/groups/${encodeURIComponent(g.slug)}`}
+                  className="px-3 py-1 rounded border"
+                >
+                  開く
+                </a>
+                <button
+                  onClick={() => leave(g.slug, g.role)}
+                  className="px-3 py-1 rounded bg-red-600 text-white"
+                >
+                  退出
+                </button>
+              </div>
+            </li>
+          ))}
+          {groups.length === 0 && (
+            <li className="rounded-lg border border-dashed p-3 text-sm text-gray-500">
+              参加中のグループはありません。
+            </li>
+          )}
+        </ul>
+
+        <div className="mt-4 space-y-2 rounded-lg border p-3">
+          <div className="font-semibold">グループに参加</div>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <input
+              placeholder="group slug"
+              value={slug}
+              onChange={(event) => setSlug(event.target.value)}
+              className="flex-1 border rounded p-2"
+            />
+            <input
+              placeholder="passcode (必要な場合)"
+              value={passcode}
+              onChange={(event) => setPasscode(event.target.value)}
+              className="flex-1 border rounded p-2"
+            />
+            <button
+              onClick={join}
+              className="px-4 py-2 rounded bg-emerald-600 text-white"
+            >
+              参加
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web/src/components/CalendarWithBars.tsx
+++ b/web/src/components/CalendarWithBars.tsx
@@ -70,9 +70,12 @@ export default function CalendarWithBars({
                 isToday && 'border-2 border-indigo-600'
               )}
               onClick={() => {
-                setSel(d);
+                if (showModal) {
+                  setSel(d);
+                }
                 onSelectDate?.(d);
               }}
+              aria-label={`${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`}
             >
               <div className="absolute left-1 top-1 text-xs">{d.getDate()}</div>
               {todays.length > 0 && (

--- a/web/src/components/NavLinks.tsx
+++ b/web/src/components/NavLinks.tsx
@@ -1,9 +1,12 @@
 'use client';
 import { usePathname } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 
 export default function NavLinks({ me, displayName }: { me: any; displayName?: string | null }) {
   const pathname = usePathname();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
   const linkClass = (href: string) =>
     clsx(
       'rounded-md px-3 py-1 hover:bg-white/20',
@@ -15,6 +18,31 @@ export default function NavLinks({ me, displayName }: { me: any; displayName?: s
         ? 'underline underline-offset-8'
         : undefined
     );
+  const userLabel =
+    displayName || me?.name || (me?.email ? me.email.split('@')[0] : null);
+  const userInitial = userLabel?.charAt(0)?.toUpperCase() ?? '👤';
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handlePointer = (event: MouseEvent) => {
+      if (!menuRef.current) return;
+      if (!menuRef.current.contains(event.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handlePointer);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handlePointer);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [menuOpen]);
+
   return (
     <nav className="flex items-center gap-4 text-sm">
       <a className={linkClass('/usage')} href="/usage">使い方</a>
@@ -24,12 +52,48 @@ export default function NavLinks({ me, displayName }: { me: any; displayName?: s
           <a className={linkClass('/groups/new')} href="/groups/new">グループをつくる</a>
           <a className={linkClass('/dashboard')} href="/dashboard">ホーム</a>
           <a className={linkClass('/groups')} href="/groups">グループ</a>
-          <span className="hidden sm:inline text-white/80">
-            {displayName || me.name || me.email.split('@')[0]}
-          </span>
-          <form action="/api/auth/logout" method="post">
-            <button className="rounded-md bg-white/10 px-3 py-1 hover:bg-white/20">ログアウト</button>
-          </form>
+          <div className="relative" ref={menuRef}>
+            <button
+              type="button"
+              onClick={() => setMenuOpen((open) => !open)}
+              className="w-9 h-9 rounded-full bg-white/20 hover:bg-white/30 flex items-center justify-center text-sm font-semibold"
+              aria-haspopup="menu"
+              aria-expanded={menuOpen}
+              aria-label="ユーザーメニュー"
+            >
+              {userInitial}
+            </button>
+            {menuOpen && (
+              <div className="absolute right-0 mt-2 w-48 rounded-xl bg-white text-gray-900 shadow-lg ring-1 ring-black/10 z-10">
+                <div className="px-4 py-2 text-sm text-gray-500 border-b border-gray-100">
+                  {userLabel}
+                </div>
+                <a
+                  href="/profile"
+                  className="block px-4 py-2 hover:bg-gray-50"
+                  onClick={() => setMenuOpen(false)}
+                >
+                  プロフィール
+                </a>
+                <a
+                  href="/groups"
+                  className="block px-4 py-2 hover:bg-gray-50"
+                  onClick={() => setMenuOpen(false)}
+                >
+                  所属グループ
+                </a>
+                <form action="/api/auth/logout" method="post">
+                  <button
+                    type="submit"
+                    className="w-full text-left px-4 py-2 hover:bg-gray-50"
+                    onClick={() => setMenuOpen(false)}
+                  >
+                    ログアウト
+                  </button>
+                </form>
+              </div>
+            )}
+          </div>
         </>
       ) : (
         <>


### PR DESCRIPTION
## Summary
- add a dropdown user menu in the header with quick links to the profile page and group list
- replace the profile route with an interactive page that edits the display name and lets members join or leave groups
- move device actions into a kebab menu, wire calendar day clicks to a new day view, and prefill the reservation form when a date is supplied

## Testing
- pnpm --filter lab_yoyaku-web lint

------
https://chatgpt.com/codex/tasks/task_e_68d760780dd8832383ff7d41f42f7a60