### PR TITLE
Fix timezone handling and reservation UX

### DIFF
--- a/web/src/app/api/groups/[slug]/reservations/route.ts
+++ b/web/src/app/api/groups/[slug]/reservations/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { localDayRange, localStringToUtcDate } from "@/lib/time";
+import { dayRangeUtc, localStringToUtcDate } from "@/lib/time";
 
 export async function GET(_: Request, { params, url }: { params: { slug: string }, url: string }) {
   const u = new URL(url);
@@ -22,9 +22,9 @@ export async function GET(_: Request, { params, url }: { params: { slug: string 
   const andConditions: any[] = [];
 
   if (date) {
-    const { start, end } = localDayRange(date);
-    notConditions.push({ end: { lte: start } });
-    andConditions.push({ start: { lt: end } });
+    const { startUtc, endUtc } = dayRangeUtc(date);
+    notConditions.push({ end: { lte: startUtc } });
+    andConditions.push({ start: { lt: endUtc } });
   } else {
     if (fromParam) {
       const fromDate = (() => {
@@ -68,5 +68,12 @@ export async function GET(_: Request, { params, url }: { params: { slug: string 
     include: { device: { select: { name: true, slug: true } } },
   });
 
-  return NextResponse.json({ data: rows });
+  const data = rows.map((row) => ({
+    id: row.id,
+    startAt: row.start.toISOString(),
+    endAt: row.end.toISOString(),
+    device: row.device,
+  }));
+
+  return NextResponse.json({ data });
 }

--- a/web/src/app/api/mock/groups/[slug]/reservations/route.ts
+++ b/web/src/app/api/mock/groups/[slug]/reservations/route.ts
@@ -6,7 +6,7 @@ import { NextResponse } from 'next/server';
 import { store } from '../../../_store';
 import { readUserFromCookie } from '@/lib/auth';
 import { loadDB } from '@/lib/mockdb';
-import { localDayRange, localStringToUtcDate } from '@/lib/time';
+import { dayRangeUtc, localStringToUtcDate } from '@/lib/time';
 
 export async function POST(req: Request, { params }: { params: { slug: string } }) {
   const body = await req.json().catch(() => ({}));
@@ -55,12 +55,12 @@ export async function GET(req: Request, { params }: { params: { slug: string } }
     list = list.filter((r: any) => r.deviceSlug === deviceSlug || r.deviceId === deviceSlug);
   }
   if (date) {
-    const { start, end } = localDayRange(date);
+    const { startUtc, endUtc } = dayRangeUtc(date);
     list = list.filter((r: any) => {
       const startAt = new Date(r.start);
       const endAt = new Date(r.end);
       if (Number.isNaN(startAt.getTime()) || Number.isNaN(endAt.getTime())) return false;
-      return !(endAt <= start || startAt >= end);
+      return !(endAt <= startUtc || startAt >= endUtc);
     });
   } else {
     if (fromParam) {

--- a/web/src/app/api/reservations/route.ts
+++ b/web/src/app/api/reservations/route.ts
@@ -1,15 +1,15 @@
 import { NextResponse } from "next/server";
 import { getServerSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { localStringToUtcDate } from "@/lib/time";
+import { localPartsToUtc, localStringToUtcDate } from "@/lib/time";
 
 export async function POST(req: Request) {
   const session = await getServerSession();
   if (!session?.user?.email) return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
 
   const body = await req.json().catch(() => ({}));
-  const { deviceId, deviceSlug, groupSlug, start, end } = body as {
-    deviceId?: string; deviceSlug?: string; groupSlug?: string; start: string; end: string;
+  const { deviceId, deviceSlug, groupSlug, date, start, end } = body as {
+    deviceId?: string; deviceSlug?: string; groupSlug?: string; date?: string; start: string; end: string;
   };
 
   // group & device を厳格に突き合わせ（他グループデバイスへの誤登録を防止）
@@ -24,9 +24,22 @@ export async function POST(req: Request) {
   if (!device) return NextResponse.json({ message: "device not found in the group" }, { status: 400 });
 
   // 「入力文字列をローカル時刻として」UTCに変換して保存（ズレ防止）
-  const startAt = localStringToUtcDate(start);
-  const endAt   = localStringToUtcDate(end);
-  if (!(startAt instanceof Date) || isNaN(+startAt) || !(endAt instanceof Date) || isNaN(+endAt))
+  let startAt: Date | null = null;
+  let endAt: Date | null = null;
+  try {
+    const hasDate = typeof date === "string" && date.length >= 10;
+    const isTimeOnly = (value: string | undefined) => typeof value === "string" && /^\d{1,2}:\d{2}(:\d{2})?$/.test(value);
+    if (hasDate && isTimeOnly(start) && isTimeOnly(end)) {
+      startAt = localPartsToUtc(date!, start);
+      endAt = localPartsToUtc(date!, end);
+    } else {
+      startAt = localStringToUtcDate(start);
+      endAt = localStringToUtcDate(end);
+    }
+  } catch {
+    return NextResponse.json({ message: "invalid datetime" }, { status: 400 });
+  }
+  if (!(startAt instanceof Date) || Number.isNaN(+startAt) || !(endAt instanceof Date) || Number.isNaN(+endAt))
     return NextResponse.json({ message: "invalid datetime" }, { status: 400 });
   if (+endAt <= +startAt)
     return NextResponse.json({ message: "end must be after start" }, { status: 400 });
@@ -41,7 +54,7 @@ export async function POST(req: Request) {
     select: { id: true },
   });
 
-  return NextResponse.json({ id: created.id }, { status: 201 });
+  return NextResponse.json({ ok: true, id: created.id }, { status: 201 });
 }
 
 // （不要な GET 叩きに 405 を返す）

--- a/web/src/app/groups/[slug]/reservations/new/Client.tsx
+++ b/web/src/app/groups/[slug]/reservations/new/Client.tsx
@@ -26,6 +26,11 @@ function buildDefaultValue(param: string | null, time: string) {
   return toLocalInputValue(candidate);
 }
 
+function splitDateTime(value: string) {
+  const [datePart = '', timePart = ''] = value.split('T');
+  return { date: datePart, time: timePart.slice(0, 5) };
+}
+
 export default function NewReservationClient({
   params,
   devices,
@@ -84,11 +89,19 @@ export default function NewReservationClient({
       return;
     }
 
+    const { date: startDate, time: startTime } = splitDateTime(startRaw);
+    const { date: endDate, time: endTime } = splitDateTime(endRaw);
+    if (!startDate || !startTime || !endTime || startDate !== endDate) {
+      toast.error('同じ日の開始・終了時刻を入力してください');
+      return;
+    }
+
     const payload = {
       groupSlug: params.slug,
       deviceSlug: parsed.data.deviceSlug,
-      start: startRaw,
-      end: endRaw,
+      date: startDate,
+      start: startTime,
+      end: endTime,
       purpose,
     };
 
@@ -124,7 +137,6 @@ export default function NewReservationClient({
           nextDevice ? `?device=${encodeURIComponent(nextDevice)}` : ''
         }`
       );
-      r.refresh();
     } catch (error) {
       toast.error('予約の作成に失敗しました');
     } finally {

--- a/web/src/components/ReservationList.tsx
+++ b/web/src/components/ReservationList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { utcDateToLocalString } from '@/lib/time';
+import clsx from 'clsx';
+import { isPast, utcDateToLocalString } from '@/lib/time';
 
 export type ReservationItem = {
   id: string;
@@ -15,15 +16,14 @@ function fmt(d: Date) {
 
 export default function ReservationList({ items }: { items: ReservationItem[] }) {
   if (!items.length) return <p className="text-sm text-neutral-500">予約がありません。</p>;
-  const now = Date.now();
   return (
     <ul className="list-disc pl-5 space-y-1 text-sm">
       {items.map((i) => {
-        const isPast = i.end.getTime() < now;
+        const past = isPast(i.end);
         return (
           <li
             key={i.id}
-            className={isPast ? 'text-gray-400 opacity-60' : undefined}
+            className={clsx({ 'text-gray-400 opacity-60': past })}
           >
             {`機器: ${i.deviceName} / 予約者: ${i.user} / 時間: ${fmt(i.start)} - ${fmt(i.end)}`}
           </li>

--- a/web/src/lib/time.ts
+++ b/web/src/lib/time.ts
@@ -1,21 +1,125 @@
-import { zonedTimeToUtc, utcToZonedTime, format } from "date-fns-tz";
-
 export const APP_TZ = process.env.NEXT_PUBLIC_TZ || "Asia/Tokyo";
 
-// "2025-10-11 13:00" / "2025-10-11T13:00" をローカル(=APP_TZ)としてUTC Dateに
-export function localStringToUtcDate(s: string): Date {
-  const normalized = s.replace("T", " "); // datetime-local/文字列の両対応
-  return zonedTimeToUtc(normalized, APP_TZ);
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function getFormatter(tz: string) {
+  const cached = formatterCache.get(tz);
+  if (cached) return cached;
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+  formatterCache.set(tz, formatter);
+  return formatter;
 }
 
-// UTC Date をローカル(=APP_TZ)の "yyyy-MM-dd HH:mm" 文字列に
-export function utcDateToLocalString(d: Date): string {
-  return format(utcToZonedTime(d, APP_TZ), "yyyy-MM-dd HH:mm", { timeZone: APP_TZ });
+type ZonedParts = {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+};
+
+function partsToRecord(parts: Intl.DateTimeFormatPart[]): ZonedParts {
+  const map = new Map<string, number>();
+  for (const part of parts) {
+    if (part.type === "literal") continue;
+    map.set(part.type, Number(part.value));
+  }
+  return {
+    year: map.get("year") ?? 0,
+    month: map.get("month") ?? 1,
+    day: map.get("day") ?? 1,
+    hour: map.get("hour") ?? 0,
+    minute: map.get("minute") ?? 0,
+    second: map.get("second") ?? 0,
+  };
 }
 
-// ローカル日付の 1 日の境界
-export function localDayRange(yyyyMmDd: string) {
-  const start = zonedTimeToUtc(`${yyyyMmDd} 00:00`, APP_TZ);
-  const end   = zonedTimeToUtc(`${yyyyMmDd} 24:00`, APP_TZ); // [start, end) の半開区間
-  return { start, end };
+export function toZoned(dateUtc: Date, tz: string = APP_TZ): ZonedParts {
+  const formatter = getFormatter(tz);
+  const parts = formatter.formatToParts(dateUtc);
+  return partsToRecord(parts);
+}
+
+function toUtcFromZonedParts(parts: ZonedParts) {
+  return new Date(Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second));
+}
+
+function parseTimeParts(timeStr: string) {
+  const [hh = "0", mm = "0", ss = "0"] = timeStr.split(":");
+  return { hour: Number(hh), minute: Number(mm), second: Number(ss) };
+}
+
+export function localPartsToUtc(dateStr: string, timeStr: string, tz: string = APP_TZ): Date {
+  const [yearStr, monthStr, dayStr] = dateStr.split("-");
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  const day = Number(dayStr);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+    throw new Error("invalid date parts");
+  }
+
+  const { hour, minute, second } = parseTimeParts(timeStr);
+  if ([hour, minute, second].some((value) => !Number.isFinite(value))) {
+    throw new Error("invalid time parts");
+  }
+
+  // ベースとなる日付をUTCで作成し、指定TZでの表示値との差分を利用してUTCに補正
+  const base = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
+  const formatter = getFormatter(tz);
+  const presented = partsToRecord(formatter.formatToParts(base));
+  const presentedUtc = toUtcFromZonedParts(presented);
+  const offsetMs = presentedUtc.getTime() - base.getTime();
+  return new Date(base.getTime() - offsetMs);
+}
+
+export function localStringToUtcDate(value: string, tz: string = APP_TZ): Date {
+  const trimmed = value.trim();
+  if (!trimmed) throw new Error("invalid datetime string");
+  const normalized = trimmed.replace("T", " ");
+  const [datePart, timePart = "00:00"] = normalized.split(/\s+/);
+  return localPartsToUtc(datePart, timePart, tz);
+}
+
+export function formatInTz(dateUtc: Date, format: string, tz: string = APP_TZ): string {
+  const zoned = toZoned(dateUtc, tz);
+  const pad = (value: number, width = 2) => String(value).padStart(width, "0");
+  switch (format) {
+    case "HH:mm":
+      return `${pad(zoned.hour)}:${pad(zoned.minute)}`;
+    case "yyyy-MM-dd":
+      return `${zoned.year}-${pad(zoned.month)}-${pad(zoned.day)}`;
+    case "yyyy-MM-dd HH:mm":
+      return `${zoned.year}-${pad(zoned.month)}-${pad(zoned.day)} ${pad(zoned.hour)}:${pad(zoned.minute)}`;
+    default:
+      return `${zoned.year}-${pad(zoned.month)}-${pad(zoned.day)} ${pad(zoned.hour)}:${pad(zoned.minute)}`;
+  }
+}
+
+export function utcDateToLocalString(dateUtc: Date, tz: string = APP_TZ): string {
+  return formatInTz(dateUtc, "yyyy-MM-dd HH:mm", tz);
+}
+
+export function dayRangeUtc(dateStr: string, tz: string = APP_TZ) {
+  const startUtc = localPartsToUtc(dateStr, "00:00", tz);
+  const endUtc = localPartsToUtc(dateStr, "24:00", tz);
+  return { startUtc, endUtc };
+}
+
+export function localDayRange(dateStr: string, tz: string = APP_TZ) {
+  const { startUtc, endUtc } = dayRangeUtc(dateStr, tz);
+  return { start: startUtc, end: endUtc };
+}
+
+export function isPast(endUtc: Date): boolean {
+  return endUtc.getTime() < Date.now();
 }


### PR DESCRIPTION
## Summary
- replace date-fns-tz usage with Intl-based helpers to keep UTC storage while rendering in the app timezone
- tighten reservation queries to the requested day and normalize API responses
- update reservation forms and lists to submit day/time parts, show toasts, redirect, and dim past bookings

## Testing
- pnpm --filter lab_yoyaku-web lint

------
https://chatgpt.com/codex/tasks/task_e_68df3d3f97288323b64f1aa5a6bbc108