### PR TITLE
Ensure auth cookies and middleware enforce single domain sessions

### DIFF
--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -1,51 +1,66 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import * as jose from 'jose';
 
+const SESSION_COOKIE = process.env.AUTH_COOKIE_NAME ?? 'lab_session';
+const PUBLIC_PATHS = ['/', '/login', '/signup'];
 const PUBLIC_PREFIXES = [
-  '/login',
+  '/api/auth',
   '/api/health',
-  '/api/health/db',
   '/_next',
   '/favicon',
   '/robots',
   '/sitemap',
-  '/',
 ];
+const CANONICAL_HOST = 'labyoyaku.vercel.app';
+const secret = new TextEncoder().encode(process.env.AUTH_SECRET || 'dev-secret');
 
-function isPublic(pathname: string) {
-  return PUBLIC_PREFIXES.some((prefix) => {
-    if (prefix === '/') {
-      return pathname === '/';
-    }
-    return pathname === prefix || pathname.startsWith(prefix);
-  });
+function isPublicPath(pathname: string) {
+  if (PUBLIC_PATHS.includes(pathname)) {
+    return true;
+  }
+  return PUBLIC_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
 }
 
-export function middleware(req: NextRequest) {
-  const { pathname, search } = req.nextUrl;
-  if (isPublic(pathname)) {
+export async function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  if (process.env.NODE_ENV === 'production') {
+    const host = req.headers.get('host');
+    if (host && host !== CANONICAL_HOST) {
+      const url = new URL(req.url);
+      url.host = CANONICAL_HOST;
+      url.protocol = 'https:';
+      return NextResponse.redirect(url);
+    }
+  }
+
+  if (isPublicPath(pathname)) {
     return NextResponse.next();
   }
 
-  const hasSession = !!req.cookies.get('lab_session')?.value;
-
-  const needAuth =
-    pathname.startsWith('/dashboard') ||
-    pathname.startsWith('/groups') ||
-    pathname.startsWith('/devices') ||
-    pathname.startsWith('/account');
-
-  if (!hasSession && needAuth) {
+  const token = req.cookies.get(SESSION_COOKIE)?.value;
+  if (!token) {
     const url = req.nextUrl.clone();
     url.pathname = '/login';
     url.search = '';
-    url.searchParams.set('next', pathname + search);
+    url.searchParams.set('next', pathname + req.nextUrl.search);
     return NextResponse.redirect(url);
   }
 
-  return NextResponse.next();
+  try {
+    await jose.jwtVerify(token, secret);
+    return NextResponse.next();
+  } catch (error) {
+    console.error('[auth] invalid token', error);
+    const url = req.nextUrl.clone();
+    url.pathname = '/login';
+    url.search = '';
+    url.searchParams.set('next', pathname + req.nextUrl.search);
+    return NextResponse.redirect(url);
+  }
 }
 
 export const config = {
-  matcher: ['/((?!api/health).*)'],
+  matcher: ['/((?!_next|favicon.ico|api/health).*)'],
 };

--- a/web/src/lib/auth/cookies.ts
+++ b/web/src/lib/auth/cookies.ts
@@ -1,6 +1,6 @@
 import type { NextResponse } from 'next/server';
 
-const COOKIE_NAME = 'lab_session';
+const COOKIE_NAME = process.env.AUTH_COOKIE_NAME ?? 'lab_session';
 export const AUTH_COOKIE = COOKIE_NAME;
 
 export function setSessionCookie(


### PR DESCRIPTION
## Summary
- allow the session cookie name to be configured via AUTH_COOKIE_NAME to keep cookies scoped per host
- harden the middleware by verifying JWTs, redirecting unauthenticated users with preserved intents, and enforcing the canonical production host

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d836a3e8b08323bb5f2997635c5f5b