### PR TITLE
Fix type-only import in dashboard client

### DIFF
--- a/web/src/app/dashboard/page.client.tsx
+++ b/web/src/app/dashboard/page.client.tsx
@@ -1,7 +1,8 @@
 'use client';
 import { useMemo, useState } from 'react';
 import UpcomingReservations, { Item } from '../_parts/UpcomingReservations';
-import CalendarWithBars, { Span } from '@/components/CalendarWithBars';
+import CalendarWithBars from '@/components/CalendarWithBars';
+import type { Span } from '@/components/CalendarWithBars';
 import { addMonths, buildWeeks, firstOfMonth } from '@/lib/date-cal';
 import { utcIsoToLocalDate } from '@/lib/time';
 


### PR DESCRIPTION
## Summary
- separate CalendarWithBars component import from Span type to satisfy type-only rules

## Testing
- pnpm -C web lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925b71656408323b8b02f59aae6791c)