### PR TITLE
fix: make absUrl helper universal

### DIFF
--- a/web/src/lib/url.ts
+++ b/web/src/lib/url.ts
@@ -1,22 +1,35 @@
-"use server";
-
 import { headers } from "next/headers";
 
-/** 環境に応じて API の絶対URLを返す */
-export function getBaseUrl() {
-  // 1. 手動設定（任意）
-  if (process.env.NEXT_PUBLIC_BASE_URL) return process.env.NEXT_PUBLIC_BASE_URL;
-  // 2. Vercel 本番/プレビュー
+/** .env や Vercel 環境変数からの baseURL（あれば文字列を返す） */
+function getBaseUrlFromEnv(): string | null {
+  if (process.env.NEXT_PUBLIC_BASE_URL) return process.env.NEXT_PUBLIC_BASE_URL!;
   if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
-  // 3. ローカル/その他（ヘッダから組み立て）
+  return null;
+}
+
+/** Server 環境での Host 取得（RSC/Route/Action いずれでも可） */
+function getServerBaseUrl(): string {
   const h = headers();
   const host = h.get("x-forwarded-host") ?? h.get("host");
   const proto = h.get("x-forwarded-proto") ?? "http";
   return `${proto}://${host}`;
 }
 
-/** 相対/絶対どちらでも渡せる。相対なら base を前置。 */
-export function absUrl(path: string) {
+/** どこからでも使える絶対URL化ヘルパ（Server/Browser 両対応） */
+export function absUrl(path: string): string {
   if (/^https?:\/\//.test(path)) return path;
-  return `${getBaseUrl()}${path.startsWith("/") ? path : `/${path}`}`;
+
+  // 1) まず環境変数/Vercel
+  const envBase = getBaseUrlFromEnv();
+  if (envBase) return `${envBase}${path.startsWith("/") ? path : `/${path}`}`;
+
+  // 2) ブラウザ実行時
+  if (typeof window !== "undefined") {
+    const { protocol, host } = window.location;
+    return `${protocol}//${host}${path.startsWith("/") ? path : `/${path}`}`;
+  }
+
+  // 3) サーバー実行時（RSC/Route/Action）
+  const srvBase = getServerBaseUrl();
+  return `${srvBase}${path.startsWith("/") ? path : `/${path}`}`;
 }


### PR DESCRIPTION
## Summary
- remove the global "use server" directive from the URL helper so exported utilities are not treated as server actions
- add environment-aware logic so `absUrl` works in both browser and server contexts by checking env vars, window, and headers

## Testing
- pnpm --filter web build *(fails: No projects matched the filters)*

------
https://chatgpt.com/codex/tasks/task_e_68d8325c99a8832380e6786f2a908d11