### PR TITLE
Update Vercel install command to avoid frozen lockfile error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "installCommand": "pnpm install --no-frozen-lockfile"
+}


### PR DESCRIPTION
## Summary
- add a Vercel configuration file to override the install command
- run pnpm install during deployments without the frozen lockfile flag to prevent outdated lockfile errors

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68df3830c62c8323b00e51e6f688ca14