### PR TITLE
Fix OneOrManyStrings schema in duties batch route

### DIFF
--- a/web/src/app/api/duties/batch/route.ts
+++ b/web/src/app/api/duties/batch/route.ts
@@ -9,7 +9,7 @@ import { canManageDuties, getActorByEmail } from '@/lib/perm';
 import { z } from 'zod';
 
 // 単一文字列 or 文字列配列 を同一に扱うためのユーティリティ
-const OneOrManyStrings = z.string().array().or(z.string());
+const OneOrManyStrings = z.string().or(z.array(z.string()));
 
 const Body = z.object({
   groupSlug: z.string(),


### PR DESCRIPTION
## Summary
- replace invalid array() call on z.string() with z.array
- allow body parsing to accept either a single string or array of strings without build errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d844681eb88323a7e394a0311629c0