### PR TITLE
feat(groups): add Host Admin Page (password rotate, members list, clear entry point)

### DIFF
--- a/web/src/app/api/groups/[slug]/admin/rotate-password/route.ts
+++ b/web/src/app/api/groups/[slug]/admin/rotate-password/route.ts
@@ -1,0 +1,47 @@
+import { randomBytes } from 'crypto';
+import bcrypt from 'bcryptjs';
+import { NextResponse } from 'next/server';
+import { prisma } from '@/src/lib/prisma';
+import { getServerSession } from '@/lib/auth';
+
+function decodeSlug(value: string) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function generatePasscode(length = 12) {
+  const candidate = randomBytes(32).toString('base64url');
+  return candidate.slice(0, length);
+}
+
+export async function POST(_: Request, { params }: { params: { slug: string } }) {
+  const session = await getServerSession();
+  const email = session?.user?.email;
+  if (!email) {
+    return NextResponse.json({ code: 'unauthorized' }, { status: 401 });
+  }
+
+  const slug = decodeSlug(params.slug ?? '').toLowerCase();
+  const group = await prisma.group.findUnique({ where: { slug } });
+  if (!group) {
+    return NextResponse.json({ code: 'group_not_found' }, { status: 404 });
+  }
+
+  if (group.hostEmail.toLowerCase() !== email.toLowerCase()) {
+    return NextResponse.json({ code: 'forbidden' }, { status: 403 });
+  }
+
+  const plain = generatePasscode();
+  const roundsRaw = parseInt(process.env.BCRYPT_ROUNDS ?? '10', 10);
+  const rounds = Number.isNaN(roundsRaw) ? 10 : roundsRaw;
+  const hash = await bcrypt.hash(plain, rounds);
+  await prisma.group.update({ where: { id: group.id }, data: { passcode: hash } });
+
+  return NextResponse.json(
+    { password: plain },
+    { headers: { 'Cache-Control': 'no-store' } },
+  );
+}

--- a/web/src/app/api/groups/[slug]/admin/route.ts
+++ b/web/src/app/api/groups/[slug]/admin/route.ts
@@ -1,0 +1,52 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+import { NextResponse } from 'next/server';
+import { prisma } from '@/src/lib/prisma';
+import { getServerSession } from '@/lib/auth';
+
+function decodeSlug(value: string) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function sanitizeBaseUrl(value: string | undefined | null) {
+  if (!value) return '';
+  return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
+export async function GET(_: Request, { params }: { params: { slug: string } }) {
+  const session = await getServerSession();
+  const email = session?.user?.email;
+  if (!email) {
+    return NextResponse.json({ code: 'unauthorized' }, { status: 401 });
+  }
+
+  const slug = decodeSlug(params.slug ?? '').toLowerCase();
+  const group = await prisma.group.findUnique({ where: { slug } });
+  if (!group) {
+    return NextResponse.json({ code: 'group_not_found' }, { status: 404 });
+  }
+
+  if (group.hostEmail.toLowerCase() !== email.toLowerCase()) {
+    return NextResponse.json({ code: 'forbidden' }, { status: 403 });
+  }
+
+  const memberCount = await prisma.groupMember.count({ where: { groupId: group.id } });
+  const baseUrl = sanitizeBaseUrl(process.env.NEXT_PUBLIC_BASE_URL);
+  const inviteLink = `${baseUrl}/groups/${encodeURIComponent(group.slug)}/join`;
+
+  return NextResponse.json(
+    {
+      name: group.name ?? group.slug,
+      slug: group.slug,
+      hasPassword: Boolean(group.passcode),
+      memberCount,
+      inviteLink,
+    },
+    { headers: { 'Cache-Control': 'no-store' } },
+  );
+}

--- a/web/src/app/groups/[slug]/_components/GroupHeader.tsx
+++ b/web/src/app/groups/[slug]/_components/GroupHeader.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+import { prisma } from '@/src/lib/prisma';
+import { getServerSession } from '@/lib/auth';
+
+export default async function GroupHeader({ slug }: { slug: string }) {
+  const session = await getServerSession();
+  const normalizedSlug = slug.toLowerCase();
+  const group = await prisma.group.findUnique({
+    where: { slug: normalizedSlug },
+    select: { id: true, name: true, hostEmail: true, slug: true },
+  });
+
+  const isOwner =
+    !!session?.user?.email &&
+    !!group?.hostEmail &&
+    session.user.email.toLowerCase() === group.hostEmail.toLowerCase();
+
+  if (!group) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center justify-between mb-4">
+      <h1 className="text-xl font-semibold">{group.name ?? group.slug}</h1>
+      {isOwner && (
+        <Link
+          href={`/groups/${encodeURIComponent(group.slug)}/admin`}
+          className="rounded-lg bg-purple-600 text-white px-3 py-2 text-sm"
+        >
+          ホスト専用ページ
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/groups/[slug]/admin/CopyButton.tsx
+++ b/web/src/app/groups/[slug]/admin/CopyButton.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useState } from 'react';
+import clsx from 'clsx';
+
+type CopyButtonProps = {
+  text: string;
+  className?: string;
+  title?: string;
+};
+
+export default function CopyButton({ text, className, title }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error('Failed to copy text', error);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className={clsx('ml-2 rounded border px-2 py-1 text-xs', className)}
+      title={title ?? 'コピー'}
+    >
+      {copied ? 'コピーしました' : 'コピー'}
+    </button>
+  );
+}

--- a/web/src/app/groups/[slug]/admin/PasswordPanel.tsx
+++ b/web/src/app/groups/[slug]/admin/PasswordPanel.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState } from 'react';
+import CopyButton from './CopyButton';
+
+type PasswordPanelProps = {
+  slug: string;
+  hasPassword: boolean;
+};
+
+export default function PasswordPanel({ slug, hasPassword }: PasswordPanelProps) {
+  const [plain, setPlain] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const rotate = async () => {
+    setPending(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/groups/${encodeURIComponent(slug)}/admin/rotate-password`,
+        { method: 'POST', cache: 'no-store' },
+      );
+      if (!res.ok) {
+        setError('パスワードの再発行に失敗しました。');
+        return;
+      }
+      const data = await res.json().catch(() => null);
+      setPlain(typeof data?.password === 'string' ? data.password : null);
+    } catch (err) {
+      console.error('Failed to rotate password', err);
+      setError('パスワードの再発行に失敗しました。');
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <section className="rounded-xl border p-4 space-y-2">
+      <h2 className="font-semibold">参加パスワード</h2>
+      <p className="text-sm text-gray-600">
+        セキュリティのためパスワードはハッシュ保存です。既存の平文は表示できません。
+        再発行すると<strong>一度だけ</strong>新しい平文を表示します。
+      </p>
+      <div>現在の設定：{hasPassword ? 'あり' : 'なし'}</div>
+      {error && <div className="text-sm text-red-600">{error}</div>}
+      {plain ? (
+        <div className="bg-yellow-50 border border-yellow-300 rounded p-3 space-y-1">
+          <div>
+            新しいパスワード：<code className="font-mono">{plain}</code>{' '}
+            <CopyButton text={plain} />
+          </div>
+          <div className="text-xs text-gray-500">※この画面を離れると再表示できません。</div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={rotate}
+          disabled={pending}
+          className="rounded bg-indigo-600 text-white px-3 py-2 text-sm disabled:opacity-60"
+        >
+          {pending ? '再発行中…' : 'パスワードを再発行して表示'}
+        </button>
+      )}
+    </section>
+  );
+}

--- a/web/src/app/groups/[slug]/admin/page.tsx
+++ b/web/src/app/groups/[slug]/admin/page.tsx
@@ -1,0 +1,115 @@
+import Link from 'next/link';
+import { prisma } from '@/src/lib/prisma';
+import { getServerSession } from '@/lib/auth';
+import PasswordPanel from './PasswordPanel';
+import CopyButton from './CopyButton';
+
+export const dynamic = 'force-dynamic';
+
+function sanitizeBaseUrl(value: string | undefined | null) {
+  if (!value) return '';
+  return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
+export default async function AdminPage({ params }: { params: { slug: string } }) {
+  const session = await getServerSession();
+  const rawSlug = params?.slug ?? '';
+  const decodedSlug = (() => {
+    try {
+      return decodeURIComponent(rawSlug);
+    } catch {
+      return rawSlug;
+    }
+  })();
+  const slug = decodedSlug.toLowerCase();
+
+  const group = await prisma.group.findUnique({
+    where: { slug },
+    include: {
+      members: {
+        include: {
+          user: { select: { name: true, email: true } },
+        },
+        orderBy: { createdAt: 'asc' },
+      },
+    },
+  });
+
+  if (!group) {
+    return <div className="p-6">グループが見つかりません。</div>;
+  }
+
+  const sessionEmail = session?.user?.email?.toLowerCase() ?? null;
+  if (!sessionEmail || sessionEmail !== group.hostEmail.toLowerCase()) {
+    return <div className="p-6">権限がありません（ホストのみ）。</div>;
+  }
+
+  const baseUrl = sanitizeBaseUrl(process.env.NEXT_PUBLIC_BASE_URL);
+  const inviteLink = `${baseUrl}/groups/${encodeURIComponent(group.slug)}/join`;
+
+  const members = group.members.map((member) => {
+    const email = member.email;
+    const fallbackName = email ? email.split('@')[0] : '-';
+    return {
+      id: member.id,
+      name: member.user?.name ?? fallbackName,
+      email,
+      role: member.role,
+    };
+  });
+
+  return (
+    <div className="p-6 space-y-6">
+      <nav className="text-sm text-gray-500">
+        <Link href="/groups" className="underline">
+          グループ一覧
+        </Link>
+        {' / '}
+        <Link href={`/groups/${encodeURIComponent(group.slug)}`} className="underline">
+          {group.name ?? group.slug}
+        </Link>
+        {' / '}
+        <span className="font-semibold text-gray-800">ホスト専用ページ</span>
+      </nav>
+
+      <section className="rounded-xl border p-4 space-y-3">
+        <h2 className="font-semibold">グループ情報</h2>
+        <div>名前：{group.name ?? group.slug}</div>
+        <div>
+          slug：<code>{group.slug}</code> <CopyButton text={group.slug} />
+        </div>
+        <div>
+          招待リンク：
+          <code className="break-all">{inviteLink}</code> <CopyButton text={inviteLink} />
+        </div>
+        <div>メンバー数：{members.length}</div>
+      </section>
+
+      <PasswordPanel slug={group.slug} hasPassword={Boolean(group.passcode)} />
+
+      <section className="rounded-xl border p-4">
+        <h2 className="font-semibold mb-3">メンバー一覧</h2>
+        <div className="overflow-x-auto">
+          <table className="min-w-[600px] w-full text-sm">
+            <thead>
+              <tr className="text-left border-b">
+                <th className="py-2">名前</th>
+                <th className="py-2">メール</th>
+                <th className="py-2">役割</th>
+              </tr>
+            </thead>
+            <tbody>
+              {members.map((member) => (
+                <tr key={member.id} className="border-b">
+                  <td className="py-2">{member.name}</td>
+                  <td className="py-2">{member.email}</td>
+                  <td className="py-2">{member.role}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -24,6 +24,7 @@ import Image from 'next/image';
 import { AUTH_COOKIE } from '@/lib/auth/cookies';
 import { decodeSession } from '@/lib/auth';
 import { unstable_noStore as noStore } from 'next/cache';
+import GroupHeader from './_components/GroupHeader';
 
 function buildMonth(base = new Date()) {
   const y = base.getFullYear(), m = base.getMonth();
@@ -263,6 +264,7 @@ export default async function GroupPage({
 
   return (
     <div className="space-y-8 max-w-4xl mx-auto">
+      <GroupHeader slug={group.slug} />
       <div className="print:hidden">
         <GroupScreenClient
           initialGroup={group}


### PR DESCRIPTION
## Summary
- add an always-visible host-only entry point to the group page header
- implement the host admin page with group details, invite link copy, passcode rotation, and member list
- provide supporting admin APIs for group info and passcode rotation

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dfd18f328c83238c43a04419692dd0