### PR TITLE
Cast regclass table checks to text

### DIFF
--- a/web/src/lib/db/ensure-initialized.ts
+++ b/web/src/lib/db/ensure-initialized.ts
@@ -52,7 +52,9 @@ async function withPrismaClient<T>(fn: (client: PrismaClient) => Promise<T>): Pr
 }
 
 async function fetchTableStatuses(client: PrismaClient): Promise<TableStatus[]> {
-  const columns = REQUIRED_TABLES.map((name) => `to_regclass('public."${name}"') AS "${name}"`).join(', ');
+  const columns = REQUIRED_TABLES.map(
+    (name) => `to_regclass('public."${name}"')::text AS "${name}"`,
+  ).join(', ');
   try {
     const result = (await client.$queryRawUnsafe(`SELECT ${columns}`)) as TableCheckRow[] | undefined;
     const row = result?.[0];


### PR DESCRIPTION
## Summary
- cast regclass results to text when checking required tables
- avoid Prisma deserialization errors when bootstrap queries system catalogs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921326bf61c8323a89ba286a0fbcb8a)