### PR TITLE
Fix reservation creation by persisting user email

### DIFF
--- a/web/src/app/api/reservations/route.ts
+++ b/web/src/app/api/reservations/route.ts
@@ -1,19 +1,19 @@
 import { NextResponse } from "next/server";
+import { cookies, headers as nextHeaders } from "next/headers";
+import { decodeJwt } from "jose";
 import { z } from "@/lib/zod-shim";
 import { prisma } from "@/lib/prisma";
 
 const Body = z.object({
   groupSlug: z.string().min(1),
-  // どちらかが来る想定。どちらも来たら deviceId を優先
   deviceId: z.string().optional(),
   deviceSlug: z.string().optional(),
-  start: z.string().min(1), // ISO or YYYY-MM-DD HH:mm
+  start: z.string().min(1),
   end: z.string().min(1),
 });
 
 function parseFlexibleDate(input: string): Date {
   const s = (input ?? "").trim();
-  // Date コンストラクタで素直に解釈（API 側は UTC/ISO を前提）
   const d = new Date(s);
   if (isNaN(d.getTime())) {
     throw new Error(`Invalid date: ${input}`);
@@ -21,11 +21,73 @@ function parseFlexibleDate(input: string): Date {
   return d;
 }
 
+/**
+ * できるだけ既存の仕組みに寄せて、複数の取り出し口から userEmail を取得
+ * - ヘッダ: x-user-email
+ * - Cookie: userEmail / email
+ * - Cookie の JWT: auth, auth_token, token, session, id_token, access_token, ly_session, lab_session, lab_auth
+ */
+function getUserEmailFromRequest(): string | null {
+  try {
+    const h = nextHeaders();
+    const fromHeader = h.get("x-user-email") ?? h.get("x-user");
+    if (fromHeader) return fromHeader;
+  } catch {}
+
+  try {
+    const c = cookies();
+    const direct =
+      c.get("userEmail")?.value ?? c.get("email")?.value ?? null;
+    if (direct) return direct;
+
+    const jwtCookieKeys = [
+      "auth",
+      "auth_token",
+      "token",
+      "session",
+      "id_token",
+      "access_token",
+      "ly_session",
+      "lab_session",
+      "lab_auth",
+    ];
+
+    for (const key of jwtCookieKeys) {
+      const v = c.get(key)?.value;
+      if (!v) continue;
+      try {
+        const payload: any = decodeJwt(v);
+        const email =
+          typeof payload?.email === "string"
+            ? payload.email
+            : typeof payload?.sub === "string" && payload.sub.includes("@")
+            ? payload.sub
+            : null;
+        if (email) return email;
+      } catch {
+        // デコード失敗は無視して次へ
+      }
+    }
+  } catch {}
+
+  return null;
+}
+
 export async function POST(req: Request) {
   try {
     const raw = await req.json();
     const body = Body.parse(raw);
 
+    // 必須: userEmail を取得（ReservationCreateInput で required）
+    const userEmail = getUserEmailFromRequest();
+    if (!userEmail) {
+      return NextResponse.json(
+        { error: "ログイン情報を取得できません（userEmail 不在）" },
+        { status: 401 }
+      );
+    }
+
+    // グループ解決
     const group = await prisma.group.findUnique({
       where: { slug: body.groupSlug },
       select: { id: true },
@@ -34,7 +96,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "グループが見つかりません" }, { status: 404 });
     }
 
-    // デバイス特定（id or slug）＋同一グループ所属チェック
+    // デバイス特定（id / slug 両対応）＋ グループ所属チェック
     const device = await prisma.device.findFirst({
       where: {
         AND: [
@@ -46,16 +108,22 @@ export async function POST(req: Request) {
       select: { id: true },
     });
     if (!device) {
-      return NextResponse.json({ error: "デバイスが見つからないか、グループ外です" }, { status: 400 });
+      return NextResponse.json(
+        { error: "デバイスが見つからないか、指定グループ外です" },
+        { status: 400 }
+      );
     }
 
     const startAt = parseFlexibleDate(body.start);
     const endAt = parseFlexibleDate(body.end);
     if (!(startAt < endAt)) {
-      return NextResponse.json({ error: "開始は終了より前である必要があります" }, { status: 400 });
+      return NextResponse.json(
+        { error: "開始は終了より前である必要があります" },
+        { status: 400 }
+      );
     }
 
-    // 予約重複チェック（同デバイス、時間重なり）
+    // 同デバイス・時間重複チェック
     const overlap = await prisma.reservation.findFirst({
       where: {
         deviceId: device.id,
@@ -65,14 +133,18 @@ export async function POST(req: Request) {
       select: { id: true },
     });
     if (overlap) {
-      return NextResponse.json({ error: "同時間帯に既存の予約があります" }, { status: 409 });
+      return NextResponse.json(
+        { error: "同時間帯に既存の予約があります" },
+        { status: 409 }
+      );
     }
 
-    // ★ ここが本題: deviceId 直書きではなく、リレーション connect を使う
+    // 作成: device は connect、必須の userEmail を保存
     const created = await prisma.reservation.create({
       data: {
         start: startAt,
         end: endAt,
+        userEmail, // ★ これが必須だった
         device: { connect: { id: device.id } },
       },
       select: { id: true },


### PR DESCRIPTION
## Summary
- extract userEmail from headers, cookies, or JWT payloads when handling reservation creation so ReservationCreateInput requirements are satisfied
- maintain existing group-scoped device resolution, overlap detection, and relation connect logic while persisting the email on the new record

## Testing
- pnpm --filter lab_yoyaku-web lint

------
https://chatgpt.com/codex/tasks/task_e_68dd6f43de88832387720774b9c1421a