### PR TITLE
Normalize server fetch init handling

### DIFF
--- a/web/src/lib/http/serverFetch.ts
+++ b/web/src/lib/http/serverFetch.ts
@@ -1,7 +1,10 @@
 import { headers } from 'next/headers';
 import { absUrl } from '@/lib/url';
 
-type Init = RequestInit & { next?: { revalidate?: number } };
+export type Init = Omit<RequestInit, 'next'> & {
+  // Next.js の fetch 拡張。false も受け取り、内部で no-store に正規化する
+  next?: { revalidate?: number | false };
+};
 
 export async function serverFetch(path: string, init: Init = {}) {
   const cookie = headers().get('cookie') ?? '';
@@ -13,11 +16,24 @@ export async function serverFetch(path: string, init: Init = {}) {
   }
 
   const { headers: _headers, ...rest } = init;
-
-  return fetch(url, {
+  const opts: RequestInit & { next?: { revalidate?: number } } = {
     ...rest,
     headers: headerBag,
-    cache: 'no-store',
-    credentials: 'include',
-  });
+  };
+
+  // revalidate: false を cache: 'no-store' に変換
+  if (init.next?.revalidate === false) {
+    if (opts.next) delete (opts.next as any).revalidate;
+    if (opts.next && Object.keys(opts.next).length === 0) delete (opts as any).next;
+    (opts as any).cache = 'no-store';
+  }
+
+  // "cache: 'no-store'" と "next.revalidate" の二重指定は片方に統一
+  if (opts.cache === 'no-store' && opts.next?.revalidate !== undefined) {
+    delete (opts as any).next;
+  }
+
+  opts.credentials ??= 'include';
+
+  return fetch(url, opts);
 }

--- a/web/src/lib/server-api.ts
+++ b/web/src/lib/server-api.ts
@@ -2,7 +2,7 @@
 import { headers } from "next/headers";
 import { createApi } from "./api-core";
 import { getBaseUrl } from "@/lib/http/base-url";
-import { serverFetch } from "@/lib/http/serverFetch";
+import { serverFetch, type Init } from "@/lib/http/serverFetch";
 
 function getInit() {
   const cookie = headers().get("cookie");
@@ -13,7 +13,7 @@ function getInit() {
   return {
     headers: headerInit,
     credentials: "include" as RequestCredentials,
-  } satisfies RequestInit;
+  } satisfies Init;
 }
 
 export const {
@@ -31,7 +31,7 @@ export const {
 /** SSR/RSC から自分の API を叩くとき用。Cookie を必ず中継して例外にしない */
 export async function serverGet<T>(
   path: string,
-  init: RequestInit = {}
+  init: Init = {}
 ): Promise<T | null> {
   const res = await serverFetch(path, init);
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- broaden the serverFetch Init type so Next.js revalidate: false is normalized to no-store
- ensure server API helpers share the same Init typing to avoid RequestInit mismatches

## Testing
- pnpm --filter lab_yoyaku-web lint

------
https://chatgpt.com/codex/tasks/task_e_68d8be39d7f48323b4285a2ebdeeb864