### PR TITLE
fix/auth-normalization-and-hash-compat

### DIFF
--- a/web/prisma/migrations/202510100900_auth_normalization/migration.sql
+++ b/web/prisma/migrations/202510100900_auth_normalization/migration.sql
@@ -1,0 +1,24 @@
+-- Add normalizedEmail column and migrate existing data
+ALTER TABLE "User" ADD COLUMN "normalizedEmail" TEXT;
+ALTER TABLE "User" ADD COLUMN "passwordHash" TEXT;
+
+UPDATE "User"
+SET "normalizedEmail" = lower(btrim("email"));
+
+ALTER TABLE "User"
+ALTER COLUMN "normalizedEmail" SET NOT NULL;
+
+-- Drop old unique constraint on email if it exists
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_indexes
+    WHERE schemaname = current_schema()
+      AND indexname = 'User_email_key'
+  ) THEN
+    EXECUTE 'DROP INDEX "User_email_key"';
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX "User_normalizedEmail_key" ON "User"("normalizedEmail");

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -8,15 +8,17 @@ datasource db {
 }
 
 model User {
-  id            String        @id @default(cuid())
-  name          String?
-  email         String?       @unique
-  emailVerified DateTime?
-  image         String?
-  accounts      Account[]
-  sessions      Session[]
-  reservations  Reservation[]
-  dutyAssignments DutyAssignment[]
+  id               String        @id @default(cuid())
+  name             String?
+  email            String?       @db.Text
+  normalizedEmail  String        @unique @db.Text
+  passwordHash     String?       @db.Text
+  emailVerified    DateTime?
+  image            String?
+  accounts         Account[]
+  sessions         Session[]
+  reservations     Reservation[]
+  dutyAssignments  DutyAssignment[]
   groupMemberships GroupMember[]
 }
 

--- a/web/src/app/api/auth/login/route.ts
+++ b/web/src/app/api/auth/login/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from 'next/server';
 import bcrypt from 'bcryptjs';
 import { SignJWT } from 'jose';
-import { findUserByEmail } from '@/lib/auth';
+import { findUserByEmail, normalizeEmail } from '@/lib/auth';
 import { setSessionCookie } from '@/lib/auth/cookies';
+import { needsRehash, verifyPassword } from '@/lib/password';
+import { prisma } from '@/lib/prisma';
 
 const JWT_SECRET = new TextEncoder().encode(
   process.env.AUTH_SECRET || process.env.JWT_SECRET || 'dev-secret',
@@ -14,7 +16,8 @@ export const runtime = 'nodejs';
 
 export async function POST(req: Request) {
   const body = await req.json().catch(() => ({}));
-  const email = String(body?.email ?? '').trim().toLowerCase();
+  const rawEmail = typeof body?.email === 'string' ? body.email.trim() : '';
+  const email = normalizeEmail(rawEmail);
   const password = String(body?.password ?? '').trim();
 
   if (!email || !password) {
@@ -35,24 +38,37 @@ export async function POST(req: Request) {
 
   const user = email ? await findUserByEmail(email) : null;
   if (!user) {
-    return NextResponse.json({ error: 'INVALID_LOGIN' }, { status: 401 });
+    return NextResponse.json({ error: 'INVALID_CREDENTIALS' }, { status: 401 });
   }
 
-  const storedHash = user.passwordHash ?? (user as any).passHash ?? '';
   let ok = false;
-  if (storedHash) {
-    try {
-      ok = await bcrypt.compare(password, storedHash);
-    } catch {
-      ok = false;
-    }
+  let storedHash = (user as any).passwordHash ?? (user as any).passHash ?? '';
+  try {
+    ok = await verifyPassword(password, storedHash);
+  } catch (error) {
+    console.error('verify password failed', error);
+    ok = false;
   }
 
   if (!ok) {
-    return NextResponse.json({ error: 'INVALID_LOGIN' }, { status: 401 });
+    return NextResponse.json({ error: 'INVALID_CREDENTIALS' }, { status: 401 });
   }
 
-  const jwt = await new SignJWT({ id: user.id, name: user.name || '', email: user.email })
+  if (await needsRehash(storedHash)) {
+    try {
+      const roundsRaw = parseInt(process.env.BCRYPT_ROUNDS ?? '12', 10);
+      const rounds = Number.isNaN(roundsRaw) ? 12 : roundsRaw;
+      const hash = await bcrypt.hash(password, rounds);
+      storedHash = hash;
+      if ('normalizedEmail' in user) {
+        await prisma.user.update({ where: { id: user.id }, data: { passwordHash: hash } });
+      }
+    } catch (error) {
+      console.warn('password rehash skipped', error);
+    }
+  }
+
+  const jwt = await new SignJWT({ id: user.id, name: user.name || '', email: user.email || rawEmail })
     .setProtectedHeader({ alg: 'HS256' })
     .setIssuedAt()
     .setExpirationTime('30d')

--- a/web/src/app/api/devices/[slug]/route.ts
+++ b/web/src/app/api/devices/[slug]/route.ts
@@ -4,7 +4,7 @@ export const runtime = 'nodejs'
 
 import { NextResponse } from 'next/server'
 import { prisma } from '@/src/lib/prisma'
-import { readUserFromCookie } from '@/lib/auth'
+import { normalizeEmail, readUserFromCookie } from '@/lib/auth'
 
 export async function GET(_req: Request, { params }: { params: { slug: string } }) {
   try {
@@ -23,9 +23,10 @@ export async function GET(_req: Request, { params }: { params: { slug: string } 
       return NextResponse.json({ error: 'device not found' }, { status: 404 })
     }
 
+    const normalizedEmail = normalizeEmail(me.email)
     const isMember =
-      device.group.hostEmail === me.email ||
-      device.group.members.some((member) => member.email === me.email)
+      normalizeEmail(device.group.hostEmail ?? '') === normalizedEmail ||
+      device.group.members.some((member) => normalizeEmail(member.email) === normalizedEmail)
     if (!isMember) {
       return NextResponse.json({ error: 'forbidden' }, { status: 403 })
     }

--- a/web/src/app/api/devices/route.ts
+++ b/web/src/app/api/devices/route.ts
@@ -4,7 +4,7 @@ export const runtime = 'nodejs'
 
 import { NextResponse } from 'next/server'
 import { z } from '@/lib/zod-helpers'
-import { readUserFromCookie } from '@/lib/auth'
+import { normalizeEmail, readUserFromCookie } from '@/lib/auth'
 import { prisma } from '@/src/lib/prisma'
 
 const QuerySchema = z.object({
@@ -38,9 +38,10 @@ export async function GET(req: Request) {
       return NextResponse.json({ error: 'group not found' }, { status: 404 })
     }
 
+    const normalizedEmail = normalizeEmail(me.email)
     const isMember =
-      group.hostEmail === me.email ||
-      group.members.some((member) => member.email === me.email)
+      normalizeEmail(group.hostEmail ?? '') === normalizedEmail ||
+      group.members.some((member) => normalizeEmail(member.email) === normalizedEmail)
 
     if (!isMember) {
       return NextResponse.json({ error: 'forbidden' }, { status: 403 })

--- a/web/src/app/api/groups/[slug]/admin/rotate-password/route.ts
+++ b/web/src/app/api/groups/[slug]/admin/rotate-password/route.ts
@@ -2,7 +2,7 @@ import { randomBytes } from 'crypto';
 import bcrypt from 'bcryptjs';
 import { NextResponse } from 'next/server';
 import { prisma } from '@/src/lib/prisma';
-import { getServerSession } from '@/lib/auth';
+import { getServerSession, normalizeEmail } from '@/lib/auth';
 
 function decodeSlug(value: string) {
   try {
@@ -30,7 +30,7 @@ export async function POST(_: Request, { params }: { params: { slug: string } })
     return NextResponse.json({ code: 'group_not_found' }, { status: 404 });
   }
 
-  if (group.hostEmail.toLowerCase() !== email.toLowerCase()) {
+  if (normalizeEmail(group.hostEmail ?? '') !== normalizeEmail(email)) {
     return NextResponse.json({ code: 'forbidden' }, { status: 403 });
   }
 

--- a/web/src/app/api/groups/[slug]/admin/route.ts
+++ b/web/src/app/api/groups/[slug]/admin/route.ts
@@ -3,7 +3,7 @@ export const revalidate = 0;
 
 import { NextResponse } from 'next/server';
 import { prisma } from '@/src/lib/prisma';
-import { getServerSession } from '@/lib/auth';
+import { getServerSession, normalizeEmail } from '@/lib/auth';
 
 function decodeSlug(value: string) {
   try {
@@ -31,7 +31,7 @@ export async function GET(_: Request, { params }: { params: { slug: string } }) 
     return NextResponse.json({ code: 'group_not_found' }, { status: 404 });
   }
 
-  if (group.hostEmail.toLowerCase() !== email.toLowerCase()) {
+  if (normalizeEmail(group.hostEmail ?? '') !== normalizeEmail(email)) {
     return NextResponse.json({ code: 'forbidden' }, { status: 403 });
   }
 

--- a/web/src/app/api/groups/[slug]/devices/[device]/route.ts
+++ b/web/src/app/api/groups/[slug]/devices/[device]/route.ts
@@ -4,7 +4,7 @@ export const runtime = 'nodejs'
 
 import { NextResponse } from 'next/server'
 import { prisma } from '@/src/lib/prisma'
-import { readUserFromCookie } from '@/lib/auth'
+import { normalizeEmail, readUserFromCookie } from '@/lib/auth'
 
 export async function GET(
   _req: Request,
@@ -34,9 +34,10 @@ export async function GET(
       return NextResponse.json({ error: 'device not found' }, { status: 404 })
     }
 
+    const normalizedEmail = normalizeEmail(me.email)
     const isMember =
-      device.group.hostEmail === me.email ||
-      device.group.members.some((member) => member.email === me.email)
+      normalizeEmail(device.group.hostEmail ?? '') === normalizedEmail ||
+      device.group.members.some((member) => normalizeEmail(member.email) === normalizedEmail)
     if (!isMember) {
       return NextResponse.json({ error: 'forbidden' }, { status: 403 })
     }
@@ -123,10 +124,12 @@ export async function DELETE(
       return NextResponse.json({ error: 'device not found' }, { status: 404 })
     }
 
+    const normalizedEmail = normalizeEmail(me.email)
     const canManage =
       device.group.deviceManagePolicy === 'MEMBERS_ALLOWED'
-        ? device.group.hostEmail === me.email || device.group.members.some((member) => member.email === me.email)
-        : device.group.hostEmail === me.email
+        ? normalizeEmail(device.group.hostEmail ?? '') === normalizedEmail ||
+          device.group.members.some((member) => normalizeEmail(member.email) === normalizedEmail)
+        : normalizeEmail(device.group.hostEmail ?? '') === normalizedEmail
 
     if (!canManage) {
       return NextResponse.json({ error: 'forbidden' }, { status: 403 })

--- a/web/src/app/api/me/profile/route.ts
+++ b/web/src/app/api/me/profile/route.ts
@@ -3,7 +3,7 @@ export const revalidate = 0
 export const runtime = 'nodejs'
 
 import { NextResponse } from 'next/server'
-import { readUserFromCookie } from '@/lib/auth'
+import { normalizeEmail, readUserFromCookie } from '@/lib/auth'
 import { prisma } from '@/src/lib/prisma'
 import { updateUserNameByEmail } from '@/lib/db'
 
@@ -24,8 +24,9 @@ export async function GET() {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
   }
 
+  const normalizedEmail = normalizeEmail(me.email)
   const existing = await prisma.user.findUnique({
-    where: { email: me.email },
+    where: { normalizedEmail },
   })
 
   if (!existing) {
@@ -72,10 +73,11 @@ export async function PUT(req: Request) {
     return NextResponse.json({ error: 'name too long' }, { status: 400 })
   }
 
+  const normalizedEmail = normalizeEmail(me.email)
   const updated = await prisma.user.upsert({
-    where: { email: me.email },
-    update: { name },
-    create: { email: me.email, name },
+    where: { normalizedEmail },
+    update: { name, email: me.email },
+    create: { email: me.email, normalizedEmail, name },
     select: { id: true, email: true, name: true },
   })
 

--- a/web/src/app/groups/[slug]/_components/GroupHeader.tsx
+++ b/web/src/app/groups/[slug]/_components/GroupHeader.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { prisma } from '@/src/lib/prisma';
 import { getServerSession } from '@/lib/auth';
+import { normalizeEmail } from '@/lib/email';
 
 export default async function GroupHeader({ slug }: { slug: string }) {
   const session = await getServerSession();
@@ -13,7 +14,7 @@ export default async function GroupHeader({ slug }: { slug: string }) {
   const isOwner =
     !!session?.user?.email &&
     !!group?.hostEmail &&
-    session.user.email.toLowerCase() === group.hostEmail.toLowerCase();
+    normalizeEmail(session.user.email) === normalizeEmail(group.hostEmail);
 
   if (!group) {
     return null;

--- a/web/src/app/groups/[slug]/admin/page.tsx
+++ b/web/src/app/groups/[slug]/admin/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { prisma } from '@/src/lib/prisma';
 import { getServerSession } from '@/lib/auth';
+import { normalizeEmail } from '@/lib/email';
 import PasswordPanel from './PasswordPanel';
 import CopyButton from './CopyButton';
 
@@ -39,8 +40,8 @@ export default async function AdminPage({ params }: { params: { slug: string } }
     return <div className="p-6">グループが見つかりません。</div>;
   }
 
-  const sessionEmail = session?.user?.email?.toLowerCase() ?? null;
-  if (!sessionEmail || sessionEmail !== group.hostEmail.toLowerCase()) {
+  const sessionEmail = session?.user?.email ? normalizeEmail(session.user.email) : null;
+  if (!sessionEmail || sessionEmail !== normalizeEmail(group.hostEmail ?? '')) {
     return <div className="p-6">権限がありません（ホストのみ）。</div>;
   }
 

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -40,7 +40,7 @@ export default function LoginPage() {
       if (!res.ok) throw new Error();
       router.replace(next || '/');
     } catch {
-      setLErr('メールまたはパスワードが違います');
+      setLErr('メールまたはパスワードが違います（大文字小文字は区別しません）');
     } finally {
       setLoadingLogin(false);
     }
@@ -66,8 +66,10 @@ export default function LoginPage() {
         credentials: 'same-origin',
       });
       if (!res.ok) {
-        const t = await res.text();
-        throw new Error(/already/.test(t) ? 'このメールは登録済みです' : '登録に失敗しました');
+        if (res.status === 409) {
+          throw new Error('このメールは既に登録されています。ログインしてください');
+        }
+        throw new Error('登録に失敗しました');
       }
       router.replace('/');
     } catch (e: any) {

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 import path from 'path';
 import { loadDB, UserRecord } from './mockdb';
+import { normalizeEmail } from './email';
 
 // ``better-sqlite3`` はネイティブモジュールのため環境によっては
 // 読み込みに失敗することがある。その場合はメモリ上のモックDBに
@@ -47,7 +48,8 @@ export async function updateUserNameByEmail(email: string, name: string): Promis
     return;
   }
   const dbData = loadDB();
-  const record = dbData.users.find((user) => user.email.toLowerCase() === email.toLowerCase());
+  const target = normalizeEmail(email);
+  const record = dbData.users.find((user) => normalizeEmail(user.email) === target);
   if (record) {
     record.name = name;
   }

--- a/web/src/lib/email.ts
+++ b/web/src/lib/email.ts
@@ -1,0 +1,1 @@
+export const normalizeEmail = (s: string) => s.trim().toLowerCase();

--- a/web/src/lib/password.ts
+++ b/web/src/lib/password.ts
@@ -1,0 +1,33 @@
+import bcrypt from 'bcryptjs';
+import { hashPassword } from '@/lib/auth';
+
+const BCRYPT_TARGET_COST = (() => {
+  const env = parseInt(process.env.BCRYPT_ROUNDS ?? '12', 10);
+  return Number.isNaN(env) ? 12 : env;
+})();
+
+const LEGACY_SHA_REGEX = /^[0-9a-f]{64}$/i;
+
+export async function verifyPassword(plain: string, hash: string | null | undefined) {
+  if (!hash) return false;
+  if (hash.startsWith('$2a$') || hash.startsWith('$2b$') || hash.startsWith('$2y$')) {
+    return bcrypt.compare(plain, hash);
+  }
+  if (LEGACY_SHA_REGEX.test(hash)) {
+    return hashPassword(plain) === hash.toLowerCase();
+  }
+  throw new Error('Unsupported hash format');
+}
+
+export async function needsRehash(hash: string | null | undefined) {
+  if (!hash) return true;
+  if (hash.startsWith('$2a$') || hash.startsWith('$2b$') || hash.startsWith('$2y$')) {
+    const cost = parseInt(hash.slice(4, 6), 10);
+    if (Number.isNaN(cost)) return true;
+    return cost < BCRYPT_TARGET_COST;
+  }
+  if (LEGACY_SHA_REGEX.test(hash)) {
+    return true;
+  }
+  return true;
+}

--- a/web/src/lib/perm.ts
+++ b/web/src/lib/perm.ts
@@ -1,8 +1,14 @@
+import { normalizeEmail } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 
 export async function getActorByEmail(email?: string | null) {
   if (!email) return null;
-  return prisma.user.findUnique({ where: { email }, select: { id: true, email: true, name: true } });
+  const normalized = normalizeEmail(email);
+  if (!normalized) return null;
+  return prisma.user.findUnique({
+    where: { normalizedEmail: normalized },
+    select: { id: true, email: true, name: true },
+  });
 }
 
 export async function getGroupAndRole(slug: string, userId: string) {


### PR DESCRIPTION
## Summary
- add a normalizedEmail column and passwordHash storage to the Prisma User model with a backfill migration
- update the authentication helpers and login/register APIs to normalize emails, surface 409 conflicts, and support legacy password hashes with rehashing
- normalize email comparisons across group/reservation endpoints and refresh the login UI messaging

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e1f33cf7d88323a60701326f7ce1e7