### PR TITLE
Fix zod import resolution by using shim

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -9,9 +9,6 @@ const nextConfig = {
     domains: ['via.placeholder.com'],
   },
   webpack(config) {
-    config.resolve = config.resolve ?? {}
-    config.resolve.alias = config.resolve.alias ?? {}
-    config.resolve.alias.zod = path.resolve(__dirname, 'src/lib/zod')
     return config
   },
 }

--- a/web/src/app/api/duties/[id]/route.ts
+++ b/web/src/app/api/duties/[id]/route.ts
@@ -6,7 +6,7 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { getActorByEmail, getGroupAndRole, canManageDuties } from '@/lib/perm';
-import { z } from 'zod';
+import { z } from '@/lib/zod-shim';
 
 const Body = z.object({
   assigneeId: z.string().nullable().optional(),

--- a/web/src/app/api/duties/batch/route.ts
+++ b/web/src/app/api/duties/batch/route.ts
@@ -6,7 +6,7 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { canManageDuties, getActorByEmail } from '@/lib/perm';
-import { z } from 'zod';
+import { z } from '@/lib/zod-shim';
 
 const Body = z.object({
   groupSlug: z.string(),

--- a/web/src/app/api/duties/rules/route.ts
+++ b/web/src/app/api/duties/rules/route.ts
@@ -6,7 +6,7 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { getActorByEmail, isAdmin } from '@/lib/perm';
-import { z } from 'zod';
+import { z } from '@/lib/zod-shim';
 
 const Body = z.object({
   typeId: z.string(),

--- a/web/src/app/api/duty-types/route.ts
+++ b/web/src/app/api/duty-types/route.ts
@@ -6,7 +6,7 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { canManageDuties, getActorByEmail } from '@/lib/perm';
-import { z } from 'zod';
+import { z } from '@/lib/zod-shim';
 
 const Body = z.object({
   groupSlug: z.string(),

--- a/web/src/app/api/groups/[slug]/duties/generate/route.ts
+++ b/web/src/app/api/groups/[slug]/duties/generate/route.ts
@@ -7,7 +7,7 @@ import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { getActorByEmail, getGroupAndRole, isAdmin } from '@/lib/perm';
 import { assignMembersToSlots } from '@/utils/duty/assign';
-import { z } from 'zod';
+import { z } from '@/lib/zod-shim';
 
 const Body = z.object({
   from: z.coerce.date(),

--- a/web/src/app/api/groups/[slug]/duties/types/route.ts
+++ b/web/src/app/api/groups/[slug]/duties/types/route.ts
@@ -6,7 +6,7 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { getActorByEmail, getGroupAndRole, isAdmin } from '@/lib/perm';
-import { z } from 'zod';
+import { z } from '@/lib/zod-shim';
 
 const Body = z.object({
   name: z.string().min(1),

--- a/web/src/lib/zod-shim.ts
+++ b/web/src/lib/zod-shim.ts
@@ -1,0 +1,2 @@
+export * from 'zod';
+export { z } from 'zod'; // いつもの "import { z } from ..." を維持できる


### PR DESCRIPTION
## Summary
- add a zod shim module that re-exports zod and use it everywhere
- update API routes to import zod through the shim
- remove the custom webpack alias for zod

## Testing
- pnpm --filter lab_yoyaku-web build *(fails: missing DATABASE_URL env var during Prisma validation)*

------
https://chatgpt.com/codex/tasks/task_e_68d853e542f48323abfcb0d7b0e3f720