### PR TITLE
Fix reservation API field names to match Prisma schema

### DIFF
--- a/web/src/app/api/groups/[slug]/reservations/route.ts
+++ b/web/src/app/api/groups/[slug]/reservations/route.ts
@@ -56,14 +56,15 @@ export async function GET(
   const rows = await prisma.reservation.findMany({
     where: {
       groupId: group.id,
-      NOT: [{ endAt: { lte: start } }],
-      AND: [{ startAt: { lt: end } }],
+      // [範囲が重なっている] 条件
+      NOT: [{ end: { lte: start } }],
+      AND: [{ start: { lt: end } }],
     },
-    orderBy: { startAt: "asc" },
+    orderBy: { start: "asc" },
     select: {
       id: true,
-      startAt: true,
-      endAt: true,
+      start: true,
+      end: true,
       device: { select: { name: true, slug: true } },
       note: true,
     },

--- a/web/src/app/api/reservations/route.ts
+++ b/web/src/app/api/reservations/route.ts
@@ -77,8 +77,8 @@ export async function POST(req: Request) {
       data: {
         groupId: group.id,
         deviceId,
-        startAt: new Date(startIso),
-        endAt: new Date(endIso),
+        start: new Date(startIso),
+        end: new Date(endIso),
         note: body.note ?? "",
       },
       select: { id: true },


### PR DESCRIPTION
## Summary
- align reservation query filters with Prisma field names `start` and `end`
- update reservation creation API to write `start`/`end` fields instead of `startAt`/`endAt`

## Testing
- `pnpm --filter web lint` *(fails: pnpm not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5c33a1cc8323963c5e510b902cdc