### PR TITLE
Fix build by enhancing local zod shim

### DIFF
--- a/web/src/app/groups/[slug]/day/[date]/page.tsx
+++ b/web/src/app/groups/[slug]/day/[date]/page.tsx
@@ -156,7 +156,20 @@ export default async function DayPage({
     })
     .filter((member) => member.id);
 
-  const dutyTypes = groupForDuties?.dutyTypes ?? [];
+  const dutyTypes = (groupForDuties?.dutyTypes ?? []).map((type) => ({
+    ...type,
+    rules: type.rules.map((rule) => ({
+      ...rule,
+      startDate:
+        typeof rule.startDate === 'string'
+          ? rule.startDate
+          : rule.startDate?.toISOString() ?? '',
+      endDate:
+        typeof rule.endDate === 'string'
+          ? rule.endDate
+          : rule.endDate?.toISOString() ?? '',
+    })),
+  }));
 
   return (
     <div className="mx-auto max-w-5xl p-6 space-y-6">

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -25,6 +25,9 @@
       ],
       "@/src/*": [
         "src/*"
+      ],
+      "zod": [
+        "src/lib/zod"
       ]
     },
     "plugins": [


### PR DESCRIPTION
## Summary
- extend the internal zod shim to support booleans, arrays, enums, defaults, and expose `ZodError`
- add a path alias so TypeScript resolves the shim when importing `zod`
- normalize duty rule dates to ISO strings before passing them to the inline create component

## Testing
- USE_MOCK=true DATABASE_URL=postgres://user:pass@localhost:5432/db pnpm --filter lab_yoyaku-web build

------
https://chatgpt.com/codex/tasks/task_e_68d82761844c832399390be6d4df25d9