### PR TITLE
Add duty management pages and backend APIs

### DIFF
--- a/web/src/app/api/duties/batch/route.ts
+++ b/web/src/app/api/duties/batch/route.ts
@@ -1,0 +1,187 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const runtime = 'nodejs';
+
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { canManageDuties, getActorByEmail } from '@/lib/perm';
+import { z } from 'zod';
+
+const Body = z.object({
+  groupSlug: z.string(),
+  dutyTypeId: z.string(),
+  from: z.string(),
+  to: z.string(),
+  mode: z.enum(['ROUND_ROBIN', 'RANDOM', 'MANUAL']),
+  memberIds: z.union([z.array(z.string()), z.string()]).optional(),
+  weekdays: z.union([z.array(z.string()), z.string()]).optional(),
+});
+
+async function readBody(req: Request) {
+  try {
+    return await req.json();
+  } catch {
+    const formData = await req.formData();
+    const acc: Record<string, any> = {};
+    for (const [key, value] of formData.entries()) {
+      if (key in acc) {
+        acc[key] = Array.isArray(acc[key]) ? [...acc[key], value] : [acc[key], value];
+      } else {
+        acc[key] = value;
+      }
+    }
+    return acc;
+  }
+}
+
+function buildDateList(from: Date, to: Date) {
+  const list: Date[] = [];
+  const cursor = new Date(from);
+  while (cursor.getTime() <= to.getTime()) {
+    list.push(new Date(cursor));
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+  return list;
+}
+
+export async function POST(req: Request) {
+  try {
+    const session = await auth();
+    const email = session?.user?.email ?? null;
+    const me = await getActorByEmail(email ?? undefined);
+    if (!me) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+
+    const raw = await readBody(req);
+    const body = Body.parse(raw);
+
+    const slug = body.groupSlug.toLowerCase();
+    const group = await prisma.group.findUnique({
+      where: { slug },
+      select: { id: true, hostEmail: true, dutyManagePolicy: true },
+    });
+    if (!group) {
+      return NextResponse.json({ error: 'group not found' }, { status: 404 });
+    }
+
+    const membership = await prisma.groupMember.findFirst({
+      where: { groupId: group.id, userId: me.id },
+      select: { role: true },
+    });
+    const normalizedEmail = email?.toLowerCase() ?? '';
+    const role = membership?.role ?? (group.hostEmail?.toLowerCase() === normalizedEmail ? 'OWNER' : null);
+    if (!canManageDuties(group.dutyManagePolicy, role)) {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+    }
+
+    const type = await prisma.dutyType.findFirst({
+      where: { id: body.dutyTypeId, groupId: group.id },
+      select: { id: true },
+    });
+    if (!type) {
+      return NextResponse.json({ error: 'duty type not found' }, { status: 404 });
+    }
+
+    const fromDate = new Date(`${body.from}T00:00:00Z`);
+    const toDate = new Date(`${body.to}T00:00:00Z`);
+    if (Number.isNaN(fromDate.getTime()) || Number.isNaN(toDate.getTime())) {
+      return NextResponse.json({ error: 'invalid date range' }, { status: 400 });
+    }
+    if (fromDate.getTime() > toDate.getTime()) {
+      return NextResponse.json({ error: 'invalid range' }, { status: 400 });
+    }
+
+    const weekdaysRaw = body.weekdays;
+    const weekdayValues = Array.isArray(weekdaysRaw)
+      ? weekdaysRaw
+      : typeof weekdaysRaw === 'string'
+        ? [weekdaysRaw]
+        : [];
+    const weekdaySet = new Set(
+      weekdayValues
+        .map((value) => Number.parseInt(String(value), 10))
+        .filter((value) => Number.isInteger(value) && value >= 0 && value <= 6)
+    );
+
+    const allDates = buildDateList(fromDate, toDate);
+    const targetDates = allDates.filter((date) =>
+      weekdaySet.size > 0 ? weekdaySet.has(date.getUTCDay()) : true
+    );
+
+    if (targetDates.length === 0) {
+      return NextResponse.json({ ok: true, count: 0 });
+    }
+
+    if (body.mode === 'MANUAL') {
+      const result = await prisma.dutyAssignment.createMany({
+        data: targetDates.map((date) => ({
+          groupId: group.id,
+          typeId: type.id,
+          date,
+          slotIndex: 0,
+          assigneeId: null,
+        })),
+        skipDuplicates: true,
+      });
+      return NextResponse.json({ ok: true, count: result.count });
+    }
+
+    const memberValues = Array.isArray(body.memberIds)
+      ? body.memberIds
+      : typeof body.memberIds === 'string'
+        ? [body.memberIds]
+        : [];
+
+    const memberIds = memberValues.map((value) => String(value)).filter(Boolean);
+    if (memberIds.length === 0) {
+      return NextResponse.json({ error: 'members required' }, { status: 400 });
+    }
+
+    const validMembers = await prisma.groupMember.findMany({
+      where: { groupId: group.id, userId: { in: memberIds } },
+      select: { userId: true },
+    });
+    const allowedIds = validMembers.map((member) => member.userId).filter((value): value is string => Boolean(value));
+    const uniqueAllowedIds = Array.from(new Set(allowedIds));
+
+    if (uniqueAllowedIds.length === 0) {
+      return NextResponse.json({ error: 'members required' }, { status: 400 });
+    }
+
+    const picks: { date: Date; assigneeId: string }[] = [];
+    if (body.mode === 'ROUND_ROBIN') {
+      let index = 0;
+      for (const date of targetDates) {
+        const assigneeId = uniqueAllowedIds[index % uniqueAllowedIds.length];
+        picks.push({ date, assigneeId });
+        index += 1;
+      }
+    } else {
+      for (const date of targetDates) {
+        const randomIndex = Math.floor(Math.random() * uniqueAllowedIds.length);
+        picks.push({ date, assigneeId: uniqueAllowedIds[randomIndex] });
+      }
+    }
+
+    const result = await prisma.dutyAssignment.createMany({
+      data: picks.map((item) => ({
+        groupId: group.id,
+        typeId: type.id,
+        date: item.date,
+        slotIndex: 0,
+        assigneeId: item.assigneeId,
+      })),
+      skipDuplicates: true,
+    });
+
+    return NextResponse.json({ ok: true, count: result.count });
+  } catch (error) {
+    console.error('batch create duties failed', error);
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: 'invalid body', details: error.flatten() }, { status: 400 });
+    }
+    return NextResponse.json({ error: 'batch create duties failed' }, { status: 500 });
+  }
+}

--- a/web/src/app/api/duty-types/route.ts
+++ b/web/src/app/api/duty-types/route.ts
@@ -1,0 +1,120 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const runtime = 'nodejs';
+
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { canManageDuties, getActorByEmail } from '@/lib/perm';
+import { z } from 'zod';
+
+const Body = z.object({
+  groupSlug: z.string(),
+  name: z.string().min(1),
+  description: z.string().optional(),
+  color: z.string().optional(),
+});
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const groupSlug = searchParams.get('groupSlug');
+    if (!groupSlug) {
+      return NextResponse.json([]);
+    }
+
+    const slug = groupSlug.toLowerCase();
+    const session = await auth();
+    const email = session?.user?.email ?? null;
+    const me = await getActorByEmail(email ?? undefined);
+    if (!me) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+
+    const group = await prisma.group.findUnique({
+      where: { slug },
+      select: {
+        id: true,
+        hostEmail: true,
+        dutyTypes: { select: { id: true, name: true, color: true, visibility: true, kind: true } },
+        members: { select: { userId: true, email: true } },
+      },
+    });
+
+    if (!group) {
+      return NextResponse.json([]);
+    }
+
+    const normalizedEmail = email?.toLowerCase() ?? '';
+    const isMember =
+      group.hostEmail?.toLowerCase() === normalizedEmail ||
+      group.members.some((member) => member.userId === me.id || member.email.toLowerCase() === normalizedEmail);
+
+    if (!isMember) {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+    }
+
+    return NextResponse.json(group.dutyTypes);
+  } catch (error) {
+    console.error('list duty types failed', error);
+    return NextResponse.json({ error: 'list duty types failed' }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const session = await auth();
+    const email = session?.user?.email ?? null;
+    const me = await getActorByEmail(email ?? undefined);
+    if (!me) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+
+    const raw = await req
+      .json()
+      .catch(async () => Object.fromEntries((await req.formData()).entries()));
+    const body = Body.parse(raw);
+    const slug = body.groupSlug.toLowerCase();
+    const name = body.name.trim();
+    if (!name) {
+      return NextResponse.json({ error: 'name required' }, { status: 400 });
+    }
+
+    const group = await prisma.group.findUnique({
+      where: { slug },
+      select: { id: true, hostEmail: true, dutyManagePolicy: true },
+    });
+
+    if (!group) {
+      return NextResponse.json({ error: 'group not found' }, { status: 404 });
+    }
+
+    const membership = await prisma.groupMember.findFirst({
+      where: { groupId: group.id, userId: me.id },
+      select: { role: true },
+    });
+
+    const normalizedEmail = email?.toLowerCase() ?? '';
+    const role = membership?.role ?? (group.hostEmail?.toLowerCase() === normalizedEmail ? 'OWNER' : null);
+    if (!canManageDuties(group.dutyManagePolicy, role)) {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+    }
+
+    const created = await prisma.dutyType.create({
+      data: {
+        groupId: group.id,
+        name,
+        color: body.color?.trim() ? body.color.trim() : undefined,
+      },
+      select: { id: true, name: true, color: true, visibility: true, kind: true },
+    });
+
+    return NextResponse.json(created, { status: 201 });
+  } catch (error) {
+    console.error('create duty type failed', error);
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: 'invalid body', details: error.flatten() }, { status: 400 });
+    }
+    return NextResponse.json({ error: 'create duty type failed' }, { status: 500 });
+  }
+}

--- a/web/src/app/api/groups/[slug]/members/route.ts
+++ b/web/src/app/api/groups/[slug]/members/route.ts
@@ -1,0 +1,84 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const runtime = 'nodejs';
+
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { getActorByEmail } from '@/lib/perm';
+
+export async function GET(_req: Request, { params }: { params: { slug: string } }) {
+  try {
+    const session = await auth();
+    const email = session?.user?.email ?? null;
+    const me = await getActorByEmail(email ?? undefined);
+    if (!me) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+
+    const slug = params.slug.toLowerCase();
+    const group = await prisma.group.findUnique({
+      where: { slug },
+      select: {
+        id: true,
+        hostEmail: true,
+        members: {
+          select: {
+            userId: true,
+            email: true,
+            user: { select: { id: true, name: true, email: true } },
+          },
+        },
+      },
+    });
+
+    if (!group) {
+      return NextResponse.json({ error: 'group not found' }, { status: 404 });
+    }
+
+    const normalizedEmail = email?.toLowerCase() ?? '';
+    const isMember =
+      group.hostEmail?.toLowerCase() === normalizedEmail ||
+      group.members.some(
+        (member) => member.userId === me.id || member.email.toLowerCase() === normalizedEmail
+      );
+
+    if (!isMember) {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+    }
+
+    const items: { id: string; email: string; displayName: string }[] = [];
+    const append = (id: string | null | undefined, emailValue: string | null | undefined, name?: string | null) => {
+      if (!id || !emailValue) return;
+      const displayName = name?.trim() || emailValue.split('@')[0] || emailValue;
+      if (!items.some((item) => item.id === id)) {
+        items.push({ id, email: emailValue, displayName });
+      }
+    };
+
+    group.members.forEach((member) => {
+      const userId = member.userId ?? member.user?.id ?? null;
+      const userEmail = member.user?.email ?? member.email;
+      append(userId, userEmail, member.user?.name ?? null);
+    });
+
+    if (group.hostEmail) {
+      const hostEmail = group.hostEmail.toLowerCase();
+      const existing = items.some((item) => item.email.toLowerCase() === hostEmail);
+      if (!existing) {
+        const host = await prisma.user.findUnique({
+          where: { email: group.hostEmail },
+          select: { id: true, name: true, email: true },
+        });
+        if (host) {
+          append(host.id, host.email, host.name);
+        }
+      }
+    }
+
+    return NextResponse.json(items);
+  } catch (error) {
+    console.error('list group members failed', error);
+    return NextResponse.json({ error: 'list group members failed' }, { status: 500 });
+  }
+}

--- a/web/src/app/groups/[slug]/day/[date]/page.tsx
+++ b/web/src/app/groups/[slug]/day/[date]/page.tsx
@@ -7,7 +7,6 @@ import Link from 'next/link';
 import { notFound, redirect } from 'next/navigation';
 import { unstable_noStore as noStore } from 'next/cache';
 import { serverFetch } from '@/lib/http/serverFetch';
-import { absUrl } from '@/lib/url';
 import { prisma } from '@/src/lib/prisma';
 import DutyInlineEditor from './DutyInlineEditor';
 import DutyInlineCreate from './DutyInlineCreate';
@@ -39,11 +38,8 @@ function formatTime(value: string) {
 async function fetchDuties(slug: string, date: string) {
   const from = new Date(`${date}T00:00:00Z`).toISOString();
   const to = new Date(`${date}T23:59:59Z`).toISOString();
-  const res = await fetch(
-    absUrl(
-      `/api/duties?groupSlug=${encodeURIComponent(slug)}&from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}&include=type`
-    ),
-    { cache: 'no-store' }
+  const res = await serverFetch(
+    `/api/duties?groupSlug=${encodeURIComponent(slug)}&from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}&include=type`
   );
   if (!res.ok) {
     return [] as any[];

--- a/web/src/app/groups/[slug]/duties/generate/page.tsx
+++ b/web/src/app/groups/[slug]/duties/generate/page.tsx
@@ -1,0 +1,121 @@
+import Link from 'next/link';
+import { serverFetch } from '@/lib/http/serverFetch';
+
+export default async function GenerateDutiesPage({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  const slug = params.slug;
+  const groupRes = await serverFetch(`/api/groups/${encodeURIComponent(slug)}`);
+  if (!groupRes.ok) {
+    return <div className="mx-auto max-w-3xl p-6">権限がありません。</div>;
+  }
+
+  const [typesRes, membersRes] = await Promise.all([
+    serverFetch(`/api/duty-types?groupSlug=${encodeURIComponent(slug)}`),
+    serverFetch(`/api/groups/${encodeURIComponent(slug)}/members`),
+  ]);
+
+  const types = typesRes.ok ? await typesRes.json().catch(() => []) : [];
+  const members = membersRes.ok ? await membersRes.json().catch(() => []) : [];
+
+  return (
+    <div className="mx-auto max-w-3xl p-6 space-y-6">
+      <div>
+        <h1 className="text-xl font-bold">期間でまとめて作成</h1>
+        <p className="text-sm text-gray-600">対象期間とメンバーを選んで一括で割り当てます。</p>
+      </div>
+
+      <form action="/api/duties/batch" method="post" className="space-y-4">
+        <input type="hidden" name="groupSlug" value={slug} />
+
+        <label className="block space-y-1">
+          <span className="text-sm font-medium">種類</span>
+          <select
+            name="dutyTypeId"
+            required
+            defaultValue=""
+            className="w-full rounded border px-3 py-2"
+          >
+            <option value="" disabled hidden>
+              選択してください
+            </option>
+            {Array.isArray(types)
+              ? types.map((type: any) => (
+                  <option key={type.id} value={type.id}>
+                    {type.name ?? '名称未設定'}
+                  </option>
+                ))
+              : null}
+          </select>
+        </label>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="block space-y-1">
+            <span className="text-sm font-medium">開始日</span>
+            <input type="date" name="from" required className="w-full rounded border px-3 py-2" />
+          </label>
+          <label className="block space-y-1">
+            <span className="text-sm font-medium">終了日</span>
+            <input type="date" name="to" required className="w-full rounded border px-3 py-2" />
+          </label>
+        </div>
+
+        <label className="block space-y-1">
+          <span className="text-sm font-medium">方式</span>
+          <select name="mode" required defaultValue="ROUND_ROBIN" className="w-full rounded border px-3 py-2">
+            <option value="ROUND_ROBIN">ラウンドロビン</option>
+            <option value="RANDOM">ランダム</option>
+            <option value="MANUAL">手動（雛形のみ作成）</option>
+          </select>
+        </label>
+
+        <label className="block space-y-1">
+          <span className="text-sm font-medium">対象メンバー（Ctrl/⌘で複数選択）</span>
+          <select
+            name="memberIds"
+            multiple
+            size={6}
+            className="w-full rounded border px-3 py-2"
+          >
+            {Array.isArray(members)
+              ? members
+                  .filter((member: any) => member?.id && member?.email)
+                  .map((member: any) => (
+                    <option key={member.id} value={member.id}>
+                      {member.displayName || member.email}
+                    </option>
+                  ))
+              : null}
+          </select>
+        </label>
+
+        <fieldset className="space-y-2">
+          <legend className="text-sm font-medium">対象曜日（省略時は毎日）</legend>
+          <div className="flex flex-wrap gap-3">
+            {['日', '月', '火', '水', '木', '金', '土'].map((label, index) => (
+              <label key={index} className="flex items-center gap-1 text-sm">
+                <input type="checkbox" name="weekdays" value={index} className="rounded" />
+                {label}
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        <button type="submit" className="rounded bg-purple-600 px-4 py-2 text-white hover:bg-purple-700">
+          プレビュー＆作成
+        </button>
+      </form>
+
+      <p>
+        <Link
+          href={`/groups/${encodeURIComponent(slug)}/duties`}
+          className="text-indigo-600 hover:underline"
+        >
+          ← 戻る
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/web/src/app/groups/[slug]/duties/new-type/page.tsx
+++ b/web/src/app/groups/[slug]/duties/new-type/page.tsx
@@ -1,0 +1,66 @@
+import Link from 'next/link';
+import { serverFetch } from '@/lib/http/serverFetch';
+
+export default async function NewDutyTypePage({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  const groupRes = await serverFetch(`/api/groups/${encodeURIComponent(params.slug)}`);
+  if (!groupRes.ok) {
+    return <div className="mx-auto max-w-2xl p-6">権限がありません。</div>;
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl p-6 space-y-6">
+      <div>
+        <h1 className="text-xl font-bold">当番・作業の種類を追加</h1>
+        <p className="text-sm text-gray-600">グループに新しい当番の種類を追加します。</p>
+      </div>
+
+      <form action="/api/duty-types" method="post" className="space-y-4">
+        <input type="hidden" name="groupSlug" value={params.slug} />
+
+        <label className="block space-y-1">
+          <span className="text-sm font-medium">名称</span>
+          <input
+            name="name"
+            required
+            placeholder="例: 掃除当番"
+            className="w-full rounded border px-3 py-2"
+          />
+        </label>
+
+        <label className="block space-y-1">
+          <span className="text-sm font-medium">説明（任意）</span>
+          <input name="description" className="w-full rounded border px-3 py-2" />
+        </label>
+
+        <label className="block space-y-1">
+          <span className="text-sm font-medium">色（任意）</span>
+          <input
+            name="color"
+            placeholder="#6c5ce7"
+            className="w-full rounded border px-3 py-2"
+          />
+        </label>
+
+        <button
+          type="submit"
+          className="rounded bg-purple-600 px-4 py-2 text-white hover:bg-purple-700"
+        >
+          作成
+        </button>
+      </form>
+
+      <p>
+        <Link
+          href={`/groups/${encodeURIComponent(params.slug)}/duties`}
+          className="text-indigo-600 hover:underline"
+        >
+          ← 戻る
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/web/src/app/groups/[slug]/duties/page.tsx
+++ b/web/src/app/groups/[slug]/duties/page.tsx
@@ -1,8 +1,8 @@
 import Link from 'next/link';
-import { absUrl } from '@/lib/url';
+import { serverFetch } from '@/lib/http/serverFetch';
 
 async function getTypes(slug: string) {
-  const res = await fetch(absUrl(`/api/groups/${encodeURIComponent(slug)}`), { cache: 'no-store' });
+  const res = await serverFetch(`/api/groups/${encodeURIComponent(slug)}`);
   if (!res.ok) {
     return [] as any[];
   }

--- a/web/src/lib/http/serverFetch.ts
+++ b/web/src/lib/http/serverFetch.ts
@@ -1,24 +1,23 @@
 import { headers } from 'next/headers';
 import { absUrl } from '@/lib/url';
 
-export async function serverFetch(path: string, init: RequestInit = {}) {
-  const incomingHeaders = headers();
-  const target = absUrl(path);
-  const cookie = incomingHeaders.get('cookie') ?? '';
+type Init = RequestInit & { next?: { revalidate?: number } };
+
+export async function serverFetch(path: string, init: Init = {}) {
+  const cookie = headers().get('cookie') ?? '';
+  const url = absUrl(path);
 
   const headerBag = new Headers(init.headers ?? undefined);
   if (cookie) {
     headerBag.set('cookie', cookie);
   }
-  headerBag.set('accept', 'application/json');
 
-  const { next, ...rest } = init as RequestInit & { next?: any };
+  const { headers: _headers, ...rest } = init;
 
-  return fetch(target, {
+  return fetch(url, {
     ...rest,
+    headers: headerBag,
     cache: 'no-store',
     credentials: 'include',
-    headers: headerBag,
-    ...(next ? { next } : {}),
   });
 }


### PR DESCRIPTION
## Summary
- ensure server-side fetch utilities forward cookies for internal API calls
- add group duty type creation and bulk generation pages to replace 404s
- expose duty type listing, duty batch creation, and member lookup APIs for the new forms

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d83db03d908323a08171d33aa7c90d