### PR TITLE
Fix reservation creation schema

### DIFF
--- a/web/src/app/api/reservations/route.ts
+++ b/web/src/app/api/reservations/route.ts
@@ -3,14 +3,15 @@ import { z } from "@/lib/zod-helpers";
 import { prisma } from "@/src/lib/prisma";
 import { normalizeSlugInput } from "@/lib/slug";
 
-const Body = z.object({
-  groupSlug: z.string(),
-  deviceId: z.string().optional(),
-  deviceSlug: z.string().optional(),
-  start: z.string(),
-  end: z.string(),
-  note: z.string().optional(),
-});
+const Body = z
+  .object({
+    groupSlug: z.string(),
+    deviceId: z.string().optional(),
+    deviceSlug: z.string().optional(),
+    start: z.string(),
+    end: z.string(),
+  })
+  .strip();
 
 function parseFlexibleDate(input: string): Date {
   const trimmed = (input ?? "").trim();
@@ -87,7 +88,6 @@ export async function POST(req: Request) {
         deviceId,
         start: new Date(startIso),
         end: new Date(endIso),
-        note: body.note ?? "",
       },
       select: { id: true },
     });


### PR DESCRIPTION
## Summary
- remove the unused `note` field from the reservation creation payload
- strip unexpected fields during request body validation to prevent type errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd699222848323b7c5b1f312207765