### PR TITLE
Switch batch duties form data loop to forEach

### DIFF
--- a/web/src/app/api/duties/batch/route.ts
+++ b/web/src/app/api/duties/batch/route.ts
@@ -24,13 +24,13 @@ async function readBody(req: Request) {
   } catch {
     const formData = await req.formData();
     const acc: Record<string, any> = {};
-    for (const [key, value] of formData.entries()) {
+    formData.forEach((value, key) => {
       if (key in acc) {
         acc[key] = Array.isArray(acc[key]) ? [...acc[key], value] : [acc[key], value];
       } else {
         acc[key] = value;
       }
-    }
+    });
     return acc;
   }
 }


### PR DESCRIPTION
## Summary
- replace the FormData entries loop in the batch duties API with `formData.forEach`
- preserve the accumulator logic so repeated keys continue to collect array values

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d852f7fd0c8323858919c2a290dc20