### PR TITLE
fix(join): ensure User upsert before GroupMember + add Host Admin Page

### DIFF
--- a/web/src/app/groups/join/page.tsx
+++ b/web/src/app/groups/join/page.tsx
@@ -36,8 +36,8 @@ export default function GroupJoinPage() {
       });
       const payload = await res.json().catch(() => null);
       if (!res.ok || !payload?.ok) {
-        const code = payload?.code || payload?.error;
-        setErr(mapJoinError(code));
+        const code = payload?.code || payload?.error || 'join_failed';
+        setErr(String(code));
         return;
       }
       const nextSlug = payload?.data?.slug || slug;
@@ -92,17 +92,3 @@ export default function GroupJoinPage() {
   );
 }
 
-const JOIN_ERROR_MESSAGES: Record<string, string> = {
-  unauthorized: 'ログインしてください。',
-  invalid_slug: 'グループの識別子が正しくありません。',
-  group_not_found: '指定されたグループが見つかりませんでした。',
-  invalid_passcode: 'パスコードが一致しません。',
-  internal_error: '参加処理でエラーが発生しました。',
-};
-
-function mapJoinError(code?: string) {
-  if (!code) return '参加に失敗しました';
-  if (JOIN_ERROR_MESSAGES[code]) return JOIN_ERROR_MESSAGES[code];
-  if (code === 'already_member') return 'すでにこのグループのメンバーです。';
-  return '参加に失敗しました';
-}


### PR DESCRIPTION
## Summary
- ensure the group join API loads the signed-in user from the server session, creates or updates the Prisma user record, handles hashed passcodes, and upserts the membership with logging and clear error codes
- display backend join error codes directly on the group join page so users can see responses such as `already_member`

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e025de83cc83239e11585890da6b21