### PR TITLE
Use namespace import for Zod in duties batch route

### DIFF
--- a/web/src/app/api/duties/batch/route.ts
+++ b/web/src/app/api/duties/batch/route.ts
@@ -6,16 +6,16 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { canManageDuties, getActorByEmail } from '@/lib/perm';
-import { z as zod } from 'zod';
+import * as Z from 'zod';
 
-const Body = zod.object({
-  groupSlug: zod.string(),
-  dutyTypeId: zod.string(),
-  from: zod.string(), // yyyy-mm-dd
-  to: zod.string(),
-  mode: zod.enum(['ROUND_ROBIN', 'RANDOM', 'MANUAL']),
-  memberIds: zod.any().optional(),
-  weekdays: zod.any().optional(),
+const Body = Z.object({
+  groupSlug: Z.string(),
+  dutyTypeId: Z.string(),
+  from: Z.string(), // yyyy-mm-dd
+  to: Z.string(),
+  mode: Z.enum(['ROUND_ROBIN', 'RANDOM', 'MANUAL']),
+  memberIds: Z.unknown().optional(),
+  weekdays: Z.unknown().optional(),
 });
 
 async function readBody(req: Request) {
@@ -179,7 +179,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: true, count: result.count });
   } catch (error) {
     console.error('batch create duties failed', error);
-    if (error instanceof zod.ZodError) {
+    if (error instanceof Z.ZodError) {
       return NextResponse.json({ error: 'invalid body', details: error.flatten() }, { status: 400 });
     }
     return NextResponse.json({ error: 'batch create duties failed' }, { status: 500 });


### PR DESCRIPTION
## Summary
- switch the duties batch handler to import Zod as a namespace to avoid symbol collisions
- relax the request body schema for memberIds and weekdays so manual normalization continues to work
- update the error guard to use the namespace import

## Testing
- `pnpm --filter lab_yoyaku-web lint`


------
https://chatgpt.com/codex/tasks/task_e_68d84ccc113c832393cddcf6db3198cc