### PR TITLE
Fix reservation calendar timezone handling

### DIFF
--- a/web/src/app/dashboard/page.client.tsx
+++ b/web/src/app/dashboard/page.client.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from 'react';
 import UpcomingReservations, { Item } from '../_parts/UpcomingReservations';
 import CalendarWithBars, { Span } from '@/components/CalendarWithBars';
 import { addMonths, buildWeeks, firstOfMonth } from '@/lib/date-cal';
+import { utcIsoToLocalDate } from '@/lib/time';
 
 export default function DashboardClient({ initialItems, initialSpans, isLoggedIn }: { initialItems: Item[]; initialSpans: Span[]; isLoggedIn: boolean }) {
   const [spans, setSpans] = useState<Span[]>(initialSpans);
@@ -31,11 +32,16 @@ export default function DashboardClient({ initialItems, initialSpans, isLoggedIn
           (typeof r.user === 'string' ? r.user.split('@')[0] : undefined) ||
           (userEmail ? userEmail.split('@')[0] : '');
 
+        const startIso = new Date(r.startsAtUTC ?? r.start).toISOString();
+        const endIso = new Date(r.endsAtUTC ?? r.end).toISOString();
+
         return {
           id: r.id,
           name: r.deviceName ?? r.deviceId,
-          start: new Date(r.startsAtUTC ?? r.start),
-          end: new Date(r.endsAtUTC ?? r.end),
+          startsAtUTC: startIso,
+          endsAtUTC: endIso,
+          start: utcIsoToLocalDate(startIso),
+          end: utcIsoToLocalDate(endIso),
           groupSlug: r.groupSlug,
           by: displayName,
           participants: r.participants ?? [],

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import DashboardClient from './page.client';
 import { serverFetch } from '@/lib/http/serverFetch';
 import { unstable_noStore as noStore } from 'next/cache';
 import { redirect } from 'next/navigation';
+import { utcIsoToLocalDate } from '@/lib/time';
 
 type Mine = {
   id:string; deviceId:string; deviceName?:string; userEmail:string; userName?:string;
@@ -46,11 +47,15 @@ export default async function DashboardPage() {
   };
   spans = mineAll.map((r: any) => {
     const deviceName = r.deviceName ?? r.deviceId;
+    const startIso = new Date(r.startsAtUTC ?? r.start).toISOString();
+    const endIso = new Date(r.endsAtUTC ?? r.end).toISOString();
     return {
       id: r.id,
       name: deviceName,
-      start: new Date(r.startsAtUTC ?? r.start),
-      end: new Date(r.endsAtUTC ?? r.end),
+      startsAtUTC: startIso,
+      endsAtUTC: endIso,
+      start: utcIsoToLocalDate(startIso),
+      end: utcIsoToLocalDate(endIso),
       groupSlug: r.groupSlug,
       by: nameOf(r),
       participants: r.participants ?? [],

--- a/web/src/app/groups/[slug]/devices/[deviceSlug]/page.tsx
+++ b/web/src/app/groups/[slug]/devices/[deviceSlug]/page.tsx
@@ -130,6 +130,8 @@ export default async function DeviceDetail({
     return {
       id: r.id,
       name: deviceName,
+      startsAtUTC: r.startsAtUTC,
+      endsAtUTC: r.endsAtUTC,
       start: r.start,
       end: r.end,
       groupSlug: group,

--- a/web/src/app/groups/[slug]/page.tsx
+++ b/web/src/app/groups/[slug]/page.tsx
@@ -184,6 +184,8 @@ export default async function GroupPage({
     return {
       id: r.id,
       name: deviceName,
+      startsAtUTC: r.startsAtUTC,
+      endsAtUTC: r.endsAtUTC,
       start: r.start,
       end: r.end,
       groupSlug: group.slug,
@@ -230,6 +232,8 @@ export default async function GroupPage({
     return {
       id: `duty-${d.id}`,
       name: `[当番] ${type.name ?? '当番'}`,
+      startsAtUTC: start.toISOString(),
+      endsAtUTC: end.toISOString(),
       start,
       end,
       groupSlug: group.slug,

--- a/web/src/components/reservations/ReservationList.tsx
+++ b/web/src/components/reservations/ReservationList.tsx
@@ -1,4 +1,4 @@
-import { formatUtcInAppTz } from '@/lib/time';
+import { formatUtcInAppTz, utcIsoToLocalDate } from '@/lib/time';
 
 export type ReservationListItem = {
   id: string;
@@ -10,6 +10,13 @@ export type ReservationListItem = {
 
 function Row({ r }: { r: ReservationListItem }) {
   const userName = r.user.name ?? '（予約者不明）';
+  console.info('[tz-check]', {
+    src: 'ReservationList',
+    itemId: r.id,
+    startUTC: r.startsAtUTC,
+    startLocal: utcIsoToLocalDate(r.startsAtUTC),
+    label: formatUtcInAppTz(r.startsAtUTC),
+  });
   return (
     <li className="leading-6">
       <span className="text-gray-500">機器：</span>

--- a/web/src/lib/color.ts
+++ b/web/src/lib/color.ts
@@ -18,5 +18,5 @@ export function deviceBg(deviceId: string) {
 
 export function deviceBgPast(deviceId: string) {
   const h = hueFromDevice(deviceId);
-  return `hsl(${h} 30% 97%)`;
+  return `hsl(${h} 22% 98%)`;
 }

--- a/web/src/lib/reservations.ts
+++ b/web/src/lib/reservations.ts
@@ -1,4 +1,4 @@
-import { APP_TZ, toUtcIsoZ, utcToLocal } from '@/lib/time';
+import { APP_TZ, toUtcIsoZ, utcIsoToLocalDate } from '@/lib/time';
 
 type Maybe<T> = T | null | undefined;
 
@@ -101,8 +101,8 @@ export function normalizeReservation(
     return null;
   }
 
-  const start = utcToLocal(startUtc, tz);
-  const end = utcToLocal(endUtc, tz);
+  const start = utcIsoToLocalDate(startIso);
+  const end = utcIsoToLocalDate(endIso);
 
   const device = raw.device ?? {};
   const user = raw.user ?? null;


### PR DESCRIPTION
## Summary
- add local day helpers to the time utilities and lighten past reservation colors
- update calendar, day view, and reservation lists to filter by APP_TZ day boundaries and format times with formatUtcInAppTz
- add temporary tz-check logging to reservation displays for debugging

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e3fbb70a308323ac166b1893cbac94