### PR TITLE
fix: normalize serverFetch next.revalidate handling

### DIFF
--- a/web/src/lib/http/serverFetch.ts
+++ b/web/src/lib/http/serverFetch.ts
@@ -1,23 +1,42 @@
-import { headers } from 'next/headers';
 import { absUrl } from '@/lib/url';
+import { headers } from 'next/headers';
 
-type Init = RequestInit & { next?: { revalidate?: number } };
+type NextInit = { next?: { revalidate?: number | false } };
+
+// 受け取りは広めに取る（false を許容）
+export type Init = Omit<RequestInit, 'next'> & NextInit;
 
 export async function serverFetch(path: string, init: Init = {}) {
-  const cookie = headers().get('cookie') ?? '';
   const url = absUrl(path);
 
-  const headerBag = new Headers(init.headers ?? undefined);
-  if (cookie) {
-    headerBag.set('cookie', cookie);
-  }
+  // Cookie をサーバからAPIへフォワード（必要なら）
+  const h = headers();
+  const cookie = h.get('cookie') ?? undefined;
 
-  const { headers: _headers, ...rest } = init;
+  const headerBag = new Headers(init.headers as HeadersInit);
+  if (cookie && !headerBag.has('cookie')) headerBag.set('cookie', cookie);
 
-  return fetch(url, {
+  // revalidate 正規化
+  const { headers: _headers, next, ...rest } = init;
+  let normalized: RequestInit & { next?: { revalidate?: number } } = {
     ...rest,
     headers: headerBag,
-    cache: 'no-store',
-    credentials: 'include',
-  });
+  };
+
+  if (next?.revalidate === false) {
+    // false は no-store に変換し、next は付けない
+    normalized.cache = 'no-store';
+  } else if (typeof next?.revalidate === 'number') {
+    normalized.next = { revalidate: next.revalidate };
+  }
+
+  // no-store と next の併用は避ける（優先は no-store）
+  if (normalized.cache === 'no-store' && normalized.next) {
+    delete normalized.next;
+  }
+
+  // 認証クッキーを使う前提なら include で統一
+  if (!normalized.credentials) normalized.credentials = 'include';
+
+  return fetch(url, normalized);
 }


### PR DESCRIPTION
## Summary
- allow serverFetch to accept `next.revalidate` as `number | false` and normalize it into standard `RequestInit`
- forward cookies only when needed and avoid conflicting cache directives while defaulting to `credentials: 'include'`

## Testing
- pnpm build *(fails: Command "build" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8c32817d08323ae502c78023b7ec5