### PR TITLE
Ensure zod imports resolve through shared shim

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -9,9 +9,9 @@ const nextConfig = {
     domains: ['via.placeholder.com'],
   },
   webpack(config) {
-    config.resolve = config.resolve ?? {}
-    config.resolve.alias = config.resolve.alias ?? {}
-    config.resolve.alias.zod = path.resolve(__dirname, 'src/lib/zod')
+    if (config.resolve?.alias && 'zod' in config.resolve.alias) {
+      delete config.resolve.alias.zod
+    }
     return config
   },
 }

--- a/web/src/app/api/duties/[id]/route.ts
+++ b/web/src/app/api/duties/[id]/route.ts
@@ -6,7 +6,7 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { getActorByEmail, getGroupAndRole, canManageDuties } from '@/lib/perm';
-import { z } from 'zod';
+import { z } from '@/lib/zod-shim';
 
 const Body = z.object({
   assigneeId: z.string().nullable().optional(),

--- a/web/src/app/api/duties/batch/route.ts
+++ b/web/src/app/api/duties/batch/route.ts
@@ -6,7 +6,7 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { canManageDuties, getActorByEmail } from '@/lib/perm';
-import { z } from 'zod';
+import { z } from '@/lib/zod-shim';
 
 const Body = z.object({
   groupSlug: z.string(),

--- a/web/src/app/api/duties/rules/route.ts
+++ b/web/src/app/api/duties/rules/route.ts
@@ -6,7 +6,7 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { getActorByEmail, isAdmin } from '@/lib/perm';
-import { z } from 'zod';
+import { z } from '@/lib/zod-shim';
 
 const Body = z.object({
   typeId: z.string(),

--- a/web/src/app/api/duty-types/route.ts
+++ b/web/src/app/api/duty-types/route.ts
@@ -6,7 +6,7 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { canManageDuties, getActorByEmail } from '@/lib/perm';
-import { z } from 'zod';
+import { z } from '@/lib/zod-shim';
 
 const Body = z.object({
   groupSlug: z.string(),

--- a/web/src/app/api/groups/[slug]/duties/generate/route.ts
+++ b/web/src/app/api/groups/[slug]/duties/generate/route.ts
@@ -7,7 +7,7 @@ import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { getActorByEmail, getGroupAndRole, isAdmin } from '@/lib/perm';
 import { assignMembersToSlots } from '@/utils/duty/assign';
-import { z } from 'zod';
+import { z } from '@/lib/zod-shim';
 
 const Body = z.object({
   from: z.coerce.date(),

--- a/web/src/app/api/groups/[slug]/duties/types/route.ts
+++ b/web/src/app/api/groups/[slug]/duties/types/route.ts
@@ -6,7 +6,7 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { getActorByEmail, getGroupAndRole, isAdmin } from '@/lib/perm';
-import { z } from 'zod';
+import { z } from '@/lib/zod-shim';
 
 const Body = z.object({
   name: z.string().min(1),

--- a/web/src/lib/zod-shim.ts
+++ b/web/src/lib/zod-shim.ts
@@ -1,0 +1,1 @@
+export * from "zod";


### PR DESCRIPTION
## Summary
- add a zod shim module that re-exports zod from web/src/lib
- update duty-related API routes to import zod via the shim
- remove the custom zod webpack alias to avoid resolution conflicts

## Testing
- pnpm --filter lab_yoyaku-web build *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68d851bd39148323bbfe376a95b5bba4