### PR TITLE
Add duty scheduling schema and APIs

### DIFF
--- a/web/prisma/migrations/202509280000_add_duty_models/migration.sql
+++ b/web/prisma/migrations/202509280000_add_duty_models/migration.sql
@@ -1,0 +1,59 @@
+CREATE TYPE "DutyVisibility" AS ENUM ('PUBLIC', 'MEMBERS_ONLY');
+CREATE TYPE "DutyManagePolicy" AS ENUM ('ADMINS_ONLY', 'MEMBERS_ALLOWED');
+
+ALTER TABLE "Group" ADD COLUMN "dutyManagePolicy" "DutyManagePolicy" NOT NULL DEFAULT 'ADMINS_ONLY';
+
+CREATE TABLE "DutyType" (
+  "id" TEXT NOT NULL,
+  "groupId" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "color" TEXT NOT NULL DEFAULT '#7c3aed',
+  "visibility" "DutyVisibility" NOT NULL DEFAULT 'PUBLIC',
+  CONSTRAINT "DutyType_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "DutyType_groupId_name_key" ON "DutyType"("groupId", "name");
+
+CREATE TABLE "DutyRule" (
+  "id" TEXT NOT NULL,
+  "typeId" TEXT NOT NULL,
+  "startDate" TIMESTAMP(3) NOT NULL,
+  "endDate" TIMESTAMP(3) NOT NULL,
+  "byWeekday" INTEGER[] NOT NULL,
+  "slotsPerDay" INTEGER NOT NULL DEFAULT 1,
+  "includeMemberIds" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  "excludeMemberIds" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  "avoidConsecutive" BOOLEAN NOT NULL DEFAULT true,
+  CONSTRAINT "DutyRule_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "DutyAssignment" (
+  "id" TEXT NOT NULL,
+  "typeId" TEXT NOT NULL,
+  "groupId" TEXT NOT NULL,
+  "date" TIMESTAMP(3) NOT NULL,
+  "slotIndex" INTEGER NOT NULL,
+  "assigneeId" TEXT,
+  "locked" BOOLEAN NOT NULL DEFAULT false,
+  "done" BOOLEAN NOT NULL DEFAULT false,
+  CONSTRAINT "DutyAssignment_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "DutyAssignment_groupId_typeId_date_slotIndex_key"
+  ON "DutyAssignment"("groupId", "typeId", "date", "slotIndex");
+
+ALTER TABLE "DutyType"
+  ADD CONSTRAINT "DutyType_groupId_fkey"
+  FOREIGN KEY ("groupId") REFERENCES "Group"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "DutyRule"
+  ADD CONSTRAINT "DutyRule_typeId_fkey"
+  FOREIGN KEY ("typeId") REFERENCES "DutyType"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "DutyAssignment"
+  ADD CONSTRAINT "DutyAssignment_typeId_fkey"
+  FOREIGN KEY ("typeId") REFERENCES "DutyType"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT "DutyAssignment_groupId_fkey"
+  FOREIGN KEY ("groupId") REFERENCES "Group"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT "DutyAssignment_assigneeId_fkey"
+  FOREIGN KEY ("assigneeId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -16,10 +16,21 @@ model User {
   accounts      Account[]
   sessions      Session[]
   reservations  Reservation[]
+  dutyAssignments DutyAssignment[]
 }
 
 enum DeviceManagePolicy {
   HOST_ONLY
+  MEMBERS_ALLOWED
+}
+
+enum DutyVisibility {
+  PUBLIC
+  MEMBERS_ONLY
+}
+
+enum DutyManagePolicy {
+  ADMINS_ONLY
   MEMBERS_ALLOWED
 }
 
@@ -67,8 +78,11 @@ model Group {
   reserveTo   DateTime?
   memo        String?
   deviceManagePolicy DeviceManagePolicy @default(HOST_ONLY)
+  dutyManagePolicy  DutyManagePolicy  @default(ADMINS_ONLY)
   devices     Device[]
   members     GroupMember[]
+  dutyTypes   DutyType[]
+  dutyAssignments DutyAssignment[]
   createdAt   DateTime      @default(now())
 }
 
@@ -121,4 +135,46 @@ model UserProfile {
   displayName String?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
+}
+
+model DutyType {
+  id           String            @id @default(cuid())
+  group        Group             @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  groupId      String
+  name         String
+  color        String            @default("#7c3aed")
+  visibility   DutyVisibility    @default(PUBLIC)
+  rules        DutyRule[]
+  assignments  DutyAssignment[]
+
+  @@unique([groupId, name])
+}
+
+model DutyRule {
+  id                String      @id @default(cuid())
+  type              DutyType    @relation(fields: [typeId], references: [id], onDelete: Cascade)
+  typeId            String
+  startDate         DateTime
+  endDate           DateTime
+  byWeekday         Int[]
+  slotsPerDay       Int         @default(1)
+  includeMemberIds  String[]    @default([])
+  excludeMemberIds  String[]    @default([])
+  avoidConsecutive  Boolean     @default(true)
+}
+
+model DutyAssignment {
+  id          String   @id @default(cuid())
+  type        DutyType @relation(fields: [typeId], references: [id], onDelete: Cascade)
+  typeId      String
+  group       Group    @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  groupId     String
+  date        DateTime
+  slotIndex   Int
+  assignee    User?    @relation(fields: [assigneeId], references: [id], onDelete: SetNull)
+  assigneeId  String?
+  locked      Boolean  @default(false)
+  done        Boolean  @default(false)
+
+  @@unique([groupId, typeId, date, slotIndex])
 }

--- a/web/src/app/api/duties/[id]/route.ts
+++ b/web/src/app/api/duties/[id]/route.ts
@@ -1,0 +1,101 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const runtime = 'nodejs';
+
+import { NextResponse } from 'next/server';
+import { prisma } from '@/src/lib/prisma';
+import { readUserFromCookie } from '@/lib/auth';
+import { canManageDuties } from '@/lib/duties/permissions';
+
+function parseBoolean(value: unknown) {
+  if (value === undefined) return undefined;
+  if (typeof value === 'boolean') return value;
+  const str = String(value).trim().toLowerCase();
+  if (str === 'true') return true;
+  if (str === 'false') return false;
+  return undefined;
+}
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  try {
+    const me = await readUserFromCookie();
+    if (!me?.email) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+
+    const assignment = await prisma.dutyAssignment.findUnique({
+      where: { id: params.id },
+      include: {
+        group: { include: { members: true } },
+        type: { select: { id: true, name: true, color: true, visibility: true } },
+      },
+    });
+    if (!assignment) {
+      return NextResponse.json({ error: 'duty assignment not found' }, { status: 404 });
+    }
+
+    if (!canManageDuties(assignment.group, me.email)) {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const updates: { assigneeId?: string | null; locked?: boolean; done?: boolean } = {};
+
+    if ((body as any)?.assigneeId !== undefined) {
+      const raw = (body as any).assigneeId;
+      const value = raw === null || raw === '' ? null : String(raw);
+      if (value) {
+        const memberEmails = Array.from(
+          new Set([assignment.group.hostEmail, ...assignment.group.members.map((member) => member.email)])
+        );
+        const members = memberEmails.length
+          ? await prisma.user.findMany({ where: { email: { in: memberEmails } }, select: { id: true } })
+          : [];
+        const allowed = new Set(members.map((member) => member.id));
+        if (!allowed.has(value)) {
+          return NextResponse.json({ error: 'assignee not member' }, { status: 400 });
+        }
+      }
+      updates.assigneeId = value;
+    }
+
+    const locked = parseBoolean((body as any)?.locked);
+    if (locked !== undefined) {
+      updates.locked = locked;
+    }
+
+    const done = parseBoolean((body as any)?.done);
+    if (done !== undefined) {
+      updates.done = done;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json({ duty: assignment });
+    }
+
+    const updated = await prisma.dutyAssignment.update({
+      where: { id: assignment.id },
+      data: updates,
+      include: {
+        type: { select: { id: true, name: true, color: true, visibility: true } },
+      },
+    });
+
+    return NextResponse.json({
+      duty: {
+        id: updated.id,
+        groupId: updated.groupId,
+        typeId: updated.typeId,
+        date: updated.date.toISOString(),
+        slotIndex: updated.slotIndex,
+        locked: updated.locked,
+        done: updated.done,
+        assigneeId: updated.assigneeId,
+        type: updated.type,
+      },
+    });
+  } catch (error) {
+    console.error('update duty assignment failed', error);
+    return NextResponse.json({ error: 'update duty assignment failed' }, { status: 500 });
+  }
+}

--- a/web/src/app/api/duties/assign/route.ts
+++ b/web/src/app/api/duties/assign/route.ts
@@ -1,0 +1,122 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const runtime = 'nodejs';
+
+import { NextResponse } from 'next/server';
+import { prisma } from '@/src/lib/prisma';
+import { readUserFromCookie } from '@/lib/auth';
+import { canManageDuties } from '@/lib/duties/permissions';
+
+function parseDate(input: unknown) {
+  if (!input) return null;
+  const value = new Date(String(input));
+  return Number.isNaN(value.getTime()) ? null : value;
+}
+
+export async function POST(req: Request) {
+  try {
+    const me = await readUserFromCookie();
+    if (!me?.email) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const typeId = String((body as any)?.typeId || '').trim();
+    if (!typeId) {
+      return NextResponse.json({ error: 'typeId is required' }, { status: 400 });
+    }
+
+    const dutyType = await prisma.dutyType.findUnique({
+      where: { id: typeId },
+      include: { group: { include: { members: true } } },
+    });
+    if (!dutyType) {
+      return NextResponse.json({ error: 'duty type not found' }, { status: 404 });
+    }
+
+    if (!canManageDuties(dutyType.group, me.email)) {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+    }
+
+    const date = parseDate((body as any)?.date);
+    if (!date) {
+      return NextResponse.json({ error: 'invalid date' }, { status: 400 });
+    }
+    date.setUTCHours(0, 0, 0, 0);
+
+    const slotIndexRaw = Number((body as any)?.slotIndex);
+    if (!Number.isInteger(slotIndexRaw) || slotIndexRaw < 0) {
+      return NextResponse.json({ error: 'slotIndex must be non-negative integer' }, { status: 400 });
+    }
+
+    const rawAssignee = (body as any)?.assigneeId;
+    const assigneeId = rawAssignee === null || rawAssignee === undefined || rawAssignee === '' ? null : String(rawAssignee);
+    if (assigneeId) {
+      const memberEmails = Array.from(
+        new Set([dutyType.group.hostEmail, ...dutyType.group.members.map((member) => member.email)])
+      );
+      const members = memberEmails.length
+        ? await prisma.user.findMany({ where: { email: { in: memberEmails } }, select: { id: true } })
+        : [];
+      const allowed = new Set(members.map((member) => member.id));
+      if (!allowed.has(assigneeId)) {
+        return NextResponse.json({ error: 'assignee not member' }, { status: 400 });
+      }
+    }
+
+    const existing = await prisma.dutyAssignment.findUnique({
+      where: {
+        groupId_typeId_date_slotIndex: {
+          groupId: dutyType.groupId,
+          typeId: dutyType.id,
+          date,
+          slotIndex: slotIndexRaw,
+        },
+      },
+      select: { id: true, locked: true, assigneeId: true },
+    });
+
+    if (existing?.locked && existing.assigneeId && existing.assigneeId !== assigneeId) {
+      return NextResponse.json({ error: 'assignment is locked' }, { status: 409 });
+    }
+
+    const saved = await prisma.dutyAssignment.upsert({
+      where: {
+        groupId_typeId_date_slotIndex: {
+          groupId: dutyType.groupId,
+          typeId: dutyType.id,
+          date,
+          slotIndex: slotIndexRaw,
+        },
+      },
+      update: { assigneeId },
+      create: {
+        groupId: dutyType.groupId,
+        typeId: dutyType.id,
+        date,
+        slotIndex: slotIndexRaw,
+        assigneeId,
+      },
+      include: {
+        type: { select: { id: true, name: true, color: true, visibility: true } },
+      },
+    });
+
+    return NextResponse.json({
+      duty: {
+        id: saved.id,
+        groupId: saved.groupId,
+        typeId: saved.typeId,
+        date: saved.date.toISOString(),
+        slotIndex: saved.slotIndex,
+        locked: saved.locked,
+        done: saved.done,
+        assigneeId: saved.assigneeId,
+        type: saved.type,
+      },
+    });
+  } catch (error) {
+    console.error('assign duty failed', error);
+    return NextResponse.json({ error: 'assign duty failed' }, { status: 500 });
+  }
+}

--- a/web/src/app/api/duties/route.ts
+++ b/web/src/app/api/duties/route.ts
@@ -1,0 +1,82 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const runtime = 'nodejs';
+
+import { NextResponse } from 'next/server';
+import { prisma } from '@/src/lib/prisma';
+import { readUserFromCookie } from '@/lib/auth';
+import { isGroupMember } from '@/lib/duties/permissions';
+
+function parseDate(value: string | null) {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+export async function GET(req: Request) {
+  try {
+    const me = await readUserFromCookie();
+    if (!me?.email) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const slug = String(searchParams.get('groupSlug') || '').trim().toLowerCase();
+    if (!slug) {
+      return NextResponse.json({ error: 'groupSlug is required' }, { status: 400 });
+    }
+
+    const from = parseDate(searchParams.get('from'));
+    const to = parseDate(searchParams.get('to'));
+    if (!from || !to || to < from) {
+      return NextResponse.json({ error: 'invalid range' }, { status: 400 });
+    }
+
+    const group = await prisma.group.findUnique({
+      where: { slug },
+      include: { members: true },
+    });
+    if (!group) {
+      return NextResponse.json({ error: 'group not found' }, { status: 404 });
+    }
+
+    if (!isGroupMember(group, me.email)) {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+    }
+
+    const assignments = await prisma.dutyAssignment.findMany({
+      where: {
+        groupId: group.id,
+        date: { gte: from, lte: to },
+      },
+      include: {
+        type: {
+          select: {
+            id: true,
+            name: true,
+            color: true,
+            visibility: true,
+          },
+        },
+      },
+      orderBy: [{ date: 'asc' }, { slotIndex: 'asc' }],
+    });
+
+    const duties = assignments.map((assignment) => ({
+      id: assignment.id,
+      typeId: assignment.typeId,
+      groupId: assignment.groupId,
+      date: assignment.date.toISOString(),
+      slotIndex: assignment.slotIndex,
+      locked: assignment.locked,
+      done: assignment.done,
+      assigneeId: assignment.assigneeId,
+      type: assignment.type,
+    }));
+
+    return NextResponse.json({ duties });
+  } catch (error) {
+    console.error('list duties failed', error);
+    return NextResponse.json({ error: 'list duties failed' }, { status: 500 });
+  }
+}

--- a/web/src/app/api/duties/rules/[id]/route.ts
+++ b/web/src/app/api/duties/rules/[id]/route.ts
@@ -1,0 +1,179 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const runtime = 'nodejs';
+
+import { NextResponse } from 'next/server';
+import { prisma } from '@/src/lib/prisma';
+import { readUserFromCookie } from '@/lib/auth';
+import { isGroupAdmin } from '@/lib/duties/permissions';
+
+function parseDate(input: unknown) {
+  if (input === undefined) return undefined;
+  if (input === null || input === '') return null;
+  const value = new Date(String(input));
+  if (Number.isNaN(value.getTime())) return undefined;
+  return value;
+}
+
+function parseWeekdays(value: unknown) {
+  if (!Array.isArray(value)) return undefined;
+  const items = value
+    .map((v) => Number(v))
+    .filter((v) => Number.isInteger(v) && v >= 0 && v <= 6);
+  return Array.from(new Set(items));
+}
+
+function parseStringArray(value: unknown) {
+  if (!Array.isArray(value)) return undefined;
+  return value
+    .map((v) => String(v || '').trim())
+    .filter((v) => v.length > 0);
+}
+
+function parseBoolean(value: unknown) {
+  if (value === undefined) return undefined;
+  if (typeof value === 'boolean') return value;
+  const str = String(value).trim().toLowerCase();
+  if (str === 'true') return true;
+  if (str === 'false') return false;
+  return undefined;
+}
+
+export async function PUT(req: Request, { params }: { params: { id: string } }) {
+  try {
+    const me = await readUserFromCookie();
+    if (!me?.email) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+
+    const rule = await prisma.dutyRule.findUnique({
+      where: { id: params.id },
+      include: { type: { include: { group: { include: { members: true } } } } },
+    });
+    if (!rule) {
+      return NextResponse.json({ error: 'duty rule not found' }, { status: 404 });
+    }
+
+    if (!isGroupAdmin(rule.type.group, me.email)) {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const updates: any = {};
+
+    if ((body as any)?.startDate !== undefined) {
+      const value = parseDate((body as any).startDate);
+      if (!value) {
+        return NextResponse.json({ error: 'invalid startDate' }, { status: 400 });
+      }
+      updates.startDate = value;
+    }
+
+    if ((body as any)?.endDate !== undefined) {
+      const value = parseDate((body as any).endDate);
+      if (!value) {
+        return NextResponse.json({ error: 'invalid endDate' }, { status: 400 });
+      }
+      updates.endDate = value;
+    }
+
+    if (updates.startDate && updates.endDate && updates.endDate < updates.startDate) {
+      return NextResponse.json({ error: 'invalid date range' }, { status: 400 });
+    }
+
+    const weekdays = parseWeekdays((body as any)?.byWeekday);
+    if (weekdays) {
+      if (weekdays.length === 0) {
+        return NextResponse.json({ error: 'byWeekday cannot be empty' }, { status: 400 });
+      }
+      updates.byWeekday = weekdays;
+    }
+
+    if ((body as any)?.slotsPerDay !== undefined) {
+      const raw = Number((body as any).slotsPerDay);
+      if (!Number.isInteger(raw) || raw <= 0) {
+        return NextResponse.json({ error: 'slotsPerDay must be positive integer' }, { status: 400 });
+      }
+      updates.slotsPerDay = raw;
+    }
+
+    const includeMemberIds = parseStringArray((body as any)?.includeMemberIds);
+    if (includeMemberIds) {
+      updates.includeMemberIds = includeMemberIds;
+    }
+    const excludeMemberIds = parseStringArray((body as any)?.excludeMemberIds);
+    if (excludeMemberIds) {
+      updates.excludeMemberIds = excludeMemberIds;
+    }
+
+    const avoidConsecutive = parseBoolean((body as any)?.avoidConsecutive);
+    if (avoidConsecutive !== undefined) {
+      updates.avoidConsecutive = avoidConsecutive;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json({ dutyRule: rule });
+    }
+
+    if (updates.startDate && !updates.endDate) {
+      if (rule.endDate < updates.startDate) {
+        return NextResponse.json({ error: 'invalid date range' }, { status: 400 });
+      }
+    }
+    if (updates.endDate && !updates.startDate) {
+      if (updates.endDate < rule.startDate) {
+        return NextResponse.json({ error: 'invalid date range' }, { status: 400 });
+      }
+    }
+
+    await prisma.dutyRule.update({ where: { id: rule.id }, data: updates });
+
+    const refreshed = await prisma.dutyRule.findUnique({
+      where: { id: rule.id },
+      select: {
+        id: true,
+        typeId: true,
+        startDate: true,
+        endDate: true,
+        byWeekday: true,
+        slotsPerDay: true,
+        includeMemberIds: true,
+        excludeMemberIds: true,
+        avoidConsecutive: true,
+      },
+    });
+
+    return NextResponse.json({ dutyRule: refreshed });
+  } catch (error) {
+    console.error('update duty rule failed', error);
+    return NextResponse.json({ error: 'update duty rule failed' }, { status: 500 });
+  }
+}
+
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+  try {
+    const me = await readUserFromCookie();
+    if (!me?.email) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+
+    const rule = await prisma.dutyRule.findUnique({
+      where: { id: params.id },
+      include: { type: { include: { group: { include: { members: true } } } } },
+    });
+    if (!rule) {
+      return NextResponse.json({ error: 'duty rule not found' }, { status: 404 });
+    }
+
+    if (!isGroupAdmin(rule.type.group, me.email)) {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+    }
+
+    await prisma.dutyRule.delete({ where: { id: rule.id } });
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('delete duty rule failed', error);
+    return NextResponse.json({ error: 'delete duty rule failed' }, { status: 500 });
+  }
+}

--- a/web/src/app/api/duties/rules/route.ts
+++ b/web/src/app/api/duties/rules/route.ts
@@ -1,0 +1,102 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const runtime = 'nodejs';
+
+import { NextResponse } from 'next/server';
+import { prisma } from '@/src/lib/prisma';
+import { readUserFromCookie } from '@/lib/auth';
+import { isGroupAdmin } from '@/lib/duties/permissions';
+
+function parseDate(input: unknown) {
+  if (!input) return null;
+  const value = new Date(String(input));
+  return Number.isNaN(value.getTime()) ? null : value;
+}
+
+function parseWeekdays(value: unknown) {
+  if (!Array.isArray(value)) return [];
+  const items = value
+    .map((v) => Number(v))
+    .filter((v) => Number.isInteger(v) && v >= 0 && v <= 6);
+  return Array.from(new Set(items));
+}
+
+function parseStringArray(value: unknown) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((v) => String(v || '').trim())
+    .filter((v) => v.length > 0);
+}
+
+export async function POST(req: Request) {
+  try {
+    const me = await readUserFromCookie();
+    if (!me?.email) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const typeId = String((body as any)?.typeId || '').trim();
+    if (!typeId) {
+      return NextResponse.json({ error: 'typeId is required' }, { status: 400 });
+    }
+
+    const dutyType = await prisma.dutyType.findUnique({
+      where: { id: typeId },
+      include: { group: { include: { members: true } } },
+    });
+    if (!dutyType) {
+      return NextResponse.json({ error: 'duty type not found' }, { status: 404 });
+    }
+
+    if (!isGroupAdmin(dutyType.group, me.email)) {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+    }
+
+    const startDate = parseDate((body as any)?.startDate);
+    const endDate = parseDate((body as any)?.endDate);
+    if (!startDate || !endDate || endDate < startDate) {
+      return NextResponse.json({ error: 'invalid date range' }, { status: 400 });
+    }
+
+    const byWeekday = parseWeekdays((body as any)?.byWeekday);
+    if (byWeekday.length === 0) {
+      return NextResponse.json({ error: 'byWeekday is required' }, { status: 400 });
+    }
+
+    const slotsPerDayRaw = Number((body as any)?.slotsPerDay ?? 1);
+    const slotsPerDay = Number.isInteger(slotsPerDayRaw) && slotsPerDayRaw > 0 ? slotsPerDayRaw : 1;
+    const includeMemberIds = parseStringArray((body as any)?.includeMemberIds);
+    const excludeMemberIds = parseStringArray((body as any)?.excludeMemberIds);
+    const avoidConsecutive = Boolean((body as any)?.avoidConsecutive ?? true);
+
+    const created = await prisma.dutyRule.create({
+      data: {
+        typeId: dutyType.id,
+        startDate,
+        endDate,
+        byWeekday,
+        slotsPerDay,
+        includeMemberIds,
+        excludeMemberIds,
+        avoidConsecutive,
+      },
+      select: {
+        id: true,
+        typeId: true,
+        startDate: true,
+        endDate: true,
+        byWeekday: true,
+        slotsPerDay: true,
+        includeMemberIds: true,
+        excludeMemberIds: true,
+        avoidConsecutive: true,
+      },
+    });
+
+    return NextResponse.json({ dutyRule: created }, { status: 201 });
+  } catch (error) {
+    console.error('create duty rule failed', error);
+    return NextResponse.json({ error: 'create duty rule failed' }, { status: 500 });
+  }
+}

--- a/web/src/app/api/duties/types/[id]/route.ts
+++ b/web/src/app/api/duties/types/[id]/route.ts
@@ -1,0 +1,103 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const runtime = 'nodejs';
+
+import { NextResponse } from 'next/server';
+import { prisma } from '@/src/lib/prisma';
+import { readUserFromCookie } from '@/lib/auth';
+import { isGroupAdmin } from '@/lib/duties/permissions';
+
+type DutyVisibility = 'PUBLIC' | 'MEMBERS_ONLY';
+
+export async function PUT(req: Request, { params }: { params: { id: string } }) {
+  try {
+    const me = await readUserFromCookie();
+    if (!me?.email) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+
+    const dutyType = await prisma.dutyType.findUnique({
+      where: { id: params.id },
+      include: { group: { include: { members: true } } },
+    });
+    if (!dutyType) {
+      return NextResponse.json({ error: 'duty type not found' }, { status: 404 });
+    }
+
+    if (!isGroupAdmin(dutyType.group, me.email)) {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const updates: { name?: string; color?: string; visibility?: DutyVisibility } = {};
+
+    if ((body as any)?.name !== undefined) {
+      const name = String((body as any).name || '').trim();
+      if (!name) {
+        return NextResponse.json({ error: 'name is required' }, { status: 400 });
+      }
+      const duplicate = await prisma.dutyType.findFirst({
+        where: { groupId: dutyType.groupId, name, id: { not: dutyType.id } },
+        select: { id: true },
+      });
+      if (duplicate) {
+        return NextResponse.json({ error: 'duty type already exists' }, { status: 409 });
+      }
+      updates.name = name;
+    }
+
+    if ((body as any)?.color !== undefined) {
+      const color = String((body as any).color || '').trim();
+      if (color) updates.color = color;
+    }
+
+    if ((body as any)?.visibility !== undefined) {
+      const visibilityValue = String((body as any).visibility);
+      if (visibilityValue === 'MEMBERS_ONLY' || visibilityValue === 'PUBLIC') {
+        updates.visibility = visibilityValue as DutyVisibility;
+      }
+    }
+
+    if (Object.keys(updates).length > 0) {
+      await prisma.dutyType.update({ where: { id: dutyType.id }, data: updates });
+    }
+
+    const refreshed = await prisma.dutyType.findUnique({
+      where: { id: dutyType.id },
+      select: { id: true, groupId: true, name: true, color: true, visibility: true },
+    });
+
+    return NextResponse.json({ dutyType: refreshed });
+  } catch (error) {
+    console.error('update duty type failed', error);
+    return NextResponse.json({ error: 'update duty type failed' }, { status: 500 });
+  }
+}
+
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+  try {
+    const me = await readUserFromCookie();
+    if (!me?.email) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+
+    const dutyType = await prisma.dutyType.findUnique({
+      where: { id: params.id },
+      include: { group: { include: { members: true } } },
+    });
+    if (!dutyType) {
+      return NextResponse.json({ error: 'duty type not found' }, { status: 404 });
+    }
+
+    if (!isGroupAdmin(dutyType.group, me.email)) {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+    }
+
+    await prisma.dutyType.delete({ where: { id: dutyType.id } });
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('delete duty type failed', error);
+    return NextResponse.json({ error: 'delete duty type failed' }, { status: 500 });
+  }
+}

--- a/web/src/app/api/groups/[slug]/duties/generate/route.ts
+++ b/web/src/app/api/groups/[slug]/duties/generate/route.ts
@@ -1,0 +1,213 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const runtime = 'nodejs';
+
+import { NextResponse } from 'next/server';
+import { prisma } from '@/src/lib/prisma';
+import { readUserFromCookie } from '@/lib/auth';
+import { isGroupAdmin } from '@/lib/duties/permissions';
+import { assignMembersToSlots } from '@/utils/duty/assign';
+
+type DutyVisibility = 'PUBLIC' | 'MEMBERS_ONLY';
+
+function normalizeSlug(value: string | string[] | undefined) {
+  if (!value) return '';
+  const raw = Array.isArray(value) ? value[0] : value;
+  return String(raw || '').trim().toLowerCase();
+}
+
+function parseDate(input: unknown) {
+  if (!input) return null;
+  const value = new Date(String(input));
+  return Number.isNaN(value.getTime()) ? null : value;
+}
+
+function keyOf(date: Date, slotIndex: number) {
+  return `${date.toISOString()}#${slotIndex}`;
+}
+
+export async function POST(req: Request, { params }: { params: { slug: string } }) {
+  try {
+    const me = await readUserFromCookie();
+    if (!me?.email) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+
+    const slug = normalizeSlug(params?.slug);
+    if (!slug) {
+      return NextResponse.json({ error: 'invalid slug' }, { status: 400 });
+    }
+
+    const group = await prisma.group.findUnique({
+      where: { slug },
+      include: { members: true },
+    });
+    if (!group) {
+      return NextResponse.json({ error: 'group not found' }, { status: 404 });
+    }
+
+    if (!isGroupAdmin(group, me.email)) {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const from = parseDate((body as any)?.from);
+    const to = parseDate((body as any)?.to);
+    if (!from || !to || to < from) {
+      return NextResponse.json({ error: 'invalid range' }, { status: 400 });
+    }
+
+    const typeIdsRaw = (body as any)?.typeIds;
+    const typeIds = Array.isArray(typeIdsRaw)
+      ? typeIdsRaw.map((v: unknown) => String(v || '').trim()).filter((v: string) => v.length > 0)
+      : undefined;
+
+    const dutyTypes = await prisma.dutyType.findMany({
+      where: {
+        groupId: group.id,
+        ...(typeIds && typeIds.length > 0 ? { id: { in: typeIds } } : {}),
+      },
+      include: { rules: true },
+    });
+
+    if (dutyTypes.length === 0) {
+      return NextResponse.json({ ok: true, created: 0 });
+    }
+
+    const memberEmails = Array.from(
+      new Set([group.hostEmail, ...group.members.map((member) => member.email)])
+    );
+
+    const users = memberEmails.length
+      ? await prisma.user.findMany({
+          where: { email: { in: memberEmails } },
+          select: { id: true, email: true },
+        })
+      : [];
+
+    const members = users.map((user) => ({ id: user.id }));
+    const memberIdSet = new Set(members.map((m) => m.id));
+
+    let created = 0;
+
+    for (const dutyType of dutyTypes) {
+      if (dutyType.rules.length === 0) continue;
+
+      const existingAssignments = await prisma.dutyAssignment.findMany({
+        where: {
+          groupId: group.id,
+          typeId: dutyType.id,
+          date: { gte: from, lte: to },
+        },
+      });
+      const existingMap = new Map<string, (typeof existingAssignments)[number]>();
+      for (const assignment of existingAssignments) {
+        existingMap.set(keyOf(assignment.date, assignment.slotIndex), assignment);
+      }
+
+      const includeIds = new Set<string>();
+      const excludeIds = new Set<string>();
+      let avoidConsecutive = false;
+      for (const rule of dutyType.rules) {
+        rule.includeMemberIds.forEach((id) => includeIds.add(id));
+        rule.excludeMemberIds.forEach((id) => excludeIds.add(id));
+        if (rule.avoidConsecutive !== false) {
+          avoidConsecutive = true;
+        }
+      }
+
+      let targetMembers = members.filter((member) => memberIdSet.has(member.id));
+      if (includeIds.size > 0) {
+        targetMembers = targetMembers.filter((member) => includeIds.has(member.id));
+      }
+      if (excludeIds.size > 0) {
+        targetMembers = targetMembers.filter((member) => !excludeIds.has(member.id));
+      }
+
+      if (targetMembers.length === 0) {
+        continue;
+      }
+
+      const slots: { date: Date; slotIndex: number; locked: boolean; assigneeId?: string }[] = [];
+
+      for (const rule of dutyType.rules) {
+        const start = new Date(Math.max(rule.startDate.getTime(), from.getTime()));
+        const end = new Date(Math.min(rule.endDate.getTime(), to.getTime()));
+        start.setUTCHours(0, 0, 0, 0);
+        end.setUTCHours(0, 0, 0, 0);
+        if (end < start) continue;
+
+        for (let cursor = new Date(start); cursor <= end; cursor.setUTCDate(cursor.getUTCDate() + 1)) {
+          const weekday = cursor.getUTCDay();
+          if (!rule.byWeekday.includes(weekday)) continue;
+          for (let slotIndex = 0; slotIndex < rule.slotsPerDay; slotIndex++) {
+            const day = new Date(cursor);
+            const key = keyOf(day, slotIndex);
+            const existing = existingMap.get(key);
+            slots.push({
+              date: day,
+              slotIndex,
+              locked: existing?.locked ?? false,
+              assigneeId: existing?.assigneeId ?? undefined,
+            });
+          }
+        }
+      }
+
+      if (slots.length === 0) {
+        continue;
+      }
+
+      const countsRaw = await prisma.dutyAssignment.groupBy({
+        by: ['assigneeId'],
+        where: { groupId: group.id, typeId: dutyType.id, assigneeId: { not: null } },
+        _count: { _all: true },
+      });
+      const countMap = new Map<string, number>();
+      for (const row of countsRaw) {
+        if (row.assigneeId) {
+          countMap.set(row.assigneeId, row._count._all);
+        }
+      }
+
+      const assigned = assignMembersToSlots(targetMembers, slots, countMap, {
+        avoidConsecutive,
+      });
+
+      for (const slot of assigned) {
+        if (slot.locked && slot.assigneeId) {
+          continue;
+        }
+        const key = keyOf(slot.date, slot.slotIndex);
+        const existing = existingMap.get(key);
+        if (existing?.locked) {
+          continue;
+        }
+        await prisma.dutyAssignment.upsert({
+          where: {
+            groupId_typeId_date_slotIndex: {
+              groupId: group.id,
+              typeId: dutyType.id,
+              date: slot.date,
+              slotIndex: slot.slotIndex,
+            },
+          },
+          update: { assigneeId: slot.assigneeId ?? null },
+          create: {
+            groupId: group.id,
+            typeId: dutyType.id,
+            date: slot.date,
+            slotIndex: slot.slotIndex,
+            assigneeId: slot.assigneeId ?? null,
+          },
+        });
+        created += 1;
+      }
+    }
+
+    return NextResponse.json({ ok: true, created });
+  } catch (error) {
+    console.error('generate duties failed', error);
+    return NextResponse.json({ error: 'generate duties failed' }, { status: 500 });
+  }
+}

--- a/web/src/app/api/groups/[slug]/duties/types/route.ts
+++ b/web/src/app/api/groups/[slug]/duties/types/route.ts
@@ -1,0 +1,83 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const runtime = 'nodejs';
+
+import { NextResponse } from 'next/server';
+import { prisma } from '@/src/lib/prisma';
+import { readUserFromCookie } from '@/lib/auth';
+import { isGroupAdmin } from '@/lib/duties/permissions';
+
+type DutyVisibility = 'PUBLIC' | 'MEMBERS_ONLY';
+
+function normalizeSlug(value: string | string[] | undefined) {
+  if (!value) return '';
+  const raw = Array.isArray(value) ? value[0] : value;
+  return String(raw || '').trim().toLowerCase();
+}
+
+export async function POST(req: Request, { params }: { params: { slug: string } }) {
+  try {
+    const me = await readUserFromCookie();
+    if (!me?.email) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+
+    const slug = normalizeSlug(params?.slug);
+    if (!slug) {
+      return NextResponse.json({ error: 'invalid slug' }, { status: 400 });
+    }
+
+    const group = await prisma.group.findUnique({
+      where: { slug },
+      include: { members: true },
+    });
+    if (!group) {
+      return NextResponse.json({ error: 'group not found' }, { status: 404 });
+    }
+
+    if (!isGroupAdmin(group, me.email)) {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const name = String((body as any)?.name || '').trim();
+    if (!name) {
+      return NextResponse.json({ error: 'name is required' }, { status: 400 });
+    }
+
+    const colorRaw = (body as any)?.color;
+    const visibilityRaw = (body as any)?.visibility;
+    const color = colorRaw ? String(colorRaw).trim() : '#7c3aed';
+    const visibility: DutyVisibility =
+      visibilityRaw === 'MEMBERS_ONLY' ? 'MEMBERS_ONLY' : 'PUBLIC';
+
+    const duplicate = await prisma.dutyType.findFirst({
+      where: { groupId: group.id, name },
+      select: { id: true },
+    });
+    if (duplicate) {
+      return NextResponse.json({ error: 'duty type already exists' }, { status: 409 });
+    }
+
+    const created = await prisma.dutyType.create({
+      data: {
+        groupId: group.id,
+        name,
+        color,
+        visibility,
+      },
+      select: {
+        id: true,
+        groupId: true,
+        name: true,
+        color: true,
+        visibility: true,
+      },
+    });
+
+    return NextResponse.json({ dutyType: created }, { status: 201 });
+  } catch (error) {
+    console.error('create duty type failed', error);
+    return NextResponse.json({ error: 'create duty type failed' }, { status: 500 });
+  }
+}

--- a/web/src/app/api/groups/[slug]/route.ts
+++ b/web/src/app/api/groups/[slug]/route.ts
@@ -117,6 +117,7 @@ export async function GET(_req: Request, { params }: { params: { slug: string } 
       reserveTo: toISO(group.reserveTo),
       memo: group.memo ?? null,
       deviceManagePolicy: group.deviceManagePolicy,
+      dutyManagePolicy: group.dutyManagePolicy,
       members,
       devices,
       reservations,
@@ -155,6 +156,7 @@ export async function PATCH(req: Request, { params }: { params: { slug: string }
     const memoRaw = body?.memo
     const hostRaw = body?.host
     const policyRaw = body?.deviceManagePolicy ?? body?.device_manage_policy
+    const dutyPolicyRaw = body?.dutyManagePolicy ?? body?.duty_manage_policy
 
     const updates: any = {}
     if (reserveFromRaw !== undefined) {
@@ -186,6 +188,12 @@ export async function PATCH(req: Request, { params }: { params: { slug: string }
         updates.deviceManagePolicy = value as 'HOST_ONLY' | 'MEMBERS_ALLOWED'
       }
     }
+    if (dutyPolicyRaw !== undefined) {
+      const value = String(dutyPolicyRaw)
+      if (value === 'ADMINS_ONLY' || value === 'MEMBERS_ALLOWED') {
+        updates.dutyManagePolicy = value as 'ADMINS_ONLY' | 'MEMBERS_ALLOWED'
+      }
+    }
 
     if (Object.keys(updates).length > 0) {
       await prisma.group.update({ where: { id: group.id }, data: updates })
@@ -209,6 +217,7 @@ export async function PATCH(req: Request, { params }: { params: { slug: string }
         devices: payload.devices,
         reservations: payload.reservations,
         deviceManagePolicy: payload.group.deviceManagePolicy,
+        dutyManagePolicy: payload.group.dutyManagePolicy,
       },
     })
   } catch (error) {

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -120,6 +120,7 @@ export default async function GroupPage({
     devices: Array.isArray(raw?.devices) ? raw.devices : [],
     reservations: Array.isArray(raw?.reservations) ? raw.reservations : [],
     deviceManagePolicy: raw?.deviceManagePolicy ?? 'HOST_ONLY',
+    dutyManagePolicy: raw?.dutyManagePolicy ?? 'ADMINS_ONLY',
   };
   const devices = group.devices;
   const me = user;

--- a/web/src/app/groups/[slug]/settings/GroupSettingsClient.tsx
+++ b/web/src/app/groups/[slug]/settings/GroupSettingsClient.tsx
@@ -12,6 +12,9 @@ export default function GroupSettingsClient({ initialGroup }: { initialGroup: an
   const [deviceManagePolicy, setDeviceManagePolicy] = useState<'HOST_ONLY' | 'MEMBERS_ALLOWED'>(
     initialGroup.deviceManagePolicy || 'HOST_ONLY'
   );
+  const [dutyManagePolicy, setDutyManagePolicy] = useState<'ADMINS_ONLY' | 'MEMBERS_ALLOWED'>(
+    initialGroup.dutyManagePolicy || 'ADMINS_ONLY'
+  );
   const [saving, setSaving] = useState(false);
   const router = useRouter();
   const members: string[] = initialGroup.members || [];
@@ -29,6 +32,7 @@ export default function GroupSettingsClient({ initialGroup }: { initialGroup: an
           memo: memo || undefined,
           host: host || undefined,
           deviceManagePolicy,
+          dutyManagePolicy,
         }),
         credentials: 'same-origin',
       });
@@ -106,6 +110,29 @@ export default function GroupSettingsClient({ initialGroup }: { initialGroup: an
               onChange={() => setDeviceManagePolicy('MEMBERS_ALLOWED')}
             />
             <span>メンバーも追加・削除可</span>
+          </label>
+        </div>
+      </section>
+      <section className="rounded-2xl border p-6 bg-white">
+        <h2 className="text-lg font-semibold mb-4">当番の管理権限</h2>
+        <div className="space-y-3">
+          <label className="flex items-center gap-3">
+            <input
+              type="radio"
+              name="dutyManagePolicy"
+              checked={dutyManagePolicy === 'ADMINS_ONLY'}
+              onChange={() => setDutyManagePolicy('ADMINS_ONLY')}
+            />
+            <span>ホストのみ変更可</span>
+          </label>
+          <label className="flex items-center gap-3">
+            <input
+              type="radio"
+              name="dutyManagePolicy"
+              checked={dutyManagePolicy === 'MEMBERS_ALLOWED'}
+              onChange={() => setDutyManagePolicy('MEMBERS_ALLOWED')}
+            />
+            <span>メンバーも変更可</span>
           </label>
         </div>
       </section>

--- a/web/src/lib/duties/permissions.ts
+++ b/web/src/lib/duties/permissions.ts
@@ -1,0 +1,21 @@
+import type { Group, GroupMember } from '@prisma/client';
+
+export type GroupWithMembers = Group & { members: Pick<GroupMember, 'email'>[] };
+
+export function isGroupMember(group: GroupWithMembers, email: string | null | undefined) {
+  if (!email) return false;
+  return group.hostEmail === email || group.members.some((member) => member.email === email);
+}
+
+export function isGroupAdmin(group: GroupWithMembers, email: string | null | undefined) {
+  if (!email) return false;
+  return group.hostEmail === email;
+}
+
+export function canManageDuties(group: GroupWithMembers, email: string | null | undefined) {
+  if (isGroupAdmin(group, email)) return true;
+  if (group.dutyManagePolicy === 'MEMBERS_ALLOWED') {
+    return isGroupMember(group, email);
+  }
+  return false;
+}

--- a/web/src/utils/duty/assign.ts
+++ b/web/src/utils/duty/assign.ts
@@ -1,0 +1,85 @@
+export type Member = { id: string };
+export type Slot = { date: Date; slotIndex: number; locked: boolean; assigneeId?: string };
+export type Options = {
+  avoidConsecutive?: boolean;
+  seed?: number;
+};
+
+export function assignMembersToSlots(
+  members: Member[],
+  slots: Slot[],
+  existingCount: Map<string, number>,
+  opts: Options = {}
+): Slot[] {
+  const avoidConsecutive = opts.avoidConsecutive ?? true;
+  const groupsByCount = new Map<number, Member[]>();
+  for (const member of members) {
+    const count = existingCount.get(member.id) ?? 0;
+    if (!groupsByCount.has(count)) groupsByCount.set(count, []);
+    groupsByCount.get(count)!.push(member);
+  }
+
+  const counts = Array.from(groupsByCount.keys()).sort((a, b) => a - b);
+  const queue: Member[] = [];
+  for (const count of counts) {
+    const arr = groupsByCount.get(count)!;
+    shuffleInPlace(arr, opts.seed);
+    queue.push(...arr);
+  }
+
+  let q = [...queue];
+  const byDateLastAssignee = new Map<string, string>();
+  const result = slots.map((slot) => ({ ...slot }));
+
+  for (const slot of result) {
+    if (slot.locked && slot.assigneeId) continue;
+    if (q.length === 0) {
+      const currentCounts = new Map<string, number>();
+      for (const member of members) {
+        currentCounts.set(member.id, existingCount.get(member.id) ?? 0);
+      }
+      const min = Math.min(...Array.from(currentCounts.values()));
+      const next = members.filter((member) => (currentCounts.get(member.id) ?? 0) === min);
+      shuffleInPlace(next, opts.seed);
+      q = [...next];
+    }
+
+    let index = 0;
+    while (index < q.length) {
+      const candidate = q[index];
+      const key = slot.date.toISOString().slice(0, 10);
+      const last = byDateLastAssignee.get(key);
+      if (!avoidConsecutive || !last || last !== candidate.id) {
+        break;
+      }
+      index++;
+    }
+
+    const chosen = q.splice(index < q.length ? index : 0, 1)[0];
+    slot.assigneeId = chosen?.id;
+    const dayKey = slot.date.toISOString().slice(0, 10);
+    if (chosen?.id) {
+      byDateLastAssignee.set(dayKey, chosen.id);
+      existingCount.set(chosen.id, (existingCount.get(chosen.id) ?? 0) + 1);
+    }
+  }
+
+  return result;
+}
+
+function shuffleInPlace<T>(arr: T[], seed = Date.now()) {
+  let random = mulberry32(seed);
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+}
+
+function mulberry32(a: number) {
+  return function () {
+    let t = (a += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}


### PR DESCRIPTION
## Summary
- introduce duty scheduling models and enums to Prisma with accompanying migration
- add utility and permission helpers plus API routes for duty types, rules, assignments, and generation
- expose duty management policy in group settings UI for configuration

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d80e55d6448323b583e5522f39dad5