### PR TITLE
Fix duty type creation schema and add duty management forms

### DIFF
--- a/web/src/app/api/duty-types/route.ts
+++ b/web/src/app/api/duty-types/route.ts
@@ -102,9 +102,9 @@ export async function POST(req: Request) {
 
     const created = await prisma.dutyType.create({
       data: {
-        groupId: group.id,
         name,
         color: body.color?.trim() ? body.color.trim() : undefined,
+        group: { connect: { id: group.id } },
       },
       select: { id: true, name: true, color: true, visibility: true, kind: true },
     });

--- a/web/src/app/groups/[slug]/duties/generate/GenerateDutiesForm.tsx
+++ b/web/src/app/groups/[slug]/duties/generate/GenerateDutiesForm.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useEffect, useMemo, useState, FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+
+type DutyType = {
+  id: string;
+  name: string;
+  color?: string | null;
+  kind: 'DAY_SLOT' | 'TIME_RANGE';
+  visibility: 'PUBLIC' | 'MEMBERS_ONLY';
+};
+
+export function GenerateDutiesForm({ slug }: { slug: string }) {
+  const router = useRouter();
+  const [from, setFrom] = useState(() => new Date().toISOString().slice(0, 10));
+  const [to, setTo] = useState(() => new Date().toISOString().slice(0, 10));
+  const [seed, setSeed] = useState<string>('');
+  const [types, setTypes] = useState<DutyType[]>([]);
+  const [selected, setSelected] = useState<Record<string, boolean>>({});
+  const [loadingTypes, setLoadingTypes] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setLoadingTypes(true);
+      try {
+        const response = await fetch(`/api/duty-types?groupSlug=${encodeURIComponent(slug)}`);
+        if (!response.ok) {
+          throw new Error('当番タイプの取得に失敗しました');
+        }
+        const data: DutyType[] = await response.json();
+        if (!cancelled) {
+          setTypes(data);
+          setSelected((prev) => {
+            if (Object.keys(prev).length > 0) return prev;
+            const initial: Record<string, boolean> = {};
+            data.forEach((type) => {
+              initial[type.id] = true;
+            });
+            return initial;
+          });
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : '当番タイプの取得に失敗しました');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingTypes(false);
+        }
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  const selectedIds = useMemo(
+    () => Object.entries(selected).filter(([, value]) => value).map(([key]) => key),
+    [selected],
+  );
+
+  const handleToggle = (id: string) => {
+    setSelected((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      if (!from || !to) {
+        throw new Error('期間を入力してください');
+      }
+      const response = await fetch(`/api/groups/${slug}/duties/generate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          from,
+          to,
+          typeIds: selectedIds.length > 0 ? selectedIds : undefined,
+          seed: seed.trim() ? Number(seed) : undefined,
+        }),
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        throw new Error(data?.error ?? '自動割当に失敗しました');
+      }
+      const data = await response.json();
+      setResult(data?.created ?? 0);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '自動割当に失敗しました');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="space-y-6" onSubmit={handleSubmit}>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-muted-foreground" htmlFor="from">
+            開始日
+          </label>
+          <input
+            id="from"
+            type="date"
+            value={from}
+            onChange={(event) => setFrom(event.target.value)}
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-muted-foreground" htmlFor="to">
+            終了日
+          </label>
+          <input
+            id="to"
+            type="date"
+            value={to}
+            onChange={(event) => setTo(event.target.value)}
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-muted-foreground" htmlFor="seed">
+          シャッフルシード（任意）
+        </label>
+        <input
+          id="seed"
+          type="number"
+          inputMode="numeric"
+          value={seed}
+          onChange={(event) => setSeed(event.target.value)}
+          placeholder="空の場合は現在時刻を使用"
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+        />
+      </div>
+
+      <div className="space-y-3">
+        <p className="text-sm font-medium text-muted-foreground">対象の当番タイプ</p>
+        {loadingTypes ? (
+          <p className="text-sm text-muted-foreground">読み込み中…</p>
+        ) : types.length === 0 ? (
+          <p className="text-sm text-muted-foreground">当番タイプが見つかりません。先に作成してください。</p>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2">
+            {types.map((type) => (
+              <label
+                key={type.id}
+                className="flex items-start gap-3 rounded-md border border-border bg-background p-3 shadow-sm hover:border-primary"
+              >
+                <input
+                  type="checkbox"
+                  className="mt-1 h-4 w-4"
+                  checked={!!selected[type.id]}
+                  onChange={() => handleToggle(type.id)}
+                />
+                <span className="text-sm">
+                  <span className="font-medium">{type.name}</span>
+                  <span className="ml-2 inline-flex items-center rounded-full border px-2 text-xs">
+                    {type.kind === 'DAY_SLOT' ? '日別枠' : '時間帯枠'}
+                  </span>
+                </span>
+              </label>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      {result !== null && !error && (
+        <p className="text-sm text-emerald-600">{result} 件の当番枠を作成・更新しました。</p>
+      )}
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <button
+          type="submit"
+          disabled={submitting || loadingTypes || types.length === 0}
+          className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-70"
+        >
+          {submitting ? '割当中…' : '自動割当を実行'}
+        </button>
+        <button
+          type="button"
+          disabled={submitting}
+          onClick={() => {
+            setFrom(new Date().toISOString().slice(0, 10));
+            setTo(new Date().toISOString().slice(0, 10));
+            setSeed('');
+            setSelected({});
+            setResult(null);
+            setError(null);
+          }}
+          className="text-sm text-muted-foreground underline-offset-4 hover:underline disabled:cursor-not-allowed"
+        >
+          入力内容をリセット
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/web/src/app/groups/[slug]/duties/generate/page.tsx
+++ b/web/src/app/groups/[slug]/duties/generate/page.tsx
@@ -1,12 +1,16 @@
+import { GenerateDutiesForm } from './GenerateDutiesForm';
+
 export default function Page({ params }: { params: { slug: string } }) {
   return (
-    <main className="max-w-3xl mx-auto p-6 space-y-4">
-      <h1 className="text-2xl font-bold">当番の自動割当</h1>
-      <p className="text-sm text-gray-500">グループ: {params.slug}</p>
-      {/* 後でウィザード実装 */}
-      <div className="rounded-lg border p-4 bg-white">
-        ここに「期間」「方式（ラウンドロビン/ランダム/手動）」「対象メンバー/曜日」などを置く予定。
-      </div>
+    <main className="mx-auto flex max-w-4xl flex-col gap-6 p-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-bold">当番の自動割当</h1>
+        <p className="text-sm text-muted-foreground">グループ: {params.slug}</p>
+      </header>
+
+      <section className="rounded-lg border bg-white p-6 shadow-sm">
+        <GenerateDutiesForm slug={params.slug} />
+      </section>
     </main>
   );
 }

--- a/web/src/app/groups/[slug]/duties/new-type/CreateDutyTypeForm.tsx
+++ b/web/src/app/groups/[slug]/duties/new-type/CreateDutyTypeForm.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+
+const VISIBILITY_OPTIONS = [
+  { value: 'PUBLIC', label: 'メンバー以外にも公開' },
+  { value: 'MEMBERS_ONLY', label: 'メンバーにのみ公開' },
+] as const;
+
+const KIND_OPTIONS = [
+  { value: 'DAY_SLOT', label: '日ごとに枠を作成' },
+  { value: 'TIME_RANGE', label: '時間帯で枠を作成' },
+] as const;
+
+type Visibility = (typeof VISIBILITY_OPTIONS)[number]['value'];
+type Kind = (typeof KIND_OPTIONS)[number]['value'];
+
+export function CreateDutyTypeForm({ slug }: { slug: string }) {
+  const router = useRouter();
+  const [name, setName] = useState('');
+  const [color, setColor] = useState('#7c3aed');
+  const [visibility, setVisibility] = useState<Visibility>('PUBLIC');
+  const [kind, setKind] = useState<Kind>('DAY_SLOT');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!name.trim()) {
+      setError('当番タイプ名を入力してください。');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    setSuccess(false);
+
+    try {
+      const response = await fetch(`/api/groups/${slug}/duties/types`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: name.trim(),
+          color: color?.trim() || undefined,
+          visibility,
+          kind,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        throw new Error(data?.error ?? '作成に失敗しました');
+      }
+
+      setSuccess(true);
+      setName('');
+      setColor('#7c3aed');
+      setVisibility('PUBLIC');
+      setKind('DAY_SLOT');
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '作成に失敗しました');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="space-y-6" onSubmit={handleSubmit}>
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-muted-foreground" htmlFor="name">
+          当番タイプ名
+        </label>
+        <input
+          id="name"
+          name="name"
+          required
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+          placeholder="例：朝当番"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-muted-foreground" htmlFor="color">
+          カラー
+        </label>
+        <div className="flex items-center gap-3">
+          <input
+            id="color"
+            name="color"
+            type="color"
+            value={color}
+            onChange={(event) => setColor(event.target.value)}
+            className="h-10 w-16 cursor-pointer rounded border border-input"
+          />
+          <input
+            type="text"
+            value={color}
+            onChange={(event) => setColor(event.target.value)}
+            className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <span className="block text-sm font-medium text-muted-foreground">公開範囲</span>
+        <div className="space-y-1">
+          {VISIBILITY_OPTIONS.map((option) => (
+            <label key={option.value} className="flex items-center gap-2 text-sm">
+              <input
+                type="radio"
+                name="visibility"
+                value={option.value}
+                checked={visibility === option.value}
+                onChange={() => setVisibility(option.value)}
+                className="h-4 w-4"
+              />
+              <span>{option.label}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <span className="block text-sm font-medium text-muted-foreground">当番の作成方式</span>
+        <div className="space-y-1">
+          {KIND_OPTIONS.map((option) => (
+            <label key={option.value} className="flex items-center gap-2 text-sm">
+              <input
+                type="radio"
+                name="kind"
+                value={option.value}
+                checked={kind === option.value}
+                onChange={() => setKind(option.value)}
+                className="h-4 w-4"
+              />
+              <span>{option.label}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      {success && <p className="text-sm text-emerald-600">当番タイプを作成しました。</p>}
+
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-70"
+        >
+          {submitting ? '作成中…' : '当番タイプを作成'}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setName('');
+            setColor('#7c3aed');
+            setVisibility('PUBLIC');
+            setKind('DAY_SLOT');
+            setError(null);
+            setSuccess(false);
+          }}
+          disabled={submitting}
+          className="text-sm text-muted-foreground underline-offset-4 hover:underline disabled:cursor-not-allowed"
+        >
+          入力内容をリセット
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/web/src/app/groups/[slug]/duties/new-type/page.tsx
+++ b/web/src/app/groups/[slug]/duties/new-type/page.tsx
@@ -1,15 +1,23 @@
 import Link from 'next/link';
 
+import { CreateDutyTypeForm } from './CreateDutyTypeForm';
+
 export default function Page({ params }: { params: { slug: string } }) {
   return (
-    <main className="max-w-3xl mx-auto p-6 space-y-4">
-      <h1 className="text-2xl font-bold">当番タイプの追加</h1>
-      <p className="text-sm text-gray-500">グループ: {params.slug}</p>
-      {/* 後でフォーム実装 */}
-      <div className="rounded-lg border p-4 bg-white">
-        ここに「当番タイプ名」「説明」「色」などのフォームを置く予定。
-      </div>
-      <Link href={`/groups/${params.slug}/duties`} className="text-blue-600 underline">
+    <main className="mx-auto flex max-w-3xl flex-col gap-6 p-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-bold">当番タイプの追加</h1>
+        <p className="text-sm text-muted-foreground">グループ: {params.slug}</p>
+      </header>
+
+      <section className="rounded-lg border bg-white p-6 shadow-sm">
+        <CreateDutyTypeForm slug={params.slug} />
+      </section>
+
+      <Link
+        href={`/groups/${params.slug}/duties`}
+        className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+      >
         ← 当番一覧へ戻る
       </Link>
     </main>


### PR DESCRIPTION
## Summary
- update duty type creation APIs to avoid spreading raw request bodies and connect the group relation explicitly
- add a dedicated form UI for creating duty types within a group
- add an auto-assignment form that lets admins choose the window and duty types before calling the generation API

## Testing
- pnpm lint *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8bc726c288323b90ae2dc5100550d