### PR TITLE
Fix bcrypt rounds parsing for group and auth routes

### DIFF
--- a/web/src/app/api/auth/register/route.ts
+++ b/web/src/app/api/auth/register/route.ts
@@ -32,7 +32,8 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok:false, error:'email already registered' }, { status:409 });
   }
 
-  const rounds = Number(process.env.BCRYPT_ROUNDS ?? 10);
+  const roundsRaw = parseInt(process.env.BCRYPT_ROUNDS ?? '10', 10);
+  const rounds = Number.isNaN(roundsRaw) ? 10 : roundsRaw;
   const salt = await bcrypt.genSalt(rounds);
   const passwordHash = await bcrypt.hash(normalizedPassword, salt);
 

--- a/web/src/app/api/groups/route.ts
+++ b/web/src/app/api/groups/route.ts
@@ -95,7 +95,8 @@ export async function POST(req: Request) {
     const passwordRaw = String((body as any).password || '').trim()
     let passcode: string | null = null
     if (passwordRaw) {
-      const rounds = Number(process.env.BCRYPT_ROUNDS ?? 10)
+      const roundsRaw = parseInt(process.env.BCRYPT_ROUNDS ?? '10', 10)
+      const rounds = Number.isNaN(roundsRaw) ? 10 : roundsRaw
       passcode = await bcrypt.hash(passwordRaw, rounds)
     }
     const reserveFrom = parseDate((body as any).startAt)


### PR DESCRIPTION
## Summary
- parse the `BCRYPT_ROUNDS` environment variable as a base-10 integer with a safe fallback
- ensure group creation and auth registration routes hash passwords using validated bcryptjs rounds

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dd634d238c83239f8135a47fa71ea3