### PR TITLE
fix: ensure zod imports resolve to npm package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
       zod:
-        specifier: ^3.23.8
+        specifier: 3.23.8
         version: 3.23.8
     devDependencies:
       '@tailwindcss/postcss':

--- a/web/package.json
+++ b/web/package.json
@@ -19,7 +19,7 @@
     "qrcode": "^1.5.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "zod": "^3.23.8"
+    "zod": "3.23.8"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.13",

--- a/web/src/app/api/duties/batch/route.ts
+++ b/web/src/app/api/duties/batch/route.ts
@@ -6,17 +6,16 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { canManageDuties, getActorByEmail } from '@/lib/perm';
-// npm の zod を“名前空間 import”で固定（衝突予防）
-import * as Z from 'zod';
+import { z } from 'zod';
 
-const Body = Z.object({
-  groupSlug: Z.string(),
-  dutyTypeId: Z.string(),
-  from: Z.string(), // yyyy-mm-dd
-  to: Z.string(),
-  mode: Z.enum(['ROUND_ROBIN', 'RANDOM', 'MANUAL']),
-  memberIds: Z.unknown().optional(),
-  weekdays: Z.unknown().optional(),
+const Body = z.object({
+  groupSlug: z.string(),
+  dutyTypeId: z.string(),
+  from: z.string(), // yyyy-mm-dd
+  to: z.string(),
+  mode: z.enum(['ROUND_ROBIN', 'RANDOM', 'MANUAL']),
+  memberIds: z.unknown().optional(),
+  weekdays: z.unknown().optional(),
 });
 
 async function readBody(req: Request) {
@@ -180,7 +179,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: true, count: result.count });
   } catch (error) {
     console.error('batch create duties failed', error);
-    if (error instanceof Z.ZodError) {
+    if (error instanceof z.ZodError) {
       return NextResponse.json({ error: 'invalid body', details: error.flatten() }, { status: 400 });
     }
     return NextResponse.json({ error: 'batch create duties failed' }, { status: 500 });


### PR DESCRIPTION
## Summary
- update the duty batch API route to import `zod` directly from the npm package
- pin the web workspace's `zod` dependency to version 3.23.8 and sync the lockfile

## Testing
- pnpm install --frozen-lockfile *(fails: registry 403 in the execution environment)*
- pnpm --filter lab_yoyaku-web build *(fails: DATABASE_URL env var missing in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d850456188832388fc62f0e821efff