### PR TITLE
Fix reservations API to query Prisma directly

### DIFF
--- a/web/src/lib/time.ts
+++ b/web/src/lib/time.ts
@@ -1,3 +1,6 @@
+import { addDays } from "date-fns";
+import { zonedTimeToUtc } from "date-fns-tz";
+
 export const APP_TZ = process.env.NEXT_PUBLIC_TZ || "Asia/Tokyo";
 
 // Local Date -> UTC (based on APP_TZ)
@@ -28,4 +31,16 @@ export function fromUTC(date: Date, tz: string = APP_TZ): Date {
 // Formatter
 export function formatInTZ(date: Date, tz: string = APP_TZ, opts: Intl.DateTimeFormatOptions = {}): string {
   return new Intl.DateTimeFormat("ja-JP", { timeZone: tz, ...opts }).format(date);
+}
+
+export function dayRangeInUtc(yyyyMmDd: string, tz: string = APP_TZ) {
+  const trimmed = yyyyMmDd.trim();
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    throw new Error(`Invalid date string: ${yyyyMmDd}`);
+  }
+
+  const dayStartUtc = zonedTimeToUtc(`${trimmed}T00:00:00`, tz);
+  const dayEndUtc = addDays(dayStartUtc, 1);
+
+  return { dayStartUtc, dayEndUtc };
 }


### PR DESCRIPTION
## Summary
- query Prisma directly inside the group reservations API instead of calling another route
- ensure reservations are restricted to the requested day using a timezone-aware range helper
- add a shared `dayRangeInUtc` helper to safely compute daily UTC windows without env-dependent URLs

## Testing
- pnpm --filter web lint *(fails: No projects matched the filters in "/workspace/lab_yoyaku")*
- pnpm lint *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68df4a9cce688323a518c4fe3b6a2a45