### PR TITLE
Adjust reservation fallback fields for day view

### DIFF
--- a/web/src/app/groups/[slug]/day/[date]/page.tsx
+++ b/web/src/app/groups/[slug]/day/[date]/page.tsx
@@ -105,8 +105,8 @@ export default async function DayPage({
   const list = listRaw
     .map((item) => ({
       ...item,
-      startAt: item.startAt ?? item.startsAt ?? (item as any).start ?? '',
-      endAt: item.endAt ?? item.endsAt ?? (item as any).end ?? '',
+      startAt: item.startAt ?? (item as any).startAt ?? (item as any).start,
+      endAt: item.endAt ?? (item as any).endAt ?? (item as any).end,
     }))
     .filter((item) => item.startAt && item.endAt && item.device?.name)
     .sort((a, b) => new Date(a.startAt).getTime() - new Date(b.startAt).getTime());


### PR DESCRIPTION
## Summary
- update the day view reservation normalization to only fall back to startAt/endAt alternatives

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd7170c2288323a5f759fc76a95028