### PR TITLE
Fix device QR route slug handling and date range filtering

### DIFF
--- a/web/src/app/groups/[slug]/day/[date]/page.tsx
+++ b/web/src/app/groups/[slug]/day/[date]/page.tsx
@@ -23,10 +23,21 @@ function isValidDateFormat(value: string) {
   return /^\d{4}-\d{2}-\d{2}$/.test(value);
 }
 
+function getLocalDateBounds(date: string) {
+  const [yearStr, monthStr, dayStr] = date.split("-");
+  const year = Number(yearStr);
+  const month = Number(monthStr) - 1;
+  const day = Number(dayStr);
+  const start = new Date(year, month, day);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(start);
+  end.setDate(end.getDate() + 1);
+  return { start, end };
+}
+
 function toRange(date: string) {
-  const from = new Date(`${date}T00:00:00Z`).toISOString();
-  const to = new Date(`${date}T23:59:59Z`).toISOString();
-  return { from, to };
+  const { start, end } = getLocalDateBounds(date);
+  return { from: start.toISOString(), to: end.toISOString() };
 }
 
 function formatTime(value: string) {
@@ -36,8 +47,9 @@ function formatTime(value: string) {
 }
 
 async function fetchDuties(slug: string, date: string) {
-  const from = new Date(`${date}T00:00:00Z`).toISOString();
-  const to = new Date(`${date}T23:59:59Z`).toISOString();
+  const { start, end } = getLocalDateBounds(date);
+  const from = start.toISOString();
+  const to = end.toISOString();
   const res = await serverFetch(
     `/api/duties?groupSlug=${encodeURIComponent(slug)}&from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}&include=type`
   );

--- a/web/src/app/groups/[slug]/devices/[deviceSlug]/page.tsx
+++ b/web/src/app/groups/[slug]/devices/[deviceSlug]/page.tsx
@@ -46,21 +46,21 @@ export default async function DeviceDetail({
   params,
   searchParams,
 }: {
-  params: { slug: string; device: string };
+  params: { slug: string; deviceSlug: string };
   searchParams: { month?: string };
 }) {
   noStore();
-  const { slug, device } = params;
+  const { slug, deviceSlug } = params;
   const group = slug;
   const user = await getUserFromCookies();
-  if (!user) redirect(`/login?next=/groups/${group}/devices/${device}`);
+  if (!user) redirect(`/login?next=/groups/${group}/devices/${deviceSlug}`);
   const res = await serverFetch(
-    `/api/groups/${encodeURIComponent(group)}/devices/${encodeURIComponent(device)}`
+    `/api/groups/${encodeURIComponent(group)}/devices/${encodeURIComponent(deviceSlug)}`
   );
-  if (res.status === 401) redirect(`/login?next=/groups/${group}/devices/${device}`);
+  if (res.status === 401) redirect(`/login?next=/groups/${group}/devices/${deviceSlug}`);
   if (res.status === 403) redirect(`/groups/join?slug=${encodeURIComponent(group)}`);
   if (res.status === 404) return notFound();
-  if (!res.ok) redirect(`/login?next=/groups/${group}/devices/${device}`);
+  if (!res.ok) redirect(`/login?next=/groups/${group}/devices/${deviceSlug}`);
   const json = await res.json();
   const dev = json?.device;
   const me = user;
@@ -87,13 +87,13 @@ export default async function DeviceDetail({
 
   const query = new URLSearchParams({
     groupSlug: group,
-    deviceSlug: device,
+    deviceSlug: deviceSlug,
     from: rangeStart.toISOString(),
     to: rangeEnd.toISOString(),
   });
   const reservationsRes = await serverFetch(`/api/reservations?${query.toString()}`);
   if (reservationsRes.status === 401) {
-    redirect(`/login?next=/groups/${group}/devices/${device}`);
+    redirect(`/login?next=/groups/${group}/devices/${deviceSlug}`);
   }
   if (reservationsRes.status === 403) {
     redirect(`/groups/join?slug=${encodeURIComponent(group)}`);
@@ -102,7 +102,7 @@ export default async function DeviceDetail({
     return notFound();
   }
   if (!reservationsRes.ok) {
-    redirect(`/login?next=/groups/${group}/devices/${device}`);
+    redirect(`/login?next=/groups/${group}/devices/${deviceSlug}`);
   }
   const reservationsJson = await reservationsRes.json();
   const reservations: ReservationResponse[] = Array.isArray(reservationsJson?.reservations)
@@ -172,7 +172,7 @@ export default async function DeviceDetail({
           <ReservationList items={listItems} />
         </div>
         <Image
-          src={`/api/devices/${encodeURIComponent(device)}/qr`}
+          src={`/api/devices/${encodeURIComponent(deviceSlug)}/qr`}
           alt="QRコード"
           width={128}
           height={128}

--- a/web/src/components/qr/PrintableQrCard.tsx
+++ b/web/src/components/qr/PrintableQrCard.tsx
@@ -236,8 +236,18 @@ export default function PrintableQrCard({
           <div className="text-xl font-semibold tracking-wide" data-qr-card-title>
             {title}
           </div>
-          <div className="text-sm text-gray-500" data-qr-card-slug>
-            {code}
+          <div className="mt-1 flex items-center justify-center gap-2">
+            <code className="text-sm text-gray-700 break-all select-all" data-qr-card-slug>
+              {code}
+            </code>
+            <button
+              type="button"
+              onClick={() => navigator.clipboard?.writeText(code)}
+              className="text-xs px-2 py-1 rounded border bg-gray-50 hover:bg-gray-100"
+              aria-label="コードをコピー"
+            >
+              コピー
+            </button>
           </div>
           {note ? (
             <div className="text-xs text-gray-400" data-qr-card-note>


### PR DESCRIPTION
## Summary
- rename device routes to use `deviceSlug` consistently and refresh the QR page card layout
- let QR card codes wrap, add a copy shortcut, and keep the text available for PNG export
- calculate day reservation ranges from local day bounds to avoid missing same-day bookings

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d97f1383cc83238cbadc78742e72a3