### PR TITLE
Fix bcrypt usage and align user password hash field

### DIFF
--- a/web/src/app/api/auth/login/route.ts
+++ b/web/src/app/api/auth/login/route.ts
@@ -38,7 +38,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'INVALID_LOGIN' }, { status: 401 });
   }
 
-  const storedHash = user.passHash ?? '';
+  const storedHash = user.passwordHash ?? (user as any).passHash ?? '';
   let ok = false;
   if (storedHash.startsWith('$2')) {
     try {

--- a/web/src/app/api/auth/register/route.ts
+++ b/web/src/app/api/auth/register/route.ts
@@ -32,12 +32,16 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok:false, error:'email already registered' }, { status:409 });
   }
 
+  const rounds = Number(process.env.BCRYPT_ROUNDS ?? 10);
+  const salt = await bcrypt.genSalt(rounds);
+  const passwordHash = await bcrypt.hash(normalizedPassword, salt);
+
   let user: UserRecord;
   user = {
     id: uid(),
     email: normalizedEmail,
     name: name ? String(name) : normalizedEmail.split('@')[0],
-    passHash: await bcrypt.hash(normalizedPassword, 10),
+    passwordHash,
   };
   await saveUser(user);
 

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -16,7 +16,7 @@ let db: any = null;
 //     id TEXT PRIMARY KEY,
 //     email TEXT UNIQUE NOT NULL,
 //     name TEXT,
-//     passHash TEXT NOT NULL
+//     passwordHash TEXT NOT NULL
 //   )`);
 // } catch (err) {
 //   console.warn('Failed to load better-sqlite3, using in-memory DB');
@@ -25,7 +25,7 @@ let db: any = null;
 
 export async function loadUsers(): Promise<UserRecord[]> {
   if (db) {
-    return db.prepare('SELECT id, email, name, passHash FROM users').all() as UserRecord[];
+    return db.prepare('SELECT id, email, name, passwordHash FROM users').all() as UserRecord[];
   }
   return loadDB().users;
 }
@@ -33,8 +33,8 @@ export async function loadUsers(): Promise<UserRecord[]> {
 export async function saveUser(user: UserRecord): Promise<void> {
   if (db) {
     db
-      .prepare('INSERT INTO users (id, email, name, passHash) VALUES (?, ?, ?, ?)')
-      .run(user.id, user.email, user.name, user.passHash);
+      .prepare('INSERT INTO users (id, email, name, passwordHash) VALUES (?, ?, ?, ?)')
+      .run(user.id, user.email, user.name, user.passwordHash);
   } else {
     const dbData = loadDB();
     dbData.users.push(user);

--- a/web/src/lib/mockdb.ts
+++ b/web/src/lib/mockdb.ts
@@ -25,7 +25,7 @@ export type UserRecord = {
   id: string;
   email: string;
   name?: string;
-  passHash: string; // sha256
+  passwordHash: string; // bcrypt (or legacy sha256)
 };
 
 type DB = { groups: Group[]; users: UserRecord[] };


### PR DESCRIPTION
## Summary
- generate salts with bcrypt.genSalt using configurable rounds before hashing passwords during registration
- rename the user password field to passwordHash throughout the data layer for consistency
- ensure login reads the unified passwordHash field while tolerating legacy data

## Testing
- pnpm --filter web lint
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dd3cbc778083239ebf83dc96ee2715