### PR TITLE
Improve QR card, reservations, and duty management UI

### DIFF
--- a/web/src/app/groups/[slug]/devices/[deviceSlug]/qr/page.tsx
+++ b/web/src/app/groups/[slug]/devices/[deviceSlug]/qr/page.tsx
@@ -22,18 +22,27 @@ export default async function DeviceQrPage({
   const targetUrl = absUrl(`/groups/${params.slug}/devices/${params.deviceSlug}`);
   const qrDataUrl = await makeQrDataUrl(targetUrl);
 
+  const deviceCode =
+    device?.code ??
+    device?.shortCode ??
+    device?.deviceCode ??
+    device?.publicCode ??
+    device?.id ??
+    device?.slug ??
+    params.deviceSlug;
+
+  const title = device?.name ?? "機器";
+
   return (
     <div className="mx-auto max-w-3xl p-6">
-      <h1 className="text-xl font-semibold mb-4">
-        QRコード（{device?.name ?? "機器"}）
-      </h1>
+      <h1 className="text-xl font-semibold mb-4">QRコード（{title}）</h1>
 
       <PrintableQrCard
         // SVG/PNG どちらでも：存在する方に合わせて
         iconSrc="/brand/labyoyaku-icon.svg"
         qrDataUrl={qrDataUrl}
-        title={device?.name ?? "機器"}
-        code={device?.slug ?? params.deviceSlug}
+        title={title}
+        code={deviceCode}
         note={group?.name ? `グループ：${group.name}` : undefined}
       />
     </div>

--- a/web/src/app/groups/[slug]/duties/DutiesManager.tsx
+++ b/web/src/app/groups/[slug]/duties/DutiesManager.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import { FormEventHandler, useMemo, useState } from "react";
+
+type DutyTypeOption = { id: string; name: string };
+type MemberOption = { id: string; displayName: string; email?: string };
+
+type Props = {
+  groupSlug: string;
+  dutyTypes: DutyTypeOption[];
+  members: MemberOption[];
+};
+
+const WEEKDAYS = [
+  { value: "0", label: "日" },
+  { value: "1", label: "月" },
+  { value: "2", label: "火" },
+  { value: "3", label: "水" },
+  { value: "4", label: "木" },
+  { value: "5", label: "金" },
+  { value: "6", label: "土" },
+];
+
+type Feedback = { type: "success" | "error"; message: string } | null;
+
+export default function DutiesManager({ groupSlug, dutyTypes, members }: Props) {
+  const [tab, setTab] = useState<"oneoff" | "weekly">("oneoff");
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2">
+        <button
+          type="button"
+          className={`px-3 py-1 rounded ${tab === "oneoff" ? "bg-blue-600 text-white" : "bg-gray-100"}`}
+          onClick={() => setTab("oneoff")}
+        >
+          単発追加
+        </button>
+        <button
+          type="button"
+          className={`px-3 py-1 rounded ${tab === "weekly" ? "bg-blue-600 text-white" : "bg-gray-100"}`}
+          onClick={() => setTab("weekly")}
+        >
+          週次ルール
+        </button>
+      </div>
+
+      {tab === "oneoff" ? (
+        <OneOffForm groupSlug={groupSlug} dutyTypes={dutyTypes} members={members} />
+      ) : (
+        <WeeklyRuleForm groupSlug={groupSlug} dutyTypes={dutyTypes} members={members} />
+      )}
+    </div>
+  );
+}
+
+function FeedbackMessage({ feedback }: { feedback: Feedback }) {
+  if (!feedback) return null;
+  const color = feedback.type === "success" ? "text-green-600" : "text-red-600";
+  return <div className={`text-sm ${color}`}>{feedback.message}</div>;
+}
+
+function OneOffForm({ groupSlug, dutyTypes, members }: Props) {
+  const [dates, setDates] = useState<string[]>([""]);
+  const [submitting, setSubmitting] = useState(false);
+  const [feedback, setFeedback] = useState<Feedback>(null);
+  const hasTypes = dutyTypes.length > 0;
+
+  const addDateField = () => setDates((prev) => [...prev, ""]);
+  const updateDate = (index: number, value: string) => {
+    setDates((prev) => prev.map((item, i) => (i === index ? value : item)));
+  };
+  const removeDate = (index: number) => {
+    setDates((prev) => (prev.length <= 1 ? prev : prev.filter((_, i) => i !== index)));
+  };
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+    if (submitting) return;
+    setSubmitting(true);
+    setFeedback(null);
+
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+    const normalizedDates = dates.map((value) => value.trim()).filter(Boolean);
+    if (normalizedDates.length === 0) {
+      setFeedback({ type: "error", message: "日付を入力してください。" });
+      setSubmitting(false);
+      return;
+    }
+
+    formData.delete("dates");
+    normalizedDates.forEach((value) => {
+      formData.append("dates", value);
+    });
+
+    try {
+      const res = await fetch("/api/duties/batch", {
+        method: "POST",
+        body: formData,
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        const message = typeof json?.error === "string" ? json.error : "登録に失敗しました。";
+        throw new Error(message);
+      }
+      setFeedback({ type: "success", message: "当番を追加しました。" });
+      form.reset();
+      setDates([""]);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "登録に失敗しました。";
+      setFeedback({ type: "error", message });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 border rounded-xl p-4 bg-white shadow-sm">
+      <input type="hidden" name="groupSlug" value={groupSlug} />
+      <div>
+        <label className="block text-sm font-medium text-gray-700">当番種別</label>
+        <select
+          name="dutyTypeId"
+          required
+          defaultValue=""
+          disabled={!hasTypes}
+          className="mt-1 w-full rounded border px-2 py-1 disabled:bg-gray-100 disabled:text-gray-500"
+        >
+          <option value="" disabled>
+            選択してください
+          </option>
+          {dutyTypes.map((type) => (
+            <option key={type.id} value={type.id}>
+              {type.name}
+            </option>
+          ))}
+        </select>
+        {!hasTypes ? (
+          <p className="mt-1 text-xs text-red-600">当番種別を作成すると利用できます。</p>
+        ) : null}
+      </div>
+
+      <div className="space-y-2">
+        <span className="block text-sm font-medium text-gray-700">日付</span>
+        {dates.map((value, index) => (
+          <div key={index} className="flex items-center gap-2">
+            <input
+              type="date"
+              name="dates"
+              value={value}
+              onChange={(event) => updateDate(index, event.target.value)}
+              className="flex-1 rounded border px-2 py-1"
+              required={index === 0}
+            />
+            {dates.length > 1 ? (
+              <button
+                type="button"
+                onClick={() => removeDate(index)}
+                className="px-2 py-1 text-xs rounded border"
+              >
+                削除
+              </button>
+            ) : null}
+          </div>
+        ))}
+        <button type="button" onClick={addDateField} className="text-sm text-blue-600 hover:underline">
+          日付を追加
+        </button>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700">1日の必要枠</label>
+        <input
+          type="number"
+          name="slots"
+          min={1}
+          defaultValue={1}
+          className="mt-1 w-32 rounded border px-2 py-1"
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700">担当者（任意・複数可）</label>
+        <select name="assigneeIds" multiple className="mt-1 w-full rounded border px-2 py-1 h-28">
+          {members.map((member) => (
+            <option key={member.id} value={member.id}>
+              {member.displayName}
+            </option>
+          ))}
+        </select>
+        <p className="mt-1 text-xs text-gray-500">選択された担当者で順番に割り当てられます。</p>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={submitting || !hasTypes}
+          className="px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-60"
+        >
+          {submitting ? "送信中..." : "追加"}
+        </button>
+        <FeedbackMessage feedback={feedback} />
+      </div>
+    </form>
+  );
+}
+
+function WeeklyRuleForm({ groupSlug, dutyTypes, members }: Props) {
+  const [submitting, setSubmitting] = useState(false);
+  const [feedback, setFeedback] = useState<Feedback>(null);
+
+  const hasMembers = members.length > 0;
+  const hasTypes = dutyTypes.length > 0;
+  const sortedMembers = useMemo(
+    () => members.slice().sort((a, b) => a.displayName.localeCompare(b.displayName)),
+    [members],
+  );
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+    if (submitting) return;
+    setSubmitting(true);
+    setFeedback(null);
+
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+
+    try {
+      const res = await fetch("/api/duties/rules", {
+        method: "POST",
+        body: formData,
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        const message = typeof json?.error === "string" ? json.error : "ルールの保存に失敗しました。";
+        throw new Error(message);
+      }
+      setFeedback({ type: "success", message: "ルールを登録しました。" });
+      form.reset();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "ルールの保存に失敗しました。";
+      setFeedback({ type: "error", message });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 border rounded-xl p-4 bg-white shadow-sm">
+      <input type="hidden" name="groupSlug" value={groupSlug} />
+      <div>
+        <label className="block text-sm font-medium text-gray-700">当番種別</label>
+        <select
+          name="typeId"
+          required
+          defaultValue=""
+          disabled={!hasTypes}
+          className="mt-1 w-full rounded border px-2 py-1 disabled:bg-gray-100 disabled:text-gray-500"
+        >
+          <option value="" disabled>
+            選択してください
+          </option>
+          {dutyTypes.map((type) => (
+            <option key={type.id} value={type.id}>
+              {type.name}
+            </option>
+          ))}
+        </select>
+        {!hasTypes ? (
+          <p className="mt-1 text-xs text-red-600">当番種別を作成すると利用できます。</p>
+        ) : null}
+      </div>
+
+      <div>
+        <span className="block text-sm font-medium text-gray-700">曜日</span>
+        <div className="mt-2 flex flex-wrap gap-3">
+          {WEEKDAYS.map((weekday) => (
+            <label key={weekday.value} className="inline-flex items-center gap-1 text-sm">
+              <input type="checkbox" name="byWeekday" value={weekday.value} />
+              <span>{weekday.label}</span>
+            </label>
+          ))}
+        </div>
+        <p className="mt-1 text-xs text-gray-500">チェックした曜日に当番枠を作成します。</p>
+      </div>
+
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <div className="flex-1">
+          <label className="block text-sm font-medium text-gray-700">開始日</label>
+          <input type="date" name="startDate" required className="mt-1 w-full rounded border px-2 py-1" />
+        </div>
+        <div className="flex-1">
+          <label className="block text-sm font-medium text-gray-700">終了日</label>
+          <input type="date" name="endDate" required className="mt-1 w-full rounded border px-2 py-1" />
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700">1日の必要枠</label>
+        <input
+          type="number"
+          name="slotsPerDay"
+          min={1}
+          defaultValue={1}
+          className="mt-1 w-32 rounded border px-2 py-1"
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700">担当者プール（任意）</label>
+        <select name="includeMemberIds" multiple className="mt-1 w-full rounded border px-2 py-1 h-28">
+          {sortedMembers.map((member) => (
+            <option key={member.id} value={member.id}>
+              {member.displayName}
+            </option>
+          ))}
+        </select>
+        {!hasMembers ? (
+          <p className="mt-1 text-xs text-gray-500">利用できるメンバーがまだ登録されていません。</p>
+        ) : (
+          <p className="mt-1 text-xs text-gray-500">選択したメンバーの中から割当対象になります。</p>
+        )}
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700">除外するメンバー（任意）</label>
+        <select name="excludeMemberIds" multiple className="mt-1 w-full rounded border px-2 py-1 h-28">
+          {sortedMembers.map((member) => (
+            <option key={member.id} value={member.id}>
+              {member.displayName}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={submitting || !hasTypes}
+          className="px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-60"
+        >
+          {submitting ? "送信中..." : "ルール追加"}
+        </button>
+        <FeedbackMessage feedback={feedback} />
+      </div>
+    </form>
+  );
+}

--- a/web/src/app/groups/[slug]/duties/page.tsx
+++ b/web/src/app/groups/[slug]/duties/page.tsx
@@ -1,21 +1,55 @@
 import Link from 'next/link';
 import { serverFetch } from '@/lib/http/serverFetch';
+import DutiesManager from './DutiesManager';
 
-async function getTypes(slug: string) {
-  const res = await serverFetch(`/api/groups/${encodeURIComponent(slug)}`);
-  if (!res.ok) {
-    return [] as any[];
+type DutyTypeSummary = { id: string; name: string };
+type MemberSummary = { id: string; displayName: string; email?: string };
+
+async function fetchDutyTypes(slug: string): Promise<DutyTypeSummary[]> {
+  try {
+    const res = await serverFetch(`/api/groups/${encodeURIComponent(slug)}`);
+    if (!res.ok) {
+      return [];
+    }
+    const json = await res.json().catch(() => ({} as any));
+    const data = (json?.group ?? json?.data) as any;
+    if (!data?.dutyTypes) return [];
+    return (Array.isArray(data.dutyTypes) ? data.dutyTypes : [])
+      .map((type: any) => ({ id: type.id ?? '', name: type.name ?? '名称未設定' }))
+      .filter((type) => type.id);
+  } catch {
+    return [];
   }
-  const json = await res.json().catch(() => ({} as any));
-  const data = (json?.group ?? json?.data) as any;
-  if (!data) return [];
-  return Array.isArray(data.dutyTypes) ? data.dutyTypes : [];
+}
+
+async function fetchMembers(slug: string): Promise<MemberSummary[]> {
+  try {
+    const res = await serverFetch(`/api/groups/${encodeURIComponent(slug)}/members`);
+    if (!res.ok) {
+      return [];
+    }
+    const json = await res.json().catch(() => [] as any[]);
+    if (!Array.isArray(json)) return [];
+    return json
+      .map((item: any) => ({
+        id: item.id ?? '',
+        displayName: item.displayName ?? item.email ?? '',
+        email: item.email ?? undefined,
+      }))
+      .filter((item) => item.id && item.displayName);
+  } catch {
+    return [];
+  }
 }
 
 export default async function DutiesPage({ params }: { params: { slug: string } }) {
-  const types = await getTypes(params.slug);
+  const [types, members] = await Promise.all([
+    fetchDutyTypes(params.slug),
+    fetchMembers(params.slug),
+  ]);
+
   return (
-    <div className="mx-auto max-w-5xl p-6 space-y-4">
+    <div className="mx-auto max-w-5xl p-6 space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-bold">当番・作業</h1>
         <div className="flex gap-2">
@@ -34,15 +68,19 @@ export default async function DutiesPage({ params }: { params: { slug: string } 
         </div>
       </div>
 
-      <p className="text-sm text-gray-600">
-        種類:{' '}
-        {types.length
-          ? types
-              .map((t: any) => `${t.name ?? '名称未設定'}(${t.kind ?? 'DAY_SLOT'})`)
-              .join(', ')
-          : '未作成'}
-      </p>
-      <p className="text-gray-500">※まず「当番の種類」を作成 → 「期間生成」で自動割当できます。</p>
+      <div className="space-y-2 text-sm text-gray-600">
+        <p>
+          種類:{' '}
+          {types.length
+            ? types.map((type) => type.name).join(', ')
+            : '未作成'}
+        </p>
+        <p className="text-gray-500">
+          単発追加と週次ルールを使って、当番枠をまとめて登録できます。
+        </p>
+      </div>
+
+      <DutiesManager groupSlug={params.slug} dutyTypes={types} members={members} />
     </div>
   );
 }

--- a/web/src/app/groups/[slug]/reservations/[date]/page.tsx
+++ b/web/src/app/groups/[slug]/reservations/[date]/page.tsx
@@ -1,0 +1,102 @@
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const runtime = "nodejs";
+
+import { absUrl } from "@/lib/url";
+
+type ReservationRecord = {
+  id: string;
+  deviceName?: string | null;
+  device?: { name?: string | null } | null;
+  deviceId?: string | null;
+  deviceSlug?: string | null;
+  start?: string;
+  end?: string;
+  startAt?: string;
+  endAt?: string;
+  startsAt?: string;
+  endsAt?: string;
+  note?: string | null;
+  purpose?: string | null;
+};
+
+function formatDateTime(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+export default async function GroupReservationDayPage({
+  params,
+}: {
+  params: { slug: string; date: string };
+}) {
+  const { slug, date } = params;
+  const detectedTz = (() => {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone;
+    } catch {
+      return undefined;
+    }
+  })();
+  const tz = detectedTz || "Asia/Tokyo";
+  const query = new URLSearchParams({
+    group: slug,
+    from: date,
+    tz,
+  });
+  const url = absUrl(`/api/reservations?${query.toString()}`);
+  const res = await fetch(url, { cache: "no-store" });
+  if (!res.ok) {
+    throw new Error("予約情報を取得できませんでした。");
+  }
+  const payload = await res.json().catch(() => ({}));
+  const source = Array.isArray(payload?.data)
+    ? (payload.data as ReservationRecord[])
+    : Array.isArray(payload?.reservations)
+      ? (payload.reservations as ReservationRecord[])
+      : [];
+
+  const reservations = source
+    .map((item) => {
+      const start = item.startAt ?? item.startsAt ?? item.start ?? "";
+      const end = item.endAt ?? item.endsAt ?? item.end ?? "";
+      const deviceName =
+        item.deviceName ??
+        item.device?.name ??
+        item.deviceId ??
+        item.deviceSlug ??
+        "";
+      return {
+        id: item.id,
+        deviceName,
+        start,
+        end,
+        note: item.note ?? item.purpose ?? null,
+      };
+    })
+    .filter((item) => item.id && item.deviceName && item.start && item.end);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-lg font-semibold">{date} の予約</h1>
+      {reservations.length ? (
+        <ul className="mt-3 space-y-2">
+          {reservations.map((reservation) => (
+            <li key={reservation.id} className="rounded border p-2 text-sm">
+              <div className="font-medium">{reservation.deviceName}</div>
+              <div className="text-gray-600">
+                {formatDateTime(reservation.start)} – {formatDateTime(reservation.end)}
+              </div>
+              {reservation.note ? (
+                <div className="text-gray-500">{reservation.note}</div>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="mt-3 text-gray-500">この日に該当する予約はありません。</div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- prioritize device codes in the QR detail view and enhance the printable card with a resilient copy button
- adjust the reservations API to fetch by local day overlaps and add a simple day listing page
- add tabbed duty forms for one-off slots and weekly rules while expanding duty APIs to accept the new payloads

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68da07022af083239e623a383748f0ff