### PR TITLE
Add printable QR card page and branding icon

### DIFF
--- a/web/public/brand/labyoyaku-icon.svg
+++ b/web/public/brand/labyoyaku-icon.svg
@@ -1,0 +1,20 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="512" height="512" rx="112" fill="#7C3AED"/>
+  <rect x="88" y="112" width="336" height="272" rx="52" fill="white"/>
+  <rect x="88" y="176" width="336" height="208" rx="44" fill="#F5F3FF"/>
+  <rect x="132" y="88" width="64" height="96" rx="24" fill="white"/>
+  <rect x="316" y="88" width="64" height="96" rx="24" fill="white"/>
+  <rect x="140" y="224" width="96" height="80" rx="20" fill="white"/>
+  <rect x="236" y="224" width="96" height="80" rx="20" fill="white"/>
+  <rect x="332" y="224" width="96" height="80" rx="20" fill="white"/>
+  <rect x="140" y="312" width="96" height="80" rx="20" fill="white"/>
+  <rect x="236" y="312" width="96" height="80" rx="20" fill="white"/>
+  <rect x="332" y="312" width="96" height="80" rx="20" fill="white"/>
+  <path d="M188 130C188 122.268 194.268 116 202 116H214C221.732 116 228 122.268 228 130V148C228 155.732 221.732 162 214 162H202C194.268 162 188 155.732 188 148V130Z" fill="#7C3AED"/>
+  <path d="M284 130C284 122.268 290.268 116 298 116H310C317.732 116 324 122.268 324 130V148C324 155.732 317.732 162 310 162H298C290.268 162 284 155.732 284 148V130Z" fill="#7C3AED"/>
+  <circle cx="332" cy="352" r="60" fill="#4C1D95"/>
+  <path d="M308.5 352.5L324.2 368.2L355.5 336.9" stroke="white" stroke-width="20" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="256" y="454" text-anchor="middle" fill="white" font-family="'Noto Sans JP', 'Hiragino Sans', 'Yu Gothic', sans-serif" font-size="68" font-weight="700">
+    ラボ予約
+  </text>
+</svg>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -11,3 +11,15 @@
   .btn-danger { @apply bg-rose-600 text-white hover:bg-rose-700 focus-visible:ring-rose-300; }
 }
 
+@media print {
+  @page {
+    size: auto;
+    margin: 10mm;
+  }
+
+  body {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+}
+

--- a/web/src/app/groups/[slug]/devices/[device]/qr/page.tsx
+++ b/web/src/app/groups/[slug]/devices/[device]/qr/page.tsx
@@ -1,0 +1,83 @@
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const runtime = "nodejs";
+
+import PrintableQrCard from "@/components/qr/PrintableQrCard";
+import { serverFetch } from "@/lib/http/serverFetch";
+import { absUrl } from "@/lib/url";
+import { notFound, redirect } from "next/navigation";
+
+type GroupResponse = {
+  group?: { name?: string } | null;
+};
+
+type DeviceResponse = {
+  device?: { name?: string | null; slug: string; groupSlug: string } | null;
+};
+
+async function makeQrDataUrl(value: string) {
+  const QRCode = (await import("qrcode")).default;
+  return QRCode.toDataURL(value, { margin: 1, width: 560 });
+}
+
+function buildLoginRedirect(slug: string, device: string) {
+  const target = `/groups/${encodeURIComponent(slug)}/devices/${encodeURIComponent(device)}/qr`;
+  return `/login?next=${encodeURIComponent(target)}`;
+}
+
+export default async function DeviceQrPage({
+  params,
+}: {
+  params: { slug: string; device: string };
+}) {
+  const { slug, device } = params;
+
+  const groupRes = await serverFetch(`/api/groups/${encodeURIComponent(slug)}`);
+  if (groupRes.status === 401) redirect(buildLoginRedirect(slug, device));
+  if (groupRes.status === 403) redirect(`/groups/join?slug=${encodeURIComponent(slug)}`);
+  if (groupRes.status === 404) return notFound();
+  if (!groupRes.ok) redirect(buildLoginRedirect(slug, device));
+  const groupJson = (await groupRes.json()) as GroupResponse;
+  const groupName = groupJson.group?.name ?? "";
+
+  const deviceRes = await serverFetch(
+    `/api/groups/${encodeURIComponent(slug)}/devices/${encodeURIComponent(device)}`
+  );
+  if (deviceRes.status === 401) redirect(buildLoginRedirect(slug, device));
+  if (deviceRes.status === 403) redirect(`/groups/join?slug=${encodeURIComponent(slug)}`);
+  if (deviceRes.status === 404) return notFound();
+  if (!deviceRes.ok) redirect(buildLoginRedirect(slug, device));
+  const deviceJson = (await deviceRes.json()) as DeviceResponse;
+
+  if (!deviceJson.device) return notFound();
+
+  const title = deviceJson.device.name || "機器";
+  const code = deviceJson.device.slug;
+  const targetUrl = absUrl(
+    `/groups/${encodeURIComponent(slug)}/devices/${encodeURIComponent(device)}`
+  );
+  const qrDataUrl = await makeQrDataUrl(targetUrl);
+
+  return (
+    <div className="mx-auto max-w-3xl p-6 space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold">QRコード（{title}）</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          左にアプリアイコン、右にQRコード、下段に機器名とコード名を表示します。
+        </p>
+      </div>
+
+      <PrintableQrCard
+        iconSrc="/brand/labyoyaku-icon.svg"
+        qrDataUrl={qrDataUrl}
+        title={title}
+        code={code}
+        note={groupName ? `グループ：${groupName}` : undefined}
+      />
+
+      <p className="text-sm text-gray-500">
+        印刷ボタンで紙のカードを出力、PNG保存で画像として共有できます。
+      </p>
+    </div>
+  );
+}

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+import Image from 'next/image';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 import { PASSWORD_HINT, passwordRegex } from '@/utils/password';
@@ -83,7 +84,18 @@ export default function LoginPage() {
 
   return (
     <div className="max-w-6xl mx-auto py-10">
-      <header className="text-center mb-8">
+      <header className="text-center mb-8 space-y-3">
+        <div className="flex items-center justify-center gap-3">
+          <Image
+            src="/brand/labyoyaku-icon.svg"
+            alt="ラボ予約"
+            width={52}
+            height={52}
+            className="rounded-2xl"
+            priority
+          />
+          <span className="text-2xl font-semibold tracking-tight text-gray-900">ラボ予約</span>
+        </div>
         <h1 className="text-3xl font-semibold tracking-tight">Lab Yoyaku へようこそ</h1>
         <p className="text-gray-600 mt-2">研究室の機器をグループで管理し、予約と使用状況をカレンダーで可視化します。</p>
       </header>

--- a/web/src/components/qr/PrintableQrCard.tsx
+++ b/web/src/components/qr/PrintableQrCard.tsx
@@ -1,0 +1,274 @@
+"use client";
+/* eslint-disable @next/next/no-img-element */
+
+import { useCallback, useRef, useState } from "react";
+
+type Props = {
+  iconSrc: string;
+  qrDataUrl: string;
+  title: string;
+  code: string;
+  note?: string;
+  cardWidthPx?: number;
+};
+
+function getSafeFileName(text: string) {
+  return text.replace(/[\\/:*?"<>|]+/g, "_").slice(0, 64) || "qr-card";
+}
+
+function toAbsoluteUrl(src: string) {
+  if (typeof window === "undefined") return src;
+  if (/^data:/i.test(src)) return src;
+  return new URL(src, window.location.href).toString();
+}
+
+function loadImage(src: string) {
+  return new Promise<HTMLImageElement>((resolve, reject) => {
+    const img = new Image();
+    if (!/^data:/i.test(src)) {
+      img.crossOrigin = "anonymous";
+    }
+    img.onload = () => resolve(img);
+    img.onerror = (err) => reject(err);
+    img.src = src;
+  });
+}
+
+function drawRoundedRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number
+) {
+  const r = Math.max(0, Math.min(radius, Math.min(width, height) / 2));
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + width - r, y);
+  ctx.quadraticCurveTo(x + width, y, x + width, y + r);
+  ctx.lineTo(x + width, y + height - r);
+  ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+  ctx.lineTo(x + r, y + height);
+  ctx.quadraticCurveTo(x, y + height, x, y + height - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+}
+
+function getRect(target: HTMLElement, base: DOMRect) {
+  const rect = target.getBoundingClientRect();
+  return {
+    x: rect.left - base.left,
+    y: rect.top - base.top,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
+function parseNumber(value: string | null, fallback: number) {
+  if (!value) return fallback;
+  const parsed = parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export default function PrintableQrCard({
+  iconSrc,
+  qrDataUrl,
+  title,
+  code,
+  note,
+  cardWidthPx = 680,
+}: Props) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [downloading, setDownloading] = useState(false);
+
+  const handleDownload = useCallback(async () => {
+    const card = cardRef.current;
+    if (!card) return;
+    setDownloading(true);
+
+    try {
+      const rect = card.getBoundingClientRect();
+      const scale = Math.max(2, Math.min(3, window.devicePixelRatio || 2));
+      const canvas = document.createElement("canvas");
+      canvas.width = Math.round(rect.width * scale);
+      canvas.height = Math.round(rect.height * scale);
+      const ctx = canvas.getContext("2d");
+      if (!ctx) throw new Error("canvas not supported");
+
+      ctx.scale(scale, scale);
+
+      const computed = window.getComputedStyle(card);
+      const borderRadius = parseNumber(computed.borderTopLeftRadius, 24);
+      const borderWidth = parseNumber(computed.borderTopWidth, 1);
+      const borderColor = computed.borderTopColor || "#e5e7eb";
+      const backgroundColor = computed.backgroundColor || "#ffffff";
+
+      drawRoundedRect(ctx, 0, 0, rect.width, rect.height, borderRadius);
+      ctx.fillStyle = backgroundColor;
+      ctx.fill();
+      if (borderWidth > 0) {
+        ctx.strokeStyle = borderColor;
+        ctx.lineWidth = borderWidth;
+        ctx.stroke();
+      }
+
+      const iconElement = card.querySelector<HTMLElement>("[data-qr-card-icon]");
+      const qrElement = card.querySelector<HTMLElement>("[data-qr-card-code]");
+      const titleElement = card.querySelector<HTMLElement>("[data-qr-card-title]");
+      const codeElement = card.querySelector<HTMLElement>("[data-qr-card-slug]");
+      const noteElement = card.querySelector<HTMLElement>("[data-qr-card-note]");
+      const watermarkElement = card.querySelector<HTMLElement>("[data-qr-card-watermark]");
+
+      const paddingLeft = parseNumber(computed.paddingLeft, 20);
+      const paddingRight = parseNumber(computed.paddingRight, 20);
+
+      if (iconElement) {
+        const iconRect = getRect(iconElement, rect);
+        const icon = await loadImage(toAbsoluteUrl(iconSrc));
+        ctx.drawImage(icon, iconRect.x, iconRect.y, iconRect.width, iconRect.height);
+      }
+
+      if (qrElement) {
+        const qrRect = getRect(qrElement, rect);
+        const qr = await loadImage(toAbsoluteUrl(qrDataUrl));
+        ctx.drawImage(qr, qrRect.x, qrRect.y, qrRect.width, qrRect.height);
+      }
+
+      const maxTextWidth = rect.width - paddingLeft - paddingRight;
+      const drawText = (element: HTMLElement | null) => {
+        if (!element) return;
+        const text = element.textContent?.trim();
+        if (!text) return;
+        const style = window.getComputedStyle(element);
+        const fontSize = parseNumber(style.fontSize, 18);
+        const fontWeight = style.fontWeight || "400";
+        const fontFamily = style.fontFamily || "system-ui, sans-serif";
+        const lineHeightRaw = style.lineHeight === "normal" ? `${fontSize * 1.3}` : style.lineHeight;
+        const lineHeight = parseNumber(lineHeightRaw, fontSize * 1.3);
+        const color = style.color || "#111827";
+        const rectInfo = getRect(element, rect);
+
+        const words = text.split(/\s+/).filter(Boolean);
+        const lines: string[] = [];
+        let current = "";
+
+        const fontValue = `${fontWeight} ${fontSize}px ${fontFamily}`;
+        ctx.font = fontValue;
+        ctx.fillStyle = color;
+        ctx.textAlign = "center";
+        ctx.textBaseline = "top";
+
+        const availableWidth = Math.min(rectInfo.width || maxTextWidth, maxTextWidth);
+
+        if (words.length === 0) {
+          lines.push(text);
+        } else {
+          for (const word of words) {
+            const tentative = current ? `${current} ${word}` : word;
+            const measure = ctx.measureText(tentative);
+            if (measure.width <= availableWidth || !current) {
+              current = tentative;
+            } else {
+              lines.push(current);
+              current = word;
+            }
+          }
+          if (current) lines.push(current);
+        }
+
+        const centerX = rectInfo.x + rectInfo.width / 2;
+        let offsetY = rectInfo.y;
+        lines.forEach((line) => {
+          ctx.fillText(line, centerX, offsetY);
+          offsetY += lineHeight;
+        });
+      };
+
+      drawText(titleElement);
+      drawText(codeElement);
+      drawText(noteElement);
+      drawText(watermarkElement);
+
+      const dataUrl = canvas.toDataURL("image/png");
+      const link = document.createElement("a");
+      link.href = dataUrl;
+      link.download = `${getSafeFileName(title)}.png`;
+      link.click();
+    } catch (error) {
+      console.error("download failed", error);
+    } finally {
+      setDownloading(false);
+    }
+  }, [iconSrc, qrDataUrl, title]);
+
+  return (
+    <div className="space-y-3">
+      <div
+        ref={cardRef}
+        className="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 print:shadow-none"
+        style={{ width: cardWidthPx }}
+      >
+        <div className="grid grid-cols-2 gap-6 items-center" data-qr-card-grid>
+          <div className="flex justify-center">
+            <div className="w-40 h-40 sm:w-48 sm:h-48">
+              <img
+                src={iconSrc}
+                alt="Lab Yoyaku Icon"
+                className="h-full w-full object-contain"
+                data-qr-card-icon
+              />
+            </div>
+          </div>
+
+          <div className="flex justify-center">
+            <img
+              src={qrDataUrl}
+              alt="QR Code"
+              className="w-44 h-44 sm:w-52 sm:h-52"
+              data-qr-card-code
+            />
+          </div>
+        </div>
+
+        <div className="mt-6 text-center space-y-1" data-qr-card-text>
+          <div className="text-xl font-semibold tracking-wide" data-qr-card-title>
+            {title}
+          </div>
+          <div className="text-sm text-gray-500" data-qr-card-slug>
+            {code}
+          </div>
+          {note ? (
+            <div className="text-xs text-gray-400" data-qr-card-note>
+              {note}
+            </div>
+          ) : null}
+        </div>
+
+        <div
+          className="mt-4 text-[11px] text-gray-400 text-center select-none"
+          data-qr-card-watermark
+        >
+          ラボ予約 — Lab Yoyaku
+        </div>
+      </div>
+
+      <div className="flex gap-2 print:hidden">
+        <button
+          className="px-3 py-2 rounded bg-gray-100 hover:bg-gray-200"
+          onClick={() => window.print()}
+        >
+          印刷する
+        </button>
+        <button
+          className="px-3 py-2 rounded bg-blue-600 text-white disabled:opacity-60"
+          onClick={handleDownload}
+          disabled={downloading}
+        >
+          {downloading ? "画像生成中..." : "PNGで保存"}
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable PrintableQrCard component that renders icon + QR + labels and can print or export PNG via canvas
- replace the device QR page with the new card layout and fetch group/device details for labeling
- add the Lab Yoyaku branding icon asset, surface it on the login page, and tweak global print styles

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d93ecb38e083239713987f17688c86