### PR TITLE
fix: sync profile name in reservations + unify timezone handling

### DIFF
--- a/web/src/app/api/groups/[slug]/reservations/route.ts
+++ b/web/src/app/api/groups/[slug]/reservations/route.ts
@@ -40,12 +40,7 @@ export async function GET(req: Request, { params }: { params: { slug: string } }
         ...(rangeEnd ? { start: { lt: rangeEnd } } : {}),
       },
       orderBy: { start: "asc" },
-      select: {
-        id: true,
-        start: true,
-        end: true,
-        purpose: true,
-        userEmail: true,
+      include: {
         device: {
           select: {
             id: true,
@@ -53,7 +48,7 @@ export async function GET(req: Request, { params }: { params: { slug: string } }
             slug: true,
           },
         },
-        userName: true,
+        user: { select: { id: true, name: true, email: true } },
       },
     });
 
@@ -66,7 +61,14 @@ export async function GET(req: Request, { params }: { params: { slug: string } }
       endsAtUTC: reservation.end.toISOString(),
       purpose: reservation.purpose,
       userEmail: reservation.userEmail,
-      userName: reservation.userName,
+      userName: reservation.user?.name ?? reservation.userName ?? null,
+      user: reservation.user
+        ? {
+            id: reservation.user.id,
+            name: reservation.user.name ?? null,
+            email: reservation.user.email ?? reservation.userEmail ?? null,
+          }
+        : null,
     }));
 
     return new NextResponse(JSON.stringify({ items }), {

--- a/web/src/app/api/groups/[slug]/route.ts
+++ b/web/src/app/api/groups/[slug]/route.ts
@@ -17,7 +17,12 @@ async function buildGroupPayload(slug: string) {
       members: true,
       devices: {
         orderBy: { name: 'asc' },
-        include: { reservations: { orderBy: { start: 'asc' } } },
+        include: {
+          reservations: {
+            orderBy: { start: 'asc' },
+            include: { user: { select: { id: true, name: true, email: true } } },
+          },
+        },
       },
       dutyTypes: {
         orderBy: { name: 'asc' },
@@ -41,6 +46,13 @@ async function buildGroupPayload(slug: string) {
       userName: reservation.userName ?? null,
       reminderMinutes: reservation.reminderMinutes ?? null,
       userId: reservation.userId,
+      user: reservation.user
+        ? {
+            id: reservation.user.id,
+            name: reservation.user.name ?? null,
+            email: reservation.user.email ?? null,
+          }
+        : null,
     }))
   )
 
@@ -49,6 +61,7 @@ async function buildGroupPayload(slug: string) {
       group.hostEmail,
       ...group.members.map((member) => member.email),
       ...reservations.map((reservation) => reservation.userEmail),
+      ...reservations.map((reservation) => reservation.user?.email).filter(Boolean) as string[],
     ])
   )
 
@@ -62,15 +75,26 @@ async function buildGroupPayload(slug: string) {
     deviceId: reservation.deviceId,
     deviceSlug: reservation.deviceSlug,
     deviceName: reservation.deviceName,
+    startsAtUTC: reservation.start.toISOString(),
+    endsAtUTC: reservation.end.toISOString(),
     start: reservation.start.toISOString(),
     end: reservation.end.toISOString(),
     purpose: reservation.purpose,
     reminderMinutes: reservation.reminderMinutes,
     userEmail: reservation.userEmail,
     userName:
+      reservation.user?.name ||
       reservation.userName ||
       displayNameMap.get(reservation.userEmail) ||
       reservation.userEmail.split('@')[0],
+    user:
+      reservation.user
+        ? {
+            id: reservation.user.id,
+            name: reservation.user.name ?? null,
+            email: reservation.user.email ?? reservation.userEmail ?? null,
+          }
+        : null,
     userId: reservation.userId,
   }))
 

--- a/web/src/app/api/me/reservations/route.ts
+++ b/web/src/app/api/me/reservations/route.ts
@@ -60,6 +60,7 @@ export async function GET(req: Request) {
           group: { select: { id: true, slug: true, name: true } },
         },
       },
+      user: { select: { id: true, name: true, email: true } },
     },
   })
 
@@ -71,12 +72,26 @@ export async function GET(req: Request) {
     groupId: reservation.device.group.id,
     groupSlug: reservation.device.group.slug,
     groupName: reservation.device.group.name ?? reservation.device.group.slug,
+    startsAtUTC: reservation.start.toISOString(),
+    endsAtUTC: reservation.end.toISOString(),
     start: reservation.start.toISOString(),
     end: reservation.end.toISOString(),
     purpose: reservation.purpose ?? null,
     reminderMinutes: reservation.reminderMinutes ?? null,
     userEmail: reservation.userEmail,
     userId: reservation.userId ?? null,
+    userName: reservation.user?.name ?? me.name ?? null,
+    user: reservation.user
+      ? {
+          id: reservation.user.id,
+          name: reservation.user.name ?? null,
+          email: reservation.user.email ?? null,
+        }
+      : {
+          id: reservation.userId ?? null,
+          name: me.name ?? null,
+          email: reservation.userEmail,
+        },
     participants: [] as string[],
   }))
 

--- a/web/src/app/api/reservations/[id]/route.ts
+++ b/web/src/app/api/reservations/[id]/route.ts
@@ -36,7 +36,7 @@ async function loadReservation(id: string) {
           },
         },
       },
-      user: { select: { id: true } },
+      user: { select: { id: true, name: true, email: true } },
     },
   })
 }
@@ -67,13 +67,26 @@ function toPayload(reservation: NonNullable<Awaited<ReturnType<typeof loadReserv
     deviceSlug: reservation.device.slug,
     deviceName: reservation.device.name,
     groupSlug: reservation.device.group.slug,
+    startsAtUTC: reservation.start.toISOString(),
+    endsAtUTC: reservation.end.toISOString(),
     start: reservation.start.toISOString(),
     end: reservation.end.toISOString(),
     purpose: reservation.purpose ?? null,
     reminderMinutes: reservation.reminderMinutes ?? null,
     userEmail: reservation.userEmail,
-    userName: reservation.userName ?? null,
+    userName: reservation.user?.name ?? reservation.userName ?? null,
     userId: reservation.user?.id ?? reservation.userId ?? null,
+    user: reservation.user
+      ? {
+          id: reservation.user.id,
+          name: reservation.user.name ?? null,
+          email: reservation.user.email ?? reservation.userEmail ?? null,
+        }
+      : {
+          id: reservation.userId ?? null,
+          name: reservation.userName ?? null,
+          email: reservation.userEmail,
+        },
   }
 }
 
@@ -143,7 +156,7 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
           },
         },
       },
-      user: { select: { id: true } },
+      user: { select: { id: true, name: true, email: true } },
     },
   })
 

--- a/web/src/app/dashboard/page.client.tsx
+++ b/web/src/app/dashboard/page.client.tsx
@@ -35,16 +35,26 @@ export default function DashboardClient({ initialItems, initialSpans, isLoggedIn
 
   const handleLoaded = (j: any) => {
     const all = (j.all ?? []) as any[];
-      const updated: Span[] = all.map((r: any) => ({
-        id: r.id,
-        name: r.deviceName ?? r.deviceId,
-        start: new Date(r.start),
-        end: new Date(r.end),
-        color: colorFromString(r.deviceId),
-        groupSlug: r.groupSlug,
-        by: r.userName || r.user?.split('@')[0] || r.user,
-        participants: r.participants ?? [],
-      }));
+      const updated: Span[] = all.map((r: any) => {
+        const userObj = typeof r.user === 'object' && r.user !== null ? r.user : null;
+        const userEmail: string | undefined = userObj?.email ?? (typeof r.user === 'string' ? r.user : undefined) ?? r.userEmail;
+        const displayName =
+          userObj?.name ||
+          r.userName ||
+          (typeof r.user === 'string' ? r.user.split('@')[0] : undefined) ||
+          (userEmail ? userEmail.split('@')[0] : '');
+
+        return {
+          id: r.id,
+          name: r.deviceName ?? r.deviceId,
+          start: new Date(r.startsAtUTC ?? r.start),
+          end: new Date(r.endsAtUTC ?? r.end),
+          color: colorFromString(r.deviceId),
+          groupSlug: r.groupSlug,
+          by: displayName,
+          participants: r.participants ?? [],
+        };
+      });
     setSpans(updated);
   };
 

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -13,7 +13,9 @@ import { redirect } from 'next/navigation';
 type Mine = {
   id:string; deviceId:string; deviceName?:string; userEmail:string; userName?:string;
   participants?: string[];
-  start:string; end:string; purpose?:string; groupSlug:string; groupName:string;
+  start:string; end:string; startsAtUTC?:string; endsAtUTC?:string;
+  purpose?:string; groupSlug:string; groupName:string;
+  user?: { id?: string | null; name?: string | null; email?: string | null } | null;
 };
 
 function colorFromString(s:string){
@@ -43,14 +45,15 @@ export default async function DashboardPage() {
 
   const mineAll = json?.all ?? [];
   const nameOf = (r: any) => {
-    if (me && r.userEmail === me.email) return me.name || me.email.split('@')[0];
-    return r.userName || r.userEmail?.split('@')[0] || r.userName || '';
+    const email: string | undefined = r.user?.email ?? r.userEmail ?? undefined;
+    if (me && email && email === me.email) return me.name || email.split('@')[0];
+    return r.user?.name || r.userName || (email ? email.split('@')[0] : '');
   };
   spans = mineAll.map((r: any) => ({
     id: r.id,
     name: r.deviceName ?? r.deviceId,
-    start: new Date(r.start),
-    end: new Date(r.end),
+    start: new Date(r.startsAtUTC ?? r.start),
+    end: new Date(r.endsAtUTC ?? r.end),
     color: colorFromString(r.deviceId),
     groupSlug: r.groupSlug,
     by: nameOf(r),

--- a/web/src/app/groups/[slug]/devices/[deviceSlug]/page.tsx
+++ b/web/src/app/groups/[slug]/devices/[deviceSlug]/page.tsx
@@ -4,7 +4,7 @@ export const runtime = 'nodejs';
 export const fetchCache = 'force-no-store';
 
 import { serverFetch } from '@/lib/http/serverFetch';
-import { APP_TZ, toUTC } from '@/lib/time';
+import { dayRangeInUtc } from '@/lib/time';
 import {
   extractReservationItems,
   normalizeReservation,
@@ -82,22 +82,10 @@ export default async function DeviceDetail({
   rangeEnd.setHours(0, 0, 0, 0);
   rangeEnd.setDate(rangeEnd.getDate() + 1);
   const toYmd = (d: Date) => `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
-  const toUtcFromLocalString = (value: string, tz: string = APP_TZ) => {
-    const normalized = value.trim().replace(' ', 'T');
-    const iso = /T\d{2}:\d{2}(?::\d{2})?$/.test(normalized) ? normalized : `${normalized}:00`;
-    const base = new Date(iso);
-    if (Number.isNaN(base.getTime())) throw new Error(`Invalid date string: ${value}`);
-    const projected = toUTC(base, tz);
-    const offset = projected.getTime() - base.getTime();
-    return new Date(base.getTime() - offset);
-  };
-  const localDayRange = (yyyyMmDd: string, tz: string = APP_TZ) => {
-    const start = toUtcFromLocalString(`${yyyyMmDd}T00:00`, tz);
-    const end = toUtcFromLocalString(`${yyyyMmDd}T24:00`, tz);
-    return { start, end };
-  };
-  const { start: rangeStartBoundary } = localDayRange(toYmd(rangeStart));
-  const { end: rangeEndBoundary } = localDayRange(toYmd(new Date(rangeEnd.getTime() - 24 * 60 * 60 * 1000)));
+  const { dayStartUtc: rangeStartBoundary } = dayRangeInUtc(toYmd(rangeStart));
+  const { dayEndUtc: rangeEndBoundary } = dayRangeInUtc(
+    toYmd(new Date(rangeEnd.getTime() - 24 * 60 * 60 * 1000)),
+  );
 
   const reservationsParams = new URLSearchParams({
     deviceSlug,
@@ -127,8 +115,11 @@ export default async function DeviceDetail({
     .filter((item): item is NormalizedReservation => Boolean(item))
     .filter((reservation) => overlapsRange(reservation, rangeStartBoundary, rangeEndBoundary));
   const nameOf = (r: NormalizedReservation) => {
-    if (me && r.userEmail === me.email) return me.name || me.email.split('@')[0];
-    return r.userName || r.userEmail?.split('@')[0] || '';
+    const email = r.user?.email ?? r.userEmail ?? undefined;
+    if (me && email && email === me.email) {
+      return me.name || email.split('@')[0];
+    }
+    return r.user?.name || r.userName || (email ? email.split('@')[0] : '');
   };
 
   const spans: Span[] = reservations.map((r) => ({

--- a/web/src/app/groups/[slug]/reservations/[date]/page.tsx
+++ b/web/src/app/groups/[slug]/reservations/[date]/page.tsx
@@ -10,6 +10,8 @@ type ReservationItem = {
   deviceId?: string | null;
   start?: string | null;
   end?: string | null;
+  startsAtUTC?: string | null;
+  endsAtUTC?: string | null;
   purpose?: string | null;
 };
 
@@ -47,8 +49,8 @@ export default async function Day({
     .map((item) => ({
       id: item.id,
       deviceName: item.deviceName || item.deviceId || "",
-      start: item.start ?? "",
-      end: item.end ?? "",
+      start: item.startsAtUTC ?? item.start ?? "",
+      end: item.endsAtUTC ?? item.end ?? "",
       note: item.purpose ?? null,
     }))
     .filter((item) => item.id && item.deviceName && item.start && item.end);

--- a/web/src/lib/reservations.ts
+++ b/web/src/lib/reservations.ts
@@ -21,6 +21,11 @@ export type ReservationDto = {
   purpose?: string | null;
   userEmail?: string | null;
   userName?: string | null;
+  user?: {
+    id?: string | null;
+    name?: string | null;
+    email?: string | null;
+  } | null;
   note?: string | null;
   start?: string;
   end?: string;
@@ -47,6 +52,11 @@ export type NormalizedReservation = {
   purpose: string | null;
   userEmail: string | null;
   userName: string | null;
+  user: {
+    id: string | null;
+    name: string | null;
+    email: string | null;
+  } | null;
   startsAtUTC: string;
   endsAtUTC: string;
   startUtc: Date;
@@ -94,6 +104,7 @@ export function normalizeReservation(
   const end = utcToZoned(endUtc, tz);
 
   const device = raw.device ?? {};
+  const user = raw.user ?? null;
   const deviceId = firstTruthy(raw.deviceId, device.id);
   if (!deviceId) {
     return null;
@@ -110,8 +121,21 @@ export function normalizeReservation(
     deviceSlug: firstTruthy(raw.deviceSlug, device.slug) ?? null,
     deviceName: firstTruthy(raw.deviceName, device.name) ?? null,
     purpose: firstTruthy(raw.purpose, raw.note) ?? null,
-    userEmail: raw.userEmail ?? null,
-    userName: raw.userName ?? null,
+    userEmail: firstTruthy(raw.userEmail, user?.email) ?? null,
+    userName: firstTruthy(raw.userName, user?.name) ?? null,
+    user: user
+      ? {
+          id: firstTruthy(user.id) ?? null,
+          name: firstTruthy(user.name) ?? null,
+          email: firstTruthy(user.email, raw.userEmail) ?? null,
+        }
+      : raw.userEmail || raw.userName
+        ? {
+            id: null,
+            name: firstTruthy(raw.userName) ?? null,
+            email: firstTruthy(raw.userEmail) ?? null,
+          }
+        : null,
     startsAtUTC: startUtc.toISOString(),
     endsAtUTC: endUtc.toISOString(),
     startUtc,


### PR DESCRIPTION
## Summary
- load joined user records for reservation listings and expose UTC timestamps across group/device/daily APIs
- normalize reservations to surface joined user info and refresh dashboard/group/device views to read `reservation.user.name`
- standardize local→UTC conversion utilities and update reservation forms to submit `startsAtUTC`/`endsAtUTC`

## Testing
- pnpm --filter lab_yoyaku-web typecheck *(fails: Prisma client model types are not generated in the workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68e029e1a12083239282ef76a649fa9e