### PR TITLE
Fix reservation overlap handling and gray out past entries

### DIFF
--- a/web/src/app/api/reservations/daily/route.ts
+++ b/web/src/app/api/reservations/daily/route.ts
@@ -72,17 +72,13 @@ export async function GET(req: Request) {
   if (!dayStartUtc) {
     return NextResponse.json({ error: 'INVALID_DATE' }, { status: 400 });
   }
-  const dayEndUtc = new Date(dayStartUtc.getTime() + 24 * 60 * 60 * 1000 + 1);
+  const dayEndUtc = new Date(dayStartUtc.getTime() + 24 * 60 * 60 * 1000 - 1);
 
   const reservations = await prisma.reservation.findMany({
     where: {
       device: { groupId: group.id },
-      NOT: {
-        OR: [
-          { end: { lte: dayStartUtc } },
-          { start: { gte: dayEndUtc } },
-        ],
-      },
+      start: { lte: dayEndUtc },
+      end: { gte: dayStartUtc },
     },
     orderBy: { start: 'asc' },
     include: {

--- a/web/src/app/groups/[slug]/reservations/[date]/page.tsx
+++ b/web/src/app/groups/[slug]/reservations/[date]/page.tsx
@@ -53,20 +53,28 @@ export default async function Day({
     }))
     .filter((item) => item.id && item.deviceName && item.start && item.end);
 
+  const now = Date.now();
+
   return (
     <div className="p-4">
       <h1 className="text-lg font-semibold">{params.date} の予約</h1>
       {reservations.length ? (
         <ul className="mt-3 space-y-2">
-          {reservations.map((reservation) => (
-            <li key={reservation.id} className="rounded border p-2 text-sm">
-              <div className="font-medium">{reservation.deviceName}</div>
-              <div className="text-gray-600">
-                {formatDateTime(reservation.start)} – {formatDateTime(reservation.end)}
-              </div>
-              {reservation.note ? <div className="text-gray-500">{reservation.note}</div> : null}
-            </li>
-          ))}
+          {reservations.map((reservation) => {
+            const isPast = new Date(reservation.end).getTime() < now;
+            return (
+              <li
+                key={reservation.id}
+                className={`rounded border p-2 text-sm ${isPast ? 'bg-gray-50 text-gray-500 opacity-60' : ''}`}
+              >
+                <div className="font-medium">{reservation.deviceName}</div>
+                <div className="text-gray-600">
+                  {formatDateTime(reservation.start)} – {formatDateTime(reservation.end)}
+                </div>
+                {reservation.note ? <div className="text-gray-500">{reservation.note}</div> : null}
+              </li>
+            );
+          })}
         </ul>
       ) : (
         <div className="mt-3 text-gray-500">この日に該当する予約はありません。</div>

--- a/web/src/components/ReservationList.tsx
+++ b/web/src/components/ReservationList.tsx
@@ -15,13 +15,20 @@ function fmt(d: Date) {
 
 export default function ReservationList({ items }: { items: ReservationItem[] }) {
   if (!items.length) return <p className="text-sm text-neutral-500">予約がありません。</p>;
+  const now = Date.now();
   return (
     <ul className="list-disc pl-5 space-y-1 text-sm">
-      {items.map((i) => (
-        <li key={i.id}>
-          {`機器: ${i.deviceName} / 予約者: ${i.user} / 時間: ${fmt(i.start)} - ${fmt(i.end)}`}
-        </li>
-      ))}
+      {items.map((i) => {
+        const isPast = i.end.getTime() < now;
+        return (
+          <li
+            key={i.id}
+            className={isPast ? 'text-gray-400 opacity-60' : undefined}
+          >
+            {`機器: ${i.deviceName} / 予約者: ${i.user} / 時間: ${fmt(i.start)} - ${fmt(i.end)}`}
+          </li>
+        );
+      })}
     </ul>
   );
 }


### PR DESCRIPTION
## Summary
- ensure daily reservation queries treat day boundaries as inclusive so multi-day bookings display on each day
- adjust the generic reservation API to keep overlapping logic when filtering by a single date while preserving range behaviour
- gray out past reservations in both the day view and shared reservation list for clearer UX

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dec246f78c8323a63df500c1148109