### PR TITLE
Fix timezone handling for reservations

### DIFF
--- a/web/src/app/api/reservations/route.ts
+++ b/web/src/app/api/reservations/route.ts
@@ -1,15 +1,33 @@
 import { NextResponse } from "next/server";
 import { getServerSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { localStringToUtcDate } from "@/lib/time";
+import { localPartsToUtc } from "@/lib/time";
 
 export async function POST(req: Request) {
   const session = await getServerSession();
   if (!session?.user?.email) return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
 
   const body = await req.json().catch(() => ({}));
-  const { deviceId, deviceSlug, groupSlug, start, end } = body as {
-    deviceId?: string; deviceSlug?: string; groupSlug?: string; start: string; end: string;
+  const {
+    deviceId,
+    deviceSlug,
+    groupSlug,
+    start,
+    end,
+    startTime,
+    endTime,
+    date,
+    endDate,
+  } = body as {
+    deviceId?: string;
+    deviceSlug?: string;
+    groupSlug?: string;
+    start?: string;
+    end?: string;
+    startTime?: string;
+    endTime?: string;
+    date?: string;
+    endDate?: string;
   };
 
   // group & device を厳格に突き合わせ（他グループデバイスへの誤登録を防止）
@@ -24,8 +42,45 @@ export async function POST(req: Request) {
   if (!device) return NextResponse.json({ message: "device not found in the group" }, { status: 400 });
 
   // 「入力文字列をローカル時刻として」UTCに変換して保存（ズレ防止）
-  const startAt = localStringToUtcDate(start);
-  const endAt   = localStringToUtcDate(end);
+  const pickTime = (value?: string) => (typeof value === "string" ? value : "");
+  const normalizeTime = (value: string) => value.trim();
+
+  const resolveParts = (datePart?: string, timePart?: string) => {
+    if (!datePart || !timePart) return null;
+    return { date: datePart, time: timePart };
+  };
+
+  const splitDateTime = (value: string) => {
+    const normalized = value.trim().replace("T", " ");
+    const [datePart, timePart] = normalized.split(/\s+/);
+    if (!datePart || !timePart) return null;
+    return { date: datePart, time: timePart };
+  };
+
+  const startTimeValue = normalizeTime(pickTime(startTime ?? start));
+  const endTimeValue = normalizeTime(pickTime(endTime ?? end));
+  const startParts = (() => {
+    if (date && startTimeValue && !startTimeValue.includes("T") && !startTimeValue.includes(" ")) {
+      return resolveParts(date, startTimeValue);
+    }
+    if (startTimeValue) return splitDateTime(startTimeValue);
+    return null;
+  })();
+  const endParts = (() => {
+    const dateCandidate = endDate || date;
+    if (dateCandidate && endTimeValue && !endTimeValue.includes("T") && !endTimeValue.includes(" ")) {
+      return resolveParts(dateCandidate, endTimeValue);
+    }
+    if (endTimeValue) return splitDateTime(endTimeValue);
+    return null;
+  })();
+
+  if (!startParts || !endParts) {
+    return NextResponse.json({ message: "invalid datetime" }, { status: 400 });
+  }
+
+  const startAt = localPartsToUtc(startParts.date, startParts.time);
+  const endAt = localPartsToUtc(endParts.date, endParts.time);
   if (!(startAt instanceof Date) || isNaN(+startAt) || !(endAt instanceof Date) || isNaN(+endAt))
     return NextResponse.json({ message: "invalid datetime" }, { status: 400 });
   if (+endAt <= +startAt)
@@ -41,7 +96,7 @@ export async function POST(req: Request) {
     select: { id: true },
   });
 
-  return NextResponse.json({ id: created.id }, { status: 201 });
+  return NextResponse.json({ ok: true, id: created.id }, { status: 201 });
 }
 
 // （不要な GET 叩きに 405 を返す）

--- a/web/src/app/groups/[slug]/day/[date]/InlineReservationForm.tsx
+++ b/web/src/app/groups/[slug]/day/[date]/InlineReservationForm.tsx
@@ -19,6 +19,20 @@ export default function InlineReservationForm({ slug, date, devices }: Props) {
   const [note, setNote] = useState('');
   const [saving, setSaving] = useState(false);
 
+  const splitDateTime = (value: string) => {
+    const normalized = value.replace('T', ' ').trim();
+    const [datePart, timePart] = normalized.split(/\s+/);
+    if (!datePart || !timePart) return null;
+    const [hour, minute, second] = timePart.split(':');
+    const hh = hour?.padStart(2, '0') ?? '00';
+    const mm = minute?.padStart(2, '0') ?? '00';
+    const ss = second ? second.padStart(2, '0') : '';
+    return {
+      date: datePart,
+      time: ss ? `${hh}:${mm}:${ss}` : `${hh}:${mm}`,
+    };
+  };
+
   async function submit() {
     if (!deviceId) {
       alert('機器を選択してください');
@@ -26,11 +40,21 @@ export default function InlineReservationForm({ slug, date, devices }: Props) {
     }
     setSaving(true);
     try {
+      const startParts = splitDateTime(start);
+      const endParts = splitDateTime(end);
+      if (!startParts || !endParts) {
+        alert('開始・終了時刻を正しく入力してください');
+        return;
+      }
       const payload = {
         groupSlug: slug,
         deviceId,
-        start,
-        end,
+        date: startParts.date,
+        endDate: endParts.date,
+        start: startParts.time,
+        end: endParts.time,
+        startTime: startParts.time,
+        endTime: endParts.time,
       };
       const res = await fetch('/api/reservations', {
         method: 'POST',

--- a/web/src/app/groups/[slug]/reservations/new/Client.tsx
+++ b/web/src/app/groups/[slug]/reservations/new/Client.tsx
@@ -26,6 +26,20 @@ function buildDefaultValue(param: string | null, time: string) {
   return toLocalInputValue(candidate);
 }
 
+function splitDateTime(value: string) {
+  const normalized = value.replace('T', ' ').trim();
+  const [datePart, timePart] = normalized.split(/\s+/);
+  if (!datePart || !timePart) return null;
+  const [hour, minute, second] = timePart.split(':');
+  const hh = hour?.padStart(2, '0') ?? '00';
+  const mm = minute?.padStart(2, '0') ?? '00';
+  const ss = second ? second.padStart(2, '0') : '';
+  return {
+    date: datePart,
+    time: ss ? `${hh}:${mm}:${ss}` : `${hh}:${mm}`,
+  };
+}
+
 export default function NewReservationClient({
   params,
   devices,
@@ -84,11 +98,22 @@ export default function NewReservationClient({
       return;
     }
 
+    const startParts = splitDateTime(startRaw);
+    const endParts = splitDateTime(endRaw);
+    if (!startParts || !endParts) {
+      toast.error('開始・終了時刻を正しく入力してください');
+      return;
+    }
+
     const payload = {
       groupSlug: params.slug,
       deviceSlug: parsed.data.deviceSlug,
-      start: startRaw,
-      end: endRaw,
+      date: startParts.date,
+      endDate: endParts.date,
+      start: startParts.time,
+      end: endParts.time,
+      startTime: startParts.time,
+      endTime: endParts.time,
       purpose,
     };
 

--- a/web/src/components/ReservationList.tsx
+++ b/web/src/components/ReservationList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { utcDateToLocalString } from '@/lib/time';
+import { isPast, utcDateToLocalString } from '@/lib/time';
 
 export type ReservationItem = {
   id: string;
@@ -15,15 +15,14 @@ function fmt(d: Date) {
 
 export default function ReservationList({ items }: { items: ReservationItem[] }) {
   if (!items.length) return <p className="text-sm text-neutral-500">予約がありません。</p>;
-  const now = Date.now();
   return (
     <ul className="list-disc pl-5 space-y-1 text-sm">
       {items.map((i) => {
-        const isPast = i.end.getTime() < now;
+        const past = isPast(i.end);
         return (
           <li
             key={i.id}
-            className={isPast ? 'text-gray-400 opacity-60' : undefined}
+            className={past ? 'text-gray-400 opacity-60' : undefined}
           >
             {`機器: ${i.deviceName} / 予約者: ${i.user} / 時間: ${fmt(i.start)} - ${fmt(i.end)}`}
           </li>

--- a/web/src/lib/time.ts
+++ b/web/src/lib/time.ts
@@ -1,21 +1,121 @@
-import { zonedTimeToUtc, utcToZonedTime, format } from "date-fns-tz";
-
 export const APP_TZ = process.env.NEXT_PUBLIC_TZ || "Asia/Tokyo";
 
-// "2025-10-11 13:00" / "2025-10-11T13:00" をローカル(=APP_TZ)としてUTC Dateに
-export function localStringToUtcDate(s: string): Date {
-  const normalized = s.replace("T", " "); // datetime-local/文字列の両対応
-  return zonedTimeToUtc(normalized, APP_TZ);
+function getFormatter(tz: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
 }
 
-// UTC Date をローカル(=APP_TZ)の "yyyy-MM-dd HH:mm" 文字列に
-export function utcDateToLocalString(d: Date): string {
-  return format(utcToZonedTime(d, APP_TZ), "yyyy-MM-dd HH:mm", { timeZone: APP_TZ });
+function parseDate(dateStr: string) {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) {
+    throw new Error("Invalid date parts");
+  }
+  return { year: y, month: m, day: d };
 }
 
-// ローカル日付の 1 日の境界
-export function localDayRange(yyyyMmDd: string) {
-  const start = zonedTimeToUtc(`${yyyyMmDd} 00:00`, APP_TZ);
-  const end   = zonedTimeToUtc(`${yyyyMmDd} 24:00`, APP_TZ); // [start, end) の半開区間
-  return { start, end };
+function parseTime(timeStr: string) {
+  const parts = timeStr.split(":").map((p) => Number(p));
+  if (parts.length < 2) throw new Error("Invalid time parts");
+  const [hour, minute, second] = parts;
+  if (!Number.isFinite(hour) || !Number.isFinite(minute)) {
+    throw new Error("Invalid time parts");
+  }
+  if (hour < 0 || hour > 24) throw new Error("Invalid hour value");
+  if (hour === 24 && (minute !== 0 || (Number.isFinite(second) && second !== 0))) {
+    throw new Error("Invalid time parts for 24:00");
+  }
+  if (minute < 0 || minute > 59) throw new Error("Invalid minute value");
+  const sec = Number.isFinite(second) ? second : 0;
+  if (sec < 0 || sec > 59) throw new Error("Invalid second value");
+  const dayOffset = hour === 24 ? 1 : 0;
+  return { hour: hour === 24 ? 0 : hour, minute, second: hour === 24 ? 0 : sec, dayOffset };
+}
+
+function mapParts(parts: Intl.DateTimeFormatPart[]) {
+  const entries = parts
+    .filter((part) => part.type !== "literal")
+    .map((part) => [part.type, Number(part.value)] as const);
+  return Object.fromEntries(entries) as Record<string, number>;
+}
+
+export function localPartsToUtc(dateStr: string, timeStr: string, tz = APP_TZ): Date {
+  const { year, month, day } = parseDate(dateStr);
+  const { hour, minute, second, dayOffset } = parseTime(timeStr);
+  const formatter = getFormatter(tz);
+  const guess = new Date(Date.UTC(year, month - 1, day + dayOffset, hour, minute, second));
+  const parts = mapParts(formatter.formatToParts(guess));
+  const interpreted = Date.UTC(
+    parts.year,
+    (parts.month || 1) - 1,
+    parts.day || 1,
+    parts.hour || 0,
+    parts.minute || 0,
+    parts.second || 0,
+  );
+  const offset = interpreted - guess.getTime();
+  return new Date(guess.getTime() - offset);
+}
+
+export function toZoned(dateUtc: Date, tz = APP_TZ) {
+  const parts = mapParts(getFormatter(tz).formatToParts(dateUtc));
+  return {
+    year: parts.year,
+    month: parts.month,
+    day: parts.day,
+    hour: parts.hour,
+    minute: parts.minute,
+    second: parts.second ?? 0,
+  };
+}
+
+export function formatInTz(dateUtc: Date, fmt: string, tz = APP_TZ): string {
+  const z = toZoned(dateUtc, tz);
+  const pad = (n: number, width = 2) => String(n).padStart(width, "0");
+  const tokens: Record<string, string> = {
+    yyyy: String(z.year),
+    MM: pad(z.month),
+    dd: pad(z.day),
+    HH: pad(z.hour),
+    mm: pad(z.minute),
+    ss: pad(z.second),
+  };
+  if (fmt === "HH:mm") return `${tokens.HH}:${tokens.mm}`;
+  if (fmt === "yyyy-MM-dd") return `${tokens.yyyy}-${tokens.MM}-${tokens.dd}`;
+  if (fmt === "yyyy-MM-dd HH:mm") return `${tokens.yyyy}-${tokens.MM}-${tokens.dd} ${tokens.HH}:${tokens.mm}`;
+  if (fmt === "yyyy-MM-dd HH:mm:ss") return `${tokens.yyyy}-${tokens.MM}-${tokens.dd} ${tokens.HH}:${tokens.mm}:${tokens.ss}`;
+  return `${tokens.yyyy}-${tokens.MM}-${tokens.dd} ${tokens.HH}:${tokens.mm}`;
+}
+
+export function utcDateToLocalString(dateUtc: Date, fmt = "yyyy-MM-dd HH:mm", tz = APP_TZ): string {
+  return formatInTz(dateUtc, fmt, tz);
+}
+
+export function localStringToUtcDate(input: string, tz = APP_TZ): Date {
+  const normalized = input.trim().replace("T", " ");
+  const [datePart, timePart = "00:00:00"] = normalized.split(/\s+/);
+  if (!datePart || !timePart) throw new Error("Invalid datetime string");
+  return localPartsToUtc(datePart, timePart, tz);
+}
+
+export function dayRangeUtc(dateStr: string, tz = APP_TZ) {
+  const startUtc = localPartsToUtc(dateStr, "00:00", tz);
+  const endUtc = localPartsToUtc(dateStr, "24:00", tz);
+  return { startUtc, endUtc };
+}
+
+export function localDayRange(dateStr: string, tz = APP_TZ) {
+  const { startUtc, endUtc } = dayRangeUtc(dateStr, tz);
+  return { start: startUtc, end: endUtc };
+}
+
+export function isPast(endUtc: Date): boolean {
+  return endUtc.getTime() < Date.now();
 }


### PR DESCRIPTION
## Summary
- replace the time utilities with Intl-based conversions to drop date-fns-tz and add a reusable past-check helper
- normalize reservation CRUD APIs to use the new helpers so day filters match [00:00,24:00) and stored datetimes stay in UTC
- update reservation forms (standard and inline) plus the mock API to submit date/time parts and highlight past bookings correctly

## Testing
- pnpm --filter lab_yoyaku-web lint

------
https://chatgpt.com/codex/tasks/task_e_68df3d3f97288323b64f1aa5a6bbc108