### PR TITLE
Normalize join inputs and improve join error handling

### DIFF
--- a/web/src/app/api/groups/[slug]/join/route.ts
+++ b/web/src/app/api/groups/[slug]/join/route.ts
@@ -7,11 +7,20 @@ import bcrypt from 'bcryptjs'
 import { prisma } from '@/src/lib/prisma'
 import { readUserFromCookie } from '@/lib/auth'
 import { normalizeSlugInput } from '@/lib/slug'
+import { normalizeJoinInput } from '@/lib/text'
 
 function normalize(value: string | string[] | undefined) {
   if (!value) return ''
   const str = Array.isArray(value) ? value[0] : value
   return normalizeSlugInput(String(str ?? ''))
+}
+
+const decodeSlug = (value: string) => {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
 }
 
 export async function POST(req: Request, { params }: { params: { slug: string } }) {
@@ -22,12 +31,15 @@ export async function POST(req: Request, { params }: { params: { slug: string } 
       hasEmail: Boolean(me?.email),
     })
     if (!me?.email) {
-      return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+      return NextResponse.json({ ok: false, code: 'unauthorized', error: 'unauthorized' }, { status: 401 })
     }
 
-    const slug = normalize(params?.slug)
+    const rawSlug = params?.slug ?? ''
+    const decodedSlug = decodeSlug(rawSlug)
+    const slug = normalize(decodedSlug)
+    console.info('[api.groups.join.POST] slug', { raw: rawSlug, decoded: decodedSlug, normalized: slug })
     if (!slug) {
-      return NextResponse.json({ error: 'invalid slug' }, { status: 400 })
+      return NextResponse.json({ ok: false, code: 'invalid_slug', error: 'invalid slug' }, { status: 400 })
     }
 
     let body: unknown = null
@@ -37,7 +49,12 @@ export async function POST(req: Request, { params }: { params: { slug: string } 
       body = null
     }
     const passRaw = body && typeof body === 'object' ? (body as any)?.passcode : undefined
-    const passcode = typeof passRaw === 'string' ? passRaw.trim() : ''
+    const passcodeInput = typeof passRaw === 'string' ? passRaw : ''
+    const normalizedPasscode = normalizeJoinInput(passcodeInput)
+    console.info('[api.groups.join.POST] passcode length', {
+      rawLength: passcodeInput.length,
+      normalizedLength: normalizedPasscode.length,
+    })
 
     const group = await prisma.group.findFirst({
       where: { slug: { equals: slug, mode: 'insensitive' } },
@@ -50,13 +67,36 @@ export async function POST(req: Request, { params }: { params: { slug: string } 
       },
     })
     if (!group) {
-      return NextResponse.json({ error: 'group not found' }, { status: 404 })
+      return NextResponse.json({ ok: false, code: 'group_not_found', error: 'group not found' }, { status: 404 })
     }
 
     if (group.passcode) {
-      const ok = await bcrypt.compare(passcode || '', group.passcode)
+      let ok = false
+      const stored = group.passcode
+      const trimmedPasscode = passcodeInput.trim()
+      const bcryptRounds = parseInt(process.env.BCRYPT_ROUNDS ?? '10', 10)
+      const rounds = Number.isNaN(bcryptRounds) ? 10 : bcryptRounds
+
+      if (stored.startsWith('$2')) {
+        if (normalizedPasscode) {
+          ok = await bcrypt.compare(normalizedPasscode, stored)
+        } else {
+          ok = await bcrypt.compare('', stored)
+        }
+        if (!ok && normalizedPasscode !== trimmedPasscode) {
+          ok = await bcrypt.compare(trimmedPasscode, stored)
+        }
+      } else {
+        const normalizedStored = normalizeJoinInput(stored)
+        ok = normalizedStored === normalizedPasscode || normalizedStored === normalizeJoinInput(trimmedPasscode)
+        if (ok) {
+          const newHash = await bcrypt.hash(normalizedStored, rounds)
+          await prisma.group.update({ where: { id: group.id }, data: { passcode: newHash } })
+        }
+      }
+
       if (!ok) {
-        return NextResponse.json({ error: 'invalid passcode' }, { status: 401 })
+        return NextResponse.json({ ok: false, code: 'invalid_passcode', error: 'invalid passcode' }, { status: 401 })
       }
     }
 
@@ -64,16 +104,24 @@ export async function POST(req: Request, { params }: { params: { slug: string } 
       (member) => member.email.toLowerCase() === me.email.toLowerCase() || (!!me.id && member.userId === me.id)
     )
     if (alreadyMember) {
-      return NextResponse.json({ ok: true, data: { slug: group.slug, name: group.name ?? group.slug } })
+      return NextResponse.json({
+        ok: true,
+        code: 'already_member',
+        data: { slug: group.slug, name: group.name ?? group.slug },
+      })
     }
 
     await prisma.groupMember.create({
       data: { groupId: group.id, email: me.email, userId: me.id, role: 'MEMBER' },
     })
 
-    return NextResponse.json({ ok: true, data: { slug: group.slug, name: group.name ?? group.slug } })
+    return NextResponse.json({
+      ok: true,
+      code: 'joined',
+      data: { slug: group.slug, name: group.name ?? group.slug },
+    })
   } catch (error) {
     console.error('join group failed', error)
-    return NextResponse.json({ error: 'join group failed' }, { status: 500 })
+    return NextResponse.json({ ok: false, code: 'internal_error', error: 'join group failed' }, { status: 500 })
   }
 }

--- a/web/src/app/api/groups/route.ts
+++ b/web/src/app/api/groups/route.ts
@@ -7,6 +7,7 @@ import bcrypt from 'bcryptjs'
 import { prisma } from '@/src/lib/prisma'
 import { readUserFromCookie } from '@/lib/auth'
 import { makeSlug } from '@/lib/slug'
+import { normalizeJoinInput } from '@/lib/text'
 import type { Prisma } from '@prisma/client'
 
 function parseDate(value: unknown) {
@@ -92,7 +93,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'slug already exists' }, { status: 409 })
     }
 
-    const passwordRaw = String((body as any).password || '').trim()
+    const passwordRaw = normalizeJoinInput(String((body as any).password || ''))
     let passcode: string | null = null
     if (passwordRaw) {
       const roundsRaw = parseInt(process.env.BCRYPT_ROUNDS ?? '10', 10)

--- a/web/src/lib/text.ts
+++ b/web/src/lib/text.ts
@@ -1,0 +1,8 @@
+export const normalizeJoinInput = (value: string) =>
+  value
+    .replace(/\u200B/g, '')
+    .replace(/\r?\n/g, '')
+    .trim()
+    .normalize('NFKC');
+
+export default normalizeJoinInput;


### PR DESCRIPTION
## Summary
- add a shared normalization helper for join passcodes and apply it when creating groups
- harden the group join APIs by decoding slugs, rehashing legacy passcodes, and surfacing structured error codes
- show clearer error messaging in the group join form based on API response codes

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68df538723888323a815967d74cccbb1