### PR TITLE
Add GET handler for reservations API

### DIFF
--- a/web/src/app/api/reservations/route.ts
+++ b/web/src/app/api/reservations/route.ts
@@ -1,8 +1,33 @@
 import { NextResponse } from "next/server";
 import { cookies, headers as nextHeaders } from "next/headers";
 import { decodeJwt } from "jose";
+import type { Prisma } from "@prisma/client";
 import { z } from "@/lib/zod-shim";
 import { prisma } from "@/lib/prisma";
+import { readUserFromCookie } from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function parseDate(value: string | null): Date | null {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function parseDateRangeFromDay(value: string | null): { from: Date; to: Date } | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return null;
+  const [yearStr, monthStr, dayStr] = trimmed.split("-");
+  const year = Number(yearStr);
+  const month = Number(monthStr) - 1;
+  const day = Number(dayStr);
+  if ([year, month, day].some((n) => !Number.isFinite(n))) return null;
+  const from = new Date(Date.UTC(year, month, day, 0, 0, 0, 0));
+  const to = new Date(from.getTime() + 24 * 60 * 60 * 1000);
+  return { from, to };
+}
 
 const Body = z.object({
   groupSlug: z.string().min(1),
@@ -71,6 +96,128 @@ function getUserEmailFromRequest(): string | null {
   } catch {}
 
   return null;
+}
+
+export async function GET(req: Request) {
+  const me = await readUserFromCookie();
+  if (!me?.email) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const url = new URL(req.url);
+  const groupSlugRaw =
+    (url.searchParams.get("groupSlug") ?? url.searchParams.get("group") ?? "").trim();
+  if (!groupSlugRaw) {
+    return NextResponse.json({ error: "groupSlug is required" }, { status: 400 });
+  }
+  const groupSlug = groupSlugRaw.toLowerCase();
+
+  const group = await prisma.group.findUnique({
+    where: { slug: groupSlug },
+    include: { members: { select: { email: true } } },
+  });
+
+  if (!group) {
+    return NextResponse.json({ error: "group not found" }, { status: 404 });
+  }
+
+  const normalizedEmail = me.email.toLowerCase();
+  const isMember =
+    group.hostEmail.toLowerCase() === normalizedEmail ||
+    group.members.some((member) => member.email.toLowerCase() === normalizedEmail);
+
+  if (!isMember) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  const deviceSlugRaw =
+    (url.searchParams.get("deviceSlug") ?? url.searchParams.get("device") ?? "").trim();
+  const deviceSlug = deviceSlugRaw ? deviceSlugRaw.toLowerCase() : null;
+
+  let from = parseDate(url.searchParams.get("from"));
+  let to = parseDate(url.searchParams.get("to"));
+
+  if (!from && !to) {
+    const dayRange = parseDateRangeFromDay(url.searchParams.get("date"));
+    if (dayRange) {
+      from = dayRange.from;
+      to = dayRange.to;
+    }
+  }
+
+  if (from && to && from >= to) {
+    return NextResponse.json({ error: "invalid range" }, { status: 400 });
+  }
+
+  const where: Prisma.ReservationWhereInput = {
+    device: {
+      groupId: group.id,
+      ...(deviceSlug ? { slug: deviceSlug } : {}),
+    },
+  };
+
+  const andConditions: Prisma.ReservationWhereInput[] = [];
+  if (from) {
+    andConditions.push({ end: { gt: from } });
+  }
+  if (to) {
+    andConditions.push({ start: { lt: to } });
+  }
+  if (andConditions.length > 0) {
+    where.AND = andConditions;
+  }
+
+  const reservations = await prisma.reservation.findMany({
+    where,
+    orderBy: { start: "asc" },
+    include: {
+      device: {
+        select: {
+          id: true,
+          slug: true,
+          name: true,
+          group: { select: { slug: true, name: true } },
+        },
+      },
+    },
+  });
+
+  const profileEmails = new Set<string>([
+    group.hostEmail,
+    ...group.members.map((member) => member.email),
+    ...reservations.map((reservation) => reservation.userEmail),
+  ]);
+
+  const profiles = profileEmails.size
+    ? await prisma.userProfile.findMany({
+        where: { email: { in: Array.from(profileEmails) } },
+      })
+    : [];
+
+  const displayNameMap = new Map(
+    profiles.map((profile) => [profile.email, profile.displayName || ""])
+  );
+
+  const payload = reservations.map((reservation) => ({
+    id: reservation.id,
+    deviceId: reservation.deviceId,
+    deviceSlug: reservation.device.slug,
+    deviceName: reservation.device.name,
+    groupSlug: reservation.device.group.slug,
+    groupName: reservation.device.group.name ?? reservation.device.group.slug,
+    start: reservation.start.toISOString(),
+    end: reservation.end.toISOString(),
+    purpose: reservation.purpose ?? null,
+    reminderMinutes: reservation.reminderMinutes ?? null,
+    userEmail: reservation.userEmail,
+    userName:
+      reservation.userName ||
+      displayNameMap.get(reservation.userEmail) ||
+      reservation.userEmail.split("@")[0],
+    userId: reservation.userId ?? null,
+  }));
+
+  return NextResponse.json({ reservations: payload });
 }
 
 export async function POST(req: Request) {


### PR DESCRIPTION
## Summary
- add a GET handler for `/api/reservations` that validates membership and filters by device and time range before returning reservation payloads
- normalize query parsing utilities for the reservations route and mark it as dynamic runtime

## Testing
- pnpm --filter lab_yoyaku-web lint

------
https://chatgpt.com/codex/tasks/task_e_68dd73cee6d88323a94f53e70375e71c