### PR TITLE
Improve dashboard responsiveness and calendar loading

### DIFF
--- a/web/src/app/_parts/UpcomingReservations.tsx
+++ b/web/src/app/_parts/UpcomingReservations.tsx
@@ -81,19 +81,21 @@ export default function UpcomingReservations({
 
   return (
     <>
-      <div className="flex items-center justify-between mb-3">
-        <div className="font-medium">直近の自分の予約</div>
-        <div className="flex items-center gap-2">
+      <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="font-medium text-lg">直近の自分の予約</div>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-2">
           <button
             onClick={load}
-            className="border rounded px-3 py-1 text-sm"
+            className="rounded border px-3 py-1 text-sm sm:w-auto"
             disabled={loading}
             aria-label="予約を更新"
             title="予約を更新"
           >
             {loading ? '更新中…' : '更新'}
           </button>
-          <a className="text-sm text-muted hover:underline" href="/groups">すべてのグループへ</a>
+          <a className="text-sm text-muted hover:underline sm:text-right" href="/groups">
+            すべてのグループへ
+          </a>
         </div>
       </div>
 
@@ -118,7 +120,7 @@ export default function UpcomingReservations({
           {items.map((r) => (
             <li
               key={r.id}
-              className="rounded-lg border px-3 py-2 flex items-start gap-3 cursor-pointer"
+              className="flex cursor-pointer flex-col gap-3 rounded-lg border px-3 py-3 sm:flex-row sm:items-start sm:gap-3"
               onClick={() => setSel(r)}
             >
               <span

--- a/web/src/app/dashboard/page.client.tsx
+++ b/web/src/app/dashboard/page.client.tsx
@@ -1,9 +1,24 @@
 'use client';
-import { useMemo, useState } from 'react';
+import dynamic from 'next/dynamic';
+import { useEffect, useMemo, useRef, useState, type ComponentProps } from 'react';
 import UpcomingReservations, { Item } from '../_parts/UpcomingReservations';
-import CalendarWithBars, { Span } from '@/components/CalendarWithBars';
+import type CalendarWithBarsBase, { Span } from '@/components/CalendarWithBars';
 import { addMonths, buildWeeks, firstOfMonth } from '@/lib/date-cal';
 import { utcIsoToLocalDate } from '@/lib/time';
+
+type CalendarProps = ComponentProps<typeof CalendarWithBarsBase>;
+
+const CalendarWithBars = dynamic<CalendarProps>(
+  () => import('@/components/CalendarWithBars'),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-[360px] w-full items-center justify-center rounded-xl border border-dashed border-gray-200 bg-white text-sm text-gray-500">
+        カレンダーを読み込み中…
+      </div>
+    ),
+  },
+);
 
 export default function DashboardClient({
   initialItems,
@@ -19,6 +34,35 @@ export default function DashboardClient({
   const [spans, setSpans] = useState<Span[]>(initialSpans);
   const today = new Date();
   const [anchor, setAnchor] = useState(firstOfMonth(today.getFullYear(), today.getMonth()));
+  const [calendarVisible, setCalendarVisible] = useState(false);
+  const calendarRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (calendarVisible) return;
+    const element = calendarRef.current;
+    if (!element) return;
+
+    const media = window.matchMedia('(min-width: 768px)');
+    if (media.matches) {
+      setCalendarVisible(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setCalendarVisible(true);
+            observer.disconnect();
+          }
+        });
+      },
+      { threshold: 0.2 },
+    );
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [calendarVisible]);
 
   const { month, weeks, monthSpans } = useMemo(() => {
     const m = anchor.getMonth();
@@ -64,7 +108,7 @@ export default function DashboardClient({
   const card = 'rounded-xl border border-gray-200 bg-white p-5 shadow-sm';
 
   return (
-    <div className="grid gap-6 md:grid-cols-3">
+    <div className="grid gap-4 sm:gap-6 md:grid-cols-3 lg:grid-cols-[2fr,1fr]">
       <section className={`md:col-span-2 ${card}`}>
         <UpcomingReservations
           initialItems={initialItems}
@@ -74,20 +118,34 @@ export default function DashboardClient({
         />
       </section>
 
-      <section className={card}>
-        <h2 className="font-medium mb-2">予約カレンダー</h2>
-        <div className="flex items-center justify-between mb-2">
-          <button className="px-2 py-1 rounded border" onClick={() => setAnchor((a) => addMonths(a, -1))}>
-            ‹
-          </button>
-          <div className="font-medium">
-            {anchor.getFullYear()}年 {anchor.getMonth() + 1}月
+      <section ref={calendarRef} className={`${card} space-y-3`}>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h2 className="font-medium text-lg sm:text-xl">予約カレンダー</h2>
+          <div className="flex w-full justify-end gap-2 sm:w-auto">
+            <button
+              className="flex-1 rounded border px-2 py-1 text-sm sm:flex-none"
+              onClick={() => setAnchor((a) => addMonths(a, -1))}
+            >
+              ‹
+            </button>
+            <div className="flex flex-1 items-center justify-center rounded border px-3 py-1 text-sm font-medium sm:flex-none sm:min-w-[180px]">
+              {anchor.getFullYear()}年 {anchor.getMonth() + 1}月
+            </div>
+            <button
+              className="flex-1 rounded border px-2 py-1 text-sm sm:flex-none"
+              onClick={() => setAnchor((a) => addMonths(a, 1))}
+            >
+              ›
+            </button>
           </div>
-          <button className="px-2 py-1 rounded border" onClick={() => setAnchor((a) => addMonths(a, 1))}>
-            ›
-          </button>
         </div>
-        <CalendarWithBars weeks={weeks} month={month} spans={monthSpans} />
+        {calendarVisible ? (
+          <CalendarWithBars weeks={weeks} month={month} spans={monthSpans} />
+        ) : (
+          <div className="flex h-[320px] items-center justify-center rounded-lg bg-gray-50 text-sm text-gray-500">
+            カレンダーを表示する準備中です…
+          </div>
+        )}
       </section>
     </div>
   );

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -121,14 +121,15 @@ export default async function DashboardPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <h1 className="text-2xl font-bold">ダッシュボード</h1>
-        <div className="flex gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row sm:gap-2">
           <Button
             href="/groups/new"
             variant="primary"
             size="sm"
             className="font-semibold"
+            block
             aria-disabled={dbNotInitialized}
             tabIndex={dbNotInitialized ? -1 : undefined}
           >
@@ -139,6 +140,7 @@ export default async function DashboardPage() {
             variant="outline"
             size="sm"
             className="font-semibold"
+            block
             aria-disabled={dbNotInitialized}
             tabIndex={dbNotInitialized ? -1 : undefined}
           >


### PR DESCRIPTION
## Summary
- adjust dashboard header, action buttons, and reservation list to better fit small screens
- lazy-load the reservation calendar with viewport detection and mobile-friendly navigation controls
- keep overall grid spacing responsive for different device sizes

## Testing
- pnpm -C web lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924f46adcd88323948d15502b7e09ed)