### PR TITLE
Fix reservation query filtering and error display

### DIFF
--- a/web/src/app/api/groups/[slug]/reservations/route.ts
+++ b/web/src/app/api/groups/[slug]/reservations/route.ts
@@ -55,11 +55,10 @@ export async function GET(
 
   const rows = await prisma.reservation.findMany({
     where: {
-      // リレーション経由でグループを絞る（groupId は存在しない）
-      group: { id: group.id },
-      // [範囲が重なっている] 条件
-      NOT: [{ end: { lte: start } }],
-      AND: [{ start: { lt: end } }],
+      // Device -> Group で絞る
+      device: { group: { id: group.id } },
+      // 期間が重なるレコードのみ
+      AND: [{ start: { lt: end } }, { end: { gt: start } }],
     },
     orderBy: { start: "asc" },
     select: {
@@ -71,11 +70,11 @@ export async function GET(
     },
   });
 
-  // FE は startAt / endAt を想定しているのでキーを揃えて返す
+  // FE が startAt / endAt を見る前提ならキーを合わせて返す
   const data = rows.map((r) => ({
     id: r.id,
     device: r.device,
-    note: r.note,
+    note: r.note ?? null,
     startAt: r.start,
     endAt: r.end,
   }));

--- a/web/src/app/groups/[slug]/day/[date]/InlineReservationForm.tsx
+++ b/web/src/app/groups/[slug]/day/[date]/InlineReservationForm.tsx
@@ -44,7 +44,13 @@ export default function InlineReservationForm({ slug, date, devices }: Props) {
       }
       router.refresh();
     } catch (error) {
-      alert(`作成失敗: ${(error as Error).message}`);
+      const msg =
+        (error &&
+          typeof error === 'object' &&
+          'message' in error &&
+          (error as any).message) ||
+        (typeof error === 'string' ? error : '');
+      alert(`作成失敗: ${msg || '不明なエラー'}`);
     } finally {
       setSaving(false);
     }


### PR DESCRIPTION
## Summary
- filter group reservation lookups through the device relation and return start/end fields as startAt/endAt
- normalise null notes in reservation responses for the daily group view
- improve inline reservation form error handling to surface readable messages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd608137888323ae0d5d43a673b9a3