### PR TITLE
Fix Vercel install command to bypass frozen lockfile

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "installCommand": "pnpm install --no-frozen-lockfile",
+  "buildCommand": "pnpm -w build"
+}


### PR DESCRIPTION
## Summary
- add a root-level `vercel.json` so Vercel uses `pnpm install --no-frozen-lockfile`

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68df3aa93080832394bbef7b9f68993a