### PR TITLE
Allow numeric salt rounds in bcrypt type definition

### DIFF
--- a/web/src/types/bcryptjs.d.ts
+++ b/web/src/types/bcryptjs.d.ts
@@ -1,6 +1,6 @@
 declare module "bcryptjs" {
   export function genSalt(rounds?: number): Promise<string>;
-  export function hash(plain: string, salt: string): Promise<string>;
+  export function hash(plain: string, salt: string | number): Promise<string>;
   export function compare(plain: string, hash: string): Promise<boolean>;
   const _default: {
     genSalt: typeof genSalt;


### PR DESCRIPTION
## Summary
- allow the bcrypt `hash` type definition to accept either string or numeric salt rounds
- keep the default export aligned with the updated `hash` signature

## Testing
- `pnpm --filter lab_yoyaku-web build` *(fails: Prisma requires DATABASE_URL environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68dd651ad790832388e1a7c845a0e1a5