### PR TITLE
Fix QR route and align reservation day range

### DIFF
--- a/web/src/app/groups/[slug]/GroupScreenClient.tsx
+++ b/web/src/app/groups/[slug]/GroupScreenClient.tsx
@@ -161,7 +161,9 @@ export default function GroupScreenClient({
                 }}
                 onShowQR={() => {
                   window.open(
-                    `/api/devices/${encodeURIComponent(d.slug)}/qr`,
+                    `/groups/${encodeURIComponent(group.slug.toLowerCase())}/devices/${encodeURIComponent(
+                      d.slug
+                    )}/qr`,
                     '_blank',
                     'noopener,noreferrer'
                   );

--- a/web/src/app/groups/[slug]/day/[date]/page.tsx
+++ b/web/src/app/groups/[slug]/day/[date]/page.tsx
@@ -23,20 +23,18 @@ function isValidDateFormat(value: string) {
   return /^\d{4}-\d{2}-\d{2}$/.test(value);
 }
 
-function getLocalDateBounds(date: string) {
-  const [yearStr, monthStr, dayStr] = date.split("-");
+function jstRange(date: string) {
+  const [yearStr, monthStr, dayStr] = date.split('-');
   const year = Number(yearStr);
   const month = Number(monthStr) - 1;
   const day = Number(dayStr);
-  const start = new Date(year, month, day);
-  start.setHours(0, 0, 0, 0);
-  const end = new Date(start);
-  end.setDate(end.getDate() + 1);
+  const start = new Date(Date.UTC(year, month, day, -9, 0, 0, 0));
+  const end = new Date(Date.UTC(year, month, day + 1, -9, 0, 0, 0));
   return { start, end };
 }
 
 function toRange(date: string) {
-  const { start, end } = getLocalDateBounds(date);
+  const { start, end } = jstRange(date);
   return { from: start.toISOString(), to: end.toISOString() };
 }
 
@@ -47,7 +45,7 @@ function formatTime(value: string) {
 }
 
 async function fetchDuties(slug: string, date: string) {
-  const { start, end } = getLocalDateBounds(date);
+  const { start, end } = jstRange(date);
   const from = start.toISOString();
   const to = end.toISOString();
   const res = await serverFetch(


### PR DESCRIPTION
## Summary
- ensure the device QR page always loads via the deviceSlug route and renders the printable card with group information
- update device QR actions to open the new route instead of the legacy API endpoint
- calculate calendar day reservation ranges in JST so date clicks consistently show the correct bookings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9835907bc8323a8c60ec272679712