### PR TITLE
Fix reservation query and response format

### DIFF
--- a/web/src/app/api/groups/[slug]/reservations/route.ts
+++ b/web/src/app/api/groups/[slug]/reservations/route.ts
@@ -55,7 +55,8 @@ export async function GET(
 
   const rows = await prisma.reservation.findMany({
     where: {
-      groupId: group.id,
+      // リレーション経由でグループを絞る（groupId は存在しない）
+      group: { id: group.id },
       // [範囲が重なっている] 条件
       NOT: [{ end: { lte: start } }],
       AND: [{ start: { lt: end } }],
@@ -70,5 +71,14 @@ export async function GET(
     },
   });
 
-  return NextResponse.json({ data: rows });
+  // FE は startAt / endAt を想定しているのでキーを揃えて返す
+  const data = rows.map((r) => ({
+    id: r.id,
+    device: r.device,
+    note: r.note,
+    startAt: r.start,
+    endAt: r.end,
+  }));
+
+  return NextResponse.json({ data });
 }


### PR DESCRIPTION
## Summary
- filter reservations by related group instead of non-existent groupId field
- normalize reservation response keys to startAt/endAt for frontend compatibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd5e56b22c8323a20f4a40eec38318