### PR TITLE
Fix timezone helpers compatibility with legacy API usage

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "prisma generate && if [ \"$USE_MOCK\" != \"true\" ]; then prisma migrate deploy; else echo 'Skipping prisma migrate deploy in mock mode'; fi && next build",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "start": "next start",
     "lint": "next lint",
     "postinstall": "echo skip prisma generate on postinstall",

--- a/web/src/lib/time.ts
+++ b/web/src/lib/time.ts
@@ -1,45 +1,109 @@
 import { addDays } from "date-fns";
-import { zonedTimeToUtc } from "date-fns-tz";
 
-export const APP_TZ = process.env.NEXT_PUBLIC_TZ || "Asia/Tokyo";
+const DEFAULT_APP_TZ = "Asia/Tokyo";
+const DEFAULT_LOCALE = "ja-JP";
 
-// Local Date -> UTC (based on APP_TZ)
-export function toUTC(date: Date, tz: string = APP_TZ): Date {
-  const fmt = new Intl.DateTimeFormat("en-US", {
-    timeZone: tz,
-    year: "numeric", month: "2-digit", day: "2-digit",
-    hour: "2-digit", minute: "2-digit", second: "2-digit",
-    hour12: false,
-  });
-  const parts = fmt.formatToParts(date);
-  const values: any = {};
-  parts.forEach(p => { if (p.type !== "literal") values[p.type] = parseInt(p.value, 10); });
-  return new Date(Date.UTC(values.year, values.month - 1, values.day, values.hour, values.minute, values.second));
+type DateInput = Date | string;
+
+function ensureDate(input: DateInput): Date {
+  const value = input instanceof Date ? new Date(input.getTime()) : new Date(input);
+  if (Number.isNaN(value.getTime())) {
+    throw new Error("Invalid date input");
+  }
+  return value;
 }
 
-// UTC -> Local TZ Date
-export function fromUTC(date: Date, tz: string = APP_TZ): Date {
-  const iso = new Intl.DateTimeFormat("sv-SE", {
+function getTimeParts(date: Date, tz: string) {
+  const formatter = new Intl.DateTimeFormat("en-US", {
     timeZone: tz,
-    year: "numeric", month: "2-digit", day: "2-digit",
-    hour: "2-digit", minute: "2-digit", second: "2-digit",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
     hour12: false,
-  }).format(date);
+  });
+
+  const parts = formatter.formatToParts(date);
+  const values = {
+    year: 0,
+    month: 0,
+    day: 0,
+    hour: 0,
+    minute: 0,
+    second: 0,
+  };
+
+  for (const part of parts) {
+    if (part.type === "literal" || part.type === "dayPeriod") continue;
+    const key = part.type as keyof typeof values;
+    values[key] = Number.parseInt(part.value, 10);
+  }
+
+  return values;
+}
+
+function createUtcDateFromParts(parts: ReturnType<typeof getTimeParts>) {
+  return new Date(
+    Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second),
+  );
+}
+
+function pad(value: number): string {
+  return value.toString().padStart(2, "0");
+}
+
+export function getAppTz(): string {
+  return process.env.NEXT_PUBLIC_APP_TZ || process.env.NEXT_PUBLIC_TZ || DEFAULT_APP_TZ;
+}
+
+export const APP_TZ = getAppTz();
+
+export function localWallclockToUtc(input: DateInput, tz: string = getAppTz()): Date {
+  const base = ensureDate(input);
+  const zonedUtc = createUtcDateFromParts(getTimeParts(base, tz));
+  const offset = zonedUtc.getTime() - base.getTime();
+  return new Date(base.getTime() - offset);
+}
+
+export function utcToZoned(input: DateInput, tz: string = getAppTz()): Date {
+  const date = ensureDate(input);
+  const parts = getTimeParts(date, tz);
+  const iso = `${parts.year}-${pad(parts.month)}-${pad(parts.day)}T${pad(parts.hour)}:${pad(parts.minute)}:${pad(parts.second)}`;
   return new Date(iso);
 }
 
-// Formatter
-export function formatInTZ(date: Date, tz: string = APP_TZ, opts: Intl.DateTimeFormatOptions = {}): string {
-  return new Intl.DateTimeFormat("ja-JP", { timeZone: tz, ...opts }).format(date);
+export function formatInAppTz(
+  input: DateInput,
+  fmt: Intl.DateTimeFormatOptions = {},
+  tz: string = getAppTz(),
+  locale: string = DEFAULT_LOCALE,
+): string {
+  const date = ensureDate(input);
+  return new Intl.DateTimeFormat(locale, { timeZone: tz, ...fmt }).format(date);
 }
 
-export function dayRangeInUtc(yyyyMmDd: string, tz: string = APP_TZ) {
+export function toUTC(input: DateInput, tz?: string): Date {
+  return localWallclockToUtc(input, tz ?? getAppTz());
+}
+
+export function formatInTZ(
+  input: DateInput,
+  tz: string = getAppTz(),
+  opts: Intl.DateTimeFormatOptions = {},
+  locale: string = DEFAULT_LOCALE,
+): string {
+  return formatInAppTz(input, opts, tz, locale);
+}
+
+export function dayRangeInUtc(yyyyMmDd: string, tz: string = getAppTz()) {
   const trimmed = yyyyMmDd.trim();
   if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
     throw new Error(`Invalid date string: ${yyyyMmDd}`);
   }
 
-  const dayStartUtc = zonedTimeToUtc(`${trimmed}T00:00:00`, tz);
+  const dayStartUtc = localWallclockToUtc(`${trimmed}T00:00:00`, tz);
   const dayEndUtc = addDays(dayStartUtc, 1);
 
   return { dayStartUtc, dayEndUtc };


### PR DESCRIPTION
## Summary
- rewrite the shared time utilities to expose new helpers while keeping legacy toUTC/formatInTZ signatures
- add a centralized getAppTz fallback and remove reliance on date-fns-tz exports
- expose a pnpm typecheck script for catching TypeScript regressions locally

## Testing
- `pnpm typecheck` *(fails: pre-existing Prisma- and duties-related type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68df50982cec8323a657dd648d7e8efa