### PR TITLE
Refactor timezone utilities to use Intl API

### DIFF
--- a/web/src/app/api/groups/[slug]/reservations/route.ts
+++ b/web/src/app/api/groups/[slug]/reservations/route.ts
@@ -1,6 +1,22 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { localDayRange, localStringToUtcDate } from "@/lib/time";
+import { APP_TZ, toUTC } from "@/lib/time";
+
+const toUtcFromLocalString = (value: string, tz: string = APP_TZ) => {
+  const normalized = value.trim().replace(" ", "T");
+  const iso = /T\d{2}:\d{2}(?::\d{2})?$/.test(normalized) ? normalized : `${normalized}:00`;
+  const base = new Date(iso);
+  if (Number.isNaN(base.getTime())) throw new Error(`Invalid date string: ${value}`);
+  const projected = toUTC(base, tz);
+  const offset = projected.getTime() - base.getTime();
+  return new Date(base.getTime() - offset);
+};
+
+const localDayRange = (yyyyMmDd: string, tz: string = APP_TZ) => {
+  const start = toUtcFromLocalString(`${yyyyMmDd}T00:00`, tz);
+  const end = toUtcFromLocalString(`${yyyyMmDd}T24:00`, tz);
+  return { start, end };
+};
 
 export async function GET(_: Request, { params, url }: { params: { slug: string }, url: string }) {
   const u = new URL(url);
@@ -31,7 +47,7 @@ export async function GET(_: Request, { params, url }: { params: { slug: string 
         const parsed = new Date(fromParam);
         if (!Number.isNaN(parsed.getTime())) return parsed;
         try {
-          return localStringToUtcDate(fromParam);
+          return toUtcFromLocalString(fromParam);
         } catch {
           return null;
         }
@@ -45,7 +61,7 @@ export async function GET(_: Request, { params, url }: { params: { slug: string 
         const parsed = new Date(toParam);
         if (!Number.isNaN(parsed.getTime())) return parsed;
         try {
-          return localStringToUtcDate(toParam);
+          return toUtcFromLocalString(toParam);
         } catch {
           return null;
         }

--- a/web/src/app/groups/[slug]/devices/[deviceSlug]/page.tsx
+++ b/web/src/app/groups/[slug]/devices/[deviceSlug]/page.tsx
@@ -4,7 +4,7 @@ export const runtime = 'nodejs';
 export const fetchCache = 'force-no-store';
 
 import { serverFetch } from '@/lib/http/serverFetch';
-import { localDayRange } from '@/lib/time';
+import { APP_TZ, toUTC } from '@/lib/time';
 import { unstable_noStore as noStore } from 'next/cache';
 import { notFound, redirect } from 'next/navigation';
 import CalendarWithBars, { Span } from '@/components/CalendarWithBars';
@@ -88,6 +88,20 @@ export default async function DeviceDetail({
   rangeEnd.setHours(0, 0, 0, 0);
   rangeEnd.setDate(rangeEnd.getDate() + 1);
   const toYmd = (d: Date) => `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+  const toUtcFromLocalString = (value: string, tz: string = APP_TZ) => {
+    const normalized = value.trim().replace(' ', 'T');
+    const iso = /T\d{2}:\d{2}(?::\d{2})?$/.test(normalized) ? normalized : `${normalized}:00`;
+    const base = new Date(iso);
+    if (Number.isNaN(base.getTime())) throw new Error(`Invalid date string: ${value}`);
+    const projected = toUTC(base, tz);
+    const offset = projected.getTime() - base.getTime();
+    return new Date(base.getTime() - offset);
+  };
+  const localDayRange = (yyyyMmDd: string, tz: string = APP_TZ) => {
+    const start = toUtcFromLocalString(`${yyyyMmDd}T00:00`, tz);
+    const end = toUtcFromLocalString(`${yyyyMmDd}T24:00`, tz);
+    return { start, end };
+  };
   const { start: rangeStartBoundary } = localDayRange(toYmd(rangeStart));
   const { end: rangeEndBoundary } = localDayRange(toYmd(new Date(rangeEnd.getTime() - 24 * 60 * 60 * 1000)));
 

--- a/web/src/components/CalendarWithBars.tsx
+++ b/web/src/components/CalendarWithBars.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useMemo, useState } from 'react';
 import clsx from 'clsx';
-import { localDayRange, utcDateToLocalString } from '@/lib/time';
+import { APP_TZ, toUTC, formatInTZ } from '@/lib/time';
 
 export type Span = {
   id: string;
@@ -18,6 +18,23 @@ const pad = (n:number)=> n.toString().padStart(2,'0');
 const short = (s:string,len=16)=> s.length<=len ? s : s.slice(0,len-1)+'…';
 
 const toYmd = (d: Date) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+
+const toUtcFromLocalString = (value: string, tz: string = APP_TZ) => {
+  const normalized = value.trim().replace(' ', 'T');
+  const iso = /T\d{2}:\d{2}(?::\d{2})?$/.test(normalized) ? normalized : `${normalized}:00`;
+  const base = new Date(iso);
+  if (Number.isNaN(base.getTime())) throw new Error(`Invalid date string: ${value}`);
+  const projected = toUTC(base, tz);
+  const offset = projected.getTime() - base.getTime();
+  return new Date(base.getTime() - offset);
+};
+
+const localDayRange = (yyyyMmDd: string, tz: string = APP_TZ) => {
+  const start = toUtcFromLocalString(`${yyyyMmDd}T00:00`, tz);
+  const end = toUtcFromLocalString(`${yyyyMmDd}T24:00`, tz);
+  return { start, end };
+};
+
 function overlaps(day:Date, s:Date, e:Date){
   const { start, end } = localDayRange(toYmd(day));
   return !(e <= start || s >= end);
@@ -25,10 +42,10 @@ function overlaps(day:Date, s:Date, e:Date){
 
 function labelForDay(cell: Date, s: Date, e: Date) {
   const { start, end } = localDayRange(toYmd(cell));
-  const startStr = utcDateToLocalString(s);
-  const endStr = utcDateToLocalString(e);
-  const from = s <= start ? '00:00' : startStr.slice(11);
-  const to   = e >= end ? '24:00' : endStr.slice(11);
+  const startStr = formatInTZ(s, APP_TZ, { hour: '2-digit', minute: '2-digit', hour12: false });
+  const endStr = formatInTZ(e, APP_TZ, { hour: '2-digit', minute: '2-digit', hour12: false });
+  const from = s <= start ? '00:00' : startStr;
+  const to   = e >= end ? '24:00' : endStr;
   return `${from}–${to}`;
 }
 
@@ -125,7 +142,7 @@ function DayModal({ date, items, onClose }:{
   date:Date; items:Span[]; onClose:()=>void;
 }){
   const pad=(n:number)=> n.toString().padStart(2,'0');
-  const hhmm=(d:Date)=>utcDateToLocalString(d).slice(11);
+  const hhmm=(d:Date)=>formatInTZ(d, APP_TZ, { hour: '2-digit', minute: '2-digit', hour12: false });
 
   return (
     <div className="fixed inset-0 bg-black/30 flex items-end sm:items-center justify-center z-50">

--- a/web/src/components/ReservationList.tsx
+++ b/web/src/components/ReservationList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { utcDateToLocalString } from '@/lib/time';
+import { APP_TZ, formatInTZ } from '@/lib/time';
 
 export type ReservationItem = {
   id: string;
@@ -9,9 +9,15 @@ export type ReservationItem = {
   end: Date;
 };
 
-function fmt(d: Date) {
-  return utcDateToLocalString(d);
-}
+const fmt = (d: Date) =>
+  formatInTZ(d, APP_TZ, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
 
 export default function ReservationList({ items }: { items: ReservationItem[] }) {
   if (!items.length) return <p className="text-sm text-neutral-500">予約がありません。</p>;


### PR DESCRIPTION
## Summary
- replace the date-fns-tz based helpers with Intl-powered toUTC/fromUTC/formatInTZ utilities
- update reservation APIs, calendar UI, and group pages to convert and format dates through the new helpers
- switch display formatting to formatInTZ so local times render without slicing string values

## Testing
- pnpm lint
- CI=1 USE_MOCK=true pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68df43a3983c8323985e992d8c3c5813